### PR TITLE
Feat/onebot adapter

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -198,6 +198,25 @@ telegram:
 #   # Application ID（在 General Information 页面，可选，用于 slash commands 注册等）
 #   application_id: ""
 
+# ─── OneBot / NapCat 设置 ───
+# 可选。用于接入 NapCat / LLOneBot / 其他 OneBot v11 实现。
+# onebot:
+#   # WebSocket 地址（NapCat 反向 WS 不适用，这里是 bot 主动连过去的正向 WS）
+#   ws_url: "ws://127.0.0.1:6099/onebot/v11/ws"
+#   # 机器人 QQ 号
+#   self_id: "1234567890"
+#   # 入站白名单（可选）
+#   # whitelist:
+#   #   enabled: true
+#   #   groups: ["123456789"]
+#   #   users: []
+#   # 拟人化发送延迟（可选）
+#   # humanized_delay:
+#   #   enabled: true
+#   #   ms_per_char: 50
+#   #   min_delay: 500
+#   #   max_delay: 5000
+
 # ─── Reflection 设置 ───
 # 控制反思引擎的行为参数
 reflection:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,10 +2,10 @@ services:
   cybergroupmate:
     build: .
     container_name: cybergroupmate
+    env_file: .env
     environment:
       - LOG_LEVEL=info
-    ports:
-      - "6767:6767"
+    network_mode: host
     volumes:
       - ./config.yaml:/app/config.yaml
       - cybergroupmate-data:/app/workspace

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true
+  node-pty: true
+  protobufjs: true

--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -1,0 +1,552 @@
+/**
+ * onebot-adapter.ts — OneBot v11 / NapCat 平台 adapter
+ *
+ * 通过 WebSocket 连接 NapCat / OneBot 服务，
+ * 监听消息并标准化后推入 NotificationCenter。
+ */
+
+import type { NotificationCenter } from "../event/notification-center.js";
+import type { OneBotConfig } from "../core/config.js";
+import type { PlatformAdapter } from "./platform-adapter.js";
+import { composeChatId, ensureCompositeId, parseChatId } from "../core/chat-id.js";
+import { createLogger } from "../core/logger.js";
+import { WebSocket } from "ws";
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+const log = createLogger("onebot-adapter");
+
+type OneBotMessageSegment = {
+    type: string;
+    data?: Record<string, unknown>;
+};
+
+type OneBotIncomingEvent = {
+    post_type?: string;
+    message_type?: "private" | "group";
+    sub_type?: string;
+    self_id?: number | string;
+    user_id?: number | string;
+    group_id?: number | string;
+    message_id?: number | string;
+    raw_message?: string;
+    message?: string | OneBotMessageSegment[];
+    sender?: {
+        user_id?: number | string;
+        nickname?: string;
+        card?: string;
+    };
+    time?: number;
+    reply?: {
+        message_id?: number | string;
+    };
+};
+
+type OneBotActionResponse = {
+    status?: string;
+    retcode?: number;
+    data?: unknown;
+    message?: string;
+    echo?: string;
+};
+
+type OneBotMediaInfo = {
+    type: "photo" | "video" | "document" | "other";
+    url?: string;
+    fileId: string;
+    uniqueFileId: string;
+    fileName?: string;
+    mimeType?: string;
+    fileSize?: number;
+};
+
+export class OneBotAdapter implements PlatformAdapter {
+    readonly platform = "onebot";
+
+    private ws: WebSocket | null = null;
+    private started = false;
+    private readonly pending = new Map<string, { resolve: (v: unknown) => void; reject: (err: Error) => void; timer: NodeJS.Timeout }>();
+
+    constructor(
+        private config: OneBotConfig,
+        private nc: NotificationCenter,
+    ) {}
+
+    async start(): Promise<void> {
+        if (this.started) return;
+        if (!this.config.wsUrl) throw new Error("onebot.ws_url is required");
+        if (!this.config.selfId) throw new Error("onebot.self_id is required");
+
+        await new Promise<void>((resolve, reject) => {
+            const ws = new WebSocket(this.config.wsUrl);
+            this.ws = ws;
+
+            ws.once("open", () => {
+                this.started = true;
+                log.info("OneBotAdapter 已连接", { wsUrl: this.config.wsUrl, selfId: this.config.selfId });
+                resolve();
+            });
+
+            ws.once("error", (err) => {
+                reject(err instanceof Error ? err : new Error(String(err)));
+            });
+
+            ws.on("message", (data) => {
+                try {
+                    this.handleWsMessage(String(data));
+                } catch (err) {
+                    log.warn("处理 OneBot 消息失败", { error: String(err) });
+                }
+            });
+
+            ws.on("close", () => {
+                this.started = false;
+                this.ws = null;
+                for (const [echo, pending] of this.pending.entries()) {
+                    clearTimeout(pending.timer);
+                    pending.reject(new Error(`OneBot websocket closed before response: ${echo}`));
+                    this.pending.delete(echo);
+                }
+                log.warn("OneBot websocket 已断开");
+            });
+        });
+    }
+
+    async stop(): Promise<void> {
+        if (!this.ws) return;
+        this.ws.close();
+        this.ws = null;
+        this.started = false;
+    }
+
+    canHandle(method: string): boolean {
+        return method.startsWith("onebot.") || method.startsWith("qq.");
+    }
+
+    getWriteMethods(): string[] {
+        return [
+            "onebot.sendText",
+            "onebot.sendMedia",
+            "onebot.sendFile",
+            "onebot.sendTyping",
+            "qq.sendText",
+            "qq.sendMedia",
+            "qq.sendFile",
+            "qq.sendTyping",
+        ];
+    }
+
+    formatMention(rawUserId: string, _username?: string): string | undefined {
+        return `[CQ:at,qq=${rawUserId}]`;
+    }
+
+    async markAsRead(_chatId: string): Promise<void> {
+        // OneBot v11 / NapCat 通常没有统一的标记已读接口，静默忽略。
+    }
+
+    async handleCall(method: string, args: unknown[]): Promise<unknown> {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+            throw new Error("OneBotAdapter is not started");
+        }
+
+        switch (method) {
+            case "onebot.sendText":
+            case "qq.sendText": {
+                const chatId = ensureCompositeId("onebot", String(args[0] ?? ""));
+                const text = String(args[1] ?? "");
+                const opts = (args[2] ?? {}) as Record<string, unknown>;
+                await this.applyHumanizedDelay(chatId, text.length);
+                return this.sendMessage(chatId, text, opts);
+            }
+            case "onebot.sendMedia":
+            case "qq.sendMedia": {
+                const chatId = ensureCompositeId("onebot", String(args[0] ?? ""));
+                const media = (args[1] ?? {}) as Record<string, unknown>;
+                const opts = (args[2] ?? {}) as Record<string, unknown>;
+                const caption = typeof media.caption === "string" ? media.caption : "";
+                await this.applyHumanizedDelay(chatId, caption.length);
+                return this.sendMedia(chatId, media, opts);
+            }
+            case "onebot.sendFile":
+            case "qq.sendFile": {
+                const chatId = ensureCompositeId("onebot", String(args[0] ?? ""));
+                const filePath = String(args[1] ?? "");
+                const opts = (args[2] ?? {}) as Record<string, unknown>;
+                const caption = typeof opts.caption === "string" ? opts.caption : "";
+                await this.applyHumanizedDelay(chatId, caption.length);
+                return this.sendFile(chatId, filePath, opts);
+            }
+            case "onebot.sendTyping":
+            case "qq.sendTyping": {
+                return null;
+            }
+            case "onebot.downloadMedia":
+            case "qq.downloadMedia": {
+                const mediaRef = String(args[0] ?? "");
+                if (!mediaRef) throw new Error("onebot.downloadMedia: mediaRef is required");
+                return this.downloadMedia(null, mediaRef);
+            }
+            default:
+                throw new Error(`Unsupported OneBot method: ${method}`);
+        }
+    }
+
+    async downloadMedia(_rawMessage: unknown, mediaRef: string): Promise<Buffer> {
+        if (mediaRef.startsWith("http://") || mediaRef.startsWith("https://")) {
+            const resp = await fetch(mediaRef);
+            if (!resp.ok) throw new Error(`downloadMedia: HTTP ${resp.status} for ${mediaRef}`);
+            return Buffer.from(await resp.arrayBuffer());
+        }
+        throw new Error(`downloadMedia: unsupported mediaRef ${mediaRef}`);
+    }
+
+    private async sendMessage(chatId: string, text: string, opts: Record<string, unknown>): Promise<unknown> {
+        const parsed = parseChatId(chatId);
+        const message = this.applyReplyTo(text, opts.replyTo);
+        if (parsed.rawId.startsWith("group:")) {
+            const groupId = parsed.rawId.slice("group:".length);
+            return this.callAction("send_group_msg", {
+                group_id: Number(groupId),
+                message,
+            });
+        }
+        if (parsed.rawId.startsWith("private:")) {
+            const userId = parsed.rawId.slice("private:".length);
+            return this.callAction("send_private_msg", {
+                user_id: Number(userId),
+                message,
+            });
+        }
+        throw new Error(`Unsupported onebot chatId: ${chatId}`);
+    }
+
+    private async sendMedia(chatId: string, media: Record<string, unknown>, opts: Record<string, unknown>): Promise<unknown> {
+        const parsed = parseChatId(chatId);
+        const segments = await this.buildOutgoingSegments(media, opts);
+        if (parsed.rawId.startsWith("group:")) {
+            const groupId = parsed.rawId.slice("group:".length);
+            return this.callAction("send_group_msg", {
+                group_id: Number(groupId),
+                message: segments,
+            });
+        }
+        if (parsed.rawId.startsWith("private:")) {
+            const userId = parsed.rawId.slice("private:".length);
+            return this.callAction("send_private_msg", {
+                user_id: Number(userId),
+                message: segments,
+            });
+        }
+        throw new Error(`Unsupported onebot chatId: ${chatId}`);
+    }
+
+    private async sendFile(chatId: string, filePath: string, opts: Record<string, unknown>): Promise<unknown> {
+        const resolvedPath = this.resolveWorkspacePath(filePath);
+        if (!existsSync(resolvedPath)) throw new Error(`sendFile: 文件不存在: ${resolvedPath}`);
+        const fileUrl = `file://${resolvedPath}`;
+        const payload: Record<string, unknown> = {
+            type: "document",
+            file: fileUrl,
+            caption: typeof opts.caption === "string" ? opts.caption : undefined,
+            fileName: typeof opts.fileName === "string" ? opts.fileName : path.basename(resolvedPath),
+        };
+        return this.sendMedia(chatId, payload, opts);
+    }
+
+    private async buildOutgoingSegments(media: Record<string, unknown>, opts: Record<string, unknown>): Promise<OneBotMessageSegment[]> {
+        const segments: OneBotMessageSegment[] = [];
+        if (opts.replyTo != null) {
+            segments.push({ type: "reply", data: { id: String(opts.replyTo) } });
+        }
+
+        const type = String(media.type ?? "");
+        let file = media.file;
+        if (typeof file === "string") {
+            if (!(file.startsWith("http://") || file.startsWith("https://") || file.startsWith("base64://") || file.startsWith("file://"))) {
+                file = `file://${this.resolveWorkspacePath(file)}`;
+            }
+        } else if (Buffer.isBuffer(file)) {
+            file = `base64://${file.toString("base64")}`;
+        }
+
+        switch (type) {
+            case "photo":
+            case "image":
+                segments.push({ type: "image", data: { file: String(file ?? "") } });
+                break;
+            case "video":
+                segments.push({ type: "video", data: { file: String(file ?? "") } });
+                break;
+            case "audio":
+            case "voice":
+                segments.push({ type: "record", data: { file: String(file ?? "") } });
+                break;
+            case "document":
+            default:
+                segments.push({ type: "file", data: { file: String(file ?? "") } });
+                break;
+        }
+
+        const caption = typeof media.caption === "string" ? media.caption : undefined;
+        if (caption) {
+            segments.push({ type: "text", data: { text: caption } });
+        }
+        return segments;
+    }
+
+    private applyReplyTo(text: string, replyTo: unknown): string | OneBotMessageSegment[] {
+        if (replyTo == null) return text;
+        return [
+            { type: "reply", data: { id: String(replyTo) } },
+            { type: "text", data: { text } },
+        ];
+    }
+
+    private handleWsMessage(raw: string): void {
+        const payload = JSON.parse(raw) as OneBotIncomingEvent | OneBotActionResponse;
+
+        if (typeof (payload as OneBotActionResponse).echo === "string") {
+            const echo = (payload as OneBotActionResponse).echo as string;
+            const pending = this.pending.get(echo);
+            if (!pending) return;
+            clearTimeout(pending.timer);
+            this.pending.delete(echo);
+            const resp = payload as OneBotActionResponse;
+            if (resp.status === "failed" || (typeof resp.retcode === "number" && resp.retcode !== 0)) {
+                pending.reject(new Error(resp.message ?? `OneBot action failed: ${resp.retcode}`));
+            } else {
+                pending.resolve(resp.data ?? resp);
+            }
+            return;
+        }
+
+        const event = payload as OneBotIncomingEvent;
+        if (event.post_type !== "message") return;
+        if (String(event.self_id ?? "") !== String(this.config.selfId)) return;
+
+        const normalized = this.normalizeIncomingMessage(event);
+        if (!normalized) return;
+
+        this.nc.push({
+            type: "nc.message",
+            scene: "onebot",
+            source: {
+                scene: "onebot",
+                platform: "onebot",
+                chatId: normalized.chatId,
+                userId: normalized.userId,
+                chatType: normalized.chatType,
+                messageId: normalized.messageId,
+                replyToMessageId: normalized.replyToMessageId,
+            },
+            chatId: normalized.chatId,
+            userId: normalized.userId,
+            displayName: normalized.displayName,
+            username: normalized.username,
+            text: normalized.text,
+            timestamp: normalized.timestamp,
+            messageId: normalized.messageId,
+            replyToMessageId: normalized.replyToMessageId,
+            chatTitle: normalized.chatTitle,
+            chatType: normalized.chatType,
+            isDirectMessage: normalized.isDirectMessage,
+            mentionsAgent: normalized.mentionsAgent,
+            mediaInfo: normalized.mediaInfo,
+            payload: {
+                scene: "onebot",
+                chatId: normalized.chatId,
+                userId: normalized.userId,
+                displayName: normalized.displayName,
+                username: normalized.username,
+                text: normalized.text,
+                timestamp: normalized.timestamp,
+                messageId: normalized.messageId,
+                replyToMessageId: normalized.replyToMessageId,
+                chatTitle: normalized.chatTitle,
+                chatType: normalized.chatType,
+                isDirectMessage: normalized.isDirectMessage,
+                mentionsAgent: normalized.mentionsAgent,
+                mediaInfo: normalized.mediaInfo,
+                source: {
+                    scene: "onebot",
+                    platform: "onebot",
+                    chatId: normalized.chatId,
+                    userId: normalized.userId,
+                    chatType: normalized.chatType,
+                    messageId: normalized.messageId,
+                    replyToMessageId: normalized.replyToMessageId,
+                },
+                platformData: {
+                    originalType: "onebot.message",
+                },
+            },
+            _urgent: normalized.isDirectMessage || normalized.mentionsAgent || normalized.replyToMessageId ? true : false,
+        });
+    }
+
+    private normalizeIncomingMessage(event: OneBotIncomingEvent) {
+        const messageType = event.message_type;
+        const userId = String(event.user_id ?? event.sender?.user_id ?? "");
+        if (!userId) return null;
+
+        const chatId = messageType === "group"
+            ? composeChatId("onebot", `group:${String(event.group_id ?? "")}`)
+            : composeChatId("onebot", `private:${userId}`);
+
+        if (!this.isWhitelisted(messageType, String(event.group_id ?? ""), userId)) {
+            return null;
+        }
+
+        const displayName = event.sender?.card || event.sender?.nickname || userId;
+        const text = this.extractText(event.message ?? event.raw_message ?? "");
+        const messageId = String(event.message_id ?? "");
+        const replyToMessageId = this.extractReplyTo(event.message) ?? (event.reply?.message_id != null ? String(event.reply.message_id) : undefined);
+        const mentionsAgent = this.hasAtSelf(event.message) || text.includes(String(this.config.selfId));
+        const mediaInfo = this.extractMediaInfo(event.message);
+
+        const normalizedText = text || (mediaInfo ? this.mediaPlaceholder(mediaInfo.type) : "");
+
+        return {
+            chatId,
+            userId,
+            displayName,
+            username: undefined,
+            text: normalizedText,
+            timestamp: new Date((event.time ?? Math.floor(Date.now() / 1000)) * 1000).toISOString(),
+            messageId,
+            replyToMessageId,
+            chatTitle: messageType === "group" ? String(event.group_id ?? "") : undefined,
+            chatType: messageType === "group" ? "group" : "private",
+            isDirectMessage: messageType === "private",
+            mentionsAgent,
+            mediaInfo,
+        };
+    }
+
+    private extractText(message: string | OneBotMessageSegment[]): string {
+        if (typeof message === "string") return message.replace(/\[CQ:[^\]]+\]/g, "").trim();
+        if (!Array.isArray(message)) return "";
+        return message.map(seg => {
+            if (seg.type === "text") return String(seg.data?.text ?? "");
+            if (seg.type === "at") return `[CQ:at,qq=${String(seg.data?.qq ?? "")}]`;
+            return "";
+        }).join("").trim();
+    }
+
+    private extractReplyTo(message: string | OneBotMessageSegment[] | undefined): string | undefined {
+        if (!Array.isArray(message)) {
+            const match = typeof message === "string" ? message.match(/\[CQ:reply,id=(\d+)\]/) : null;
+            return match?.[1];
+        }
+        const seg = message.find(seg => seg.type === "reply");
+        if (!seg) return undefined;
+        const id = seg.data?.id;
+        return id == null ? undefined : String(id);
+    }
+
+    private extractMediaInfo(message: string | OneBotMessageSegment[] | undefined): OneBotMediaInfo | undefined {
+        if (!Array.isArray(message)) return undefined;
+        for (const seg of message) {
+            const data = seg.data ?? {};
+            if (seg.type === "image") {
+                const url = typeof data.url === "string" ? data.url : undefined;
+                const file = String(data.file ?? url ?? "");
+                return {
+                    type: "photo",
+                    url,
+                    fileId: file,
+                    uniqueFileId: String(data.file_unique ?? data.file_id ?? file),
+                    fileName: typeof data.file === "string" ? path.basename(String(data.file)) : undefined,
+                };
+            }
+            if (seg.type === "video") {
+                const url = typeof data.url === "string" ? data.url : undefined;
+                const file = String(data.file ?? url ?? "");
+                return {
+                    type: "video",
+                    url,
+                    fileId: file,
+                    uniqueFileId: String(data.file_unique ?? data.file_id ?? file),
+                    fileName: typeof data.file === "string" ? path.basename(String(data.file)) : undefined,
+                };
+            }
+            if (seg.type === "file" || seg.type === "record") {
+                const url = typeof data.url === "string" ? data.url : undefined;
+                const file = String(data.file ?? url ?? "");
+                return {
+                    type: "document",
+                    url,
+                    fileId: file,
+                    uniqueFileId: String(data.file_unique ?? data.file_id ?? file),
+                    fileName: typeof data.name === "string" ? data.name : (typeof data.file === "string" ? path.basename(String(data.file)) : undefined),
+                };
+            }
+        }
+        return undefined;
+    }
+
+    private mediaPlaceholder(type: OneBotMediaInfo["type"]): string {
+        switch (type) {
+            case "photo":
+                return "[📷 图片]";
+            case "video":
+                return "[🎬 视频]";
+            case "document":
+                return "[📎 文件]";
+            default:
+                return "[📎 媒体]";
+        }
+    }
+
+    private hasAtSelf(message: string | OneBotMessageSegment[] | undefined): boolean {
+        if (!Array.isArray(message)) {
+            return typeof message === "string" && message.includes(`[CQ:at,qq=${this.config.selfId}]`);
+        }
+        return message.some(seg => seg.type === "at" && String(seg.data?.qq ?? "") === String(this.config.selfId));
+    }
+
+    private isWhitelisted(messageType: "private" | "group" | undefined, groupId: string, userId: string): boolean {
+        const wl = this.config.whitelist;
+        if (!wl?.enabled) return true;
+        if (messageType === "group") return wl.groups.includes(groupId);
+        return wl.users.includes(userId);
+    }
+
+    private async callAction(action: string, params: Record<string, unknown>): Promise<unknown> {
+        if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+            throw new Error("OneBot websocket is not connected");
+        }
+
+        const echo = `cgm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const payload = JSON.stringify({ action, params, echo });
+
+        return await new Promise<unknown>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                this.pending.delete(echo);
+                reject(new Error(`OneBot action timeout: ${action}`));
+            }, 15000);
+
+            this.pending.set(echo, { resolve, reject, timer });
+            this.ws!.send(payload, (err) => {
+                if (err) {
+                    clearTimeout(timer);
+                    this.pending.delete(echo);
+                    reject(err instanceof Error ? err : new Error(String(err)));
+                }
+            });
+        });
+    }
+
+    private resolveWorkspacePath(filePath: string): string {
+        if (filePath.startsWith("/")) return path.resolve(filePath);
+        const workspaceDir = path.join(process.cwd(), "workspace");
+        return path.resolve(workspaceDir, filePath);
+    }
+
+    private async applyHumanizedDelay(_chatId: string, textLen: number): Promise<void> {
+        const cfg = this.config.humanizedDelay;
+        if (!cfg?.enabled) return;
+        const delay = Math.max(cfg.minDelay, Math.min(cfg.maxDelay, textLen * cfg.msPerChar));
+        await new Promise(resolve => setTimeout(resolve, delay));
+    }
+}

--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -8,6 +8,7 @@
 import type { NotificationCenter } from "../event/notification-center.js";
 import type { OneBotConfig } from "../core/config.js";
 import type { PlatformAdapter } from "./platform-adapter.js";
+import type { MediaDownloader } from "../core/media-downloader.js";
 import { composeChatId, ensureCompositeId, parseChatId } from "../core/chat-id.js";
 import { createLogger } from "../core/logger.js";
 import { WebSocket } from "ws";
@@ -71,6 +72,7 @@ export class OneBotAdapter implements PlatformAdapter {
     constructor(
         private config: OneBotConfig,
         private nc: NotificationCenter,
+        private mediaDownloader?: MediaDownloader,
     ) {}
 
     async start(): Promise<void> {
@@ -129,11 +131,15 @@ export class OneBotAdapter implements PlatformAdapter {
             "onebot.sendText",
             "onebot.sendMedia",
             "onebot.sendFile",
+            "onebot.sendSticker",
+            "onebot.sendFace",
             "onebot.sendTyping",
             "onebot.deleteMessages",
             "qq.sendText",
             "qq.sendMedia",
             "qq.sendFile",
+            "qq.sendSticker",
+            "qq.sendFace",
             "qq.sendTyping",
             "qq.deleteMessages",
         ];
@@ -223,6 +229,23 @@ export class OneBotAdapter implements PlatformAdapter {
                 await this.applyHumanizedDelay(chatId, caption.length);
                 return this.sendFile(chatId, filePath, opts);
             }
+            case "onebot.sendSticker":
+            case "qq.sendSticker": {
+                const chatId = ensureCompositeId("onebot", String(args[0] ?? ""));
+                const sticker = args[1];
+                const opts = (args[2] ?? {}) as Record<string, unknown>;
+                const caption = typeof opts.caption === "string" ? opts.caption : "";
+                await this.applyHumanizedDelay(chatId, caption.length);
+                return this.sendSticker(chatId, sticker, opts);
+            }
+            case "onebot.sendFace":
+            case "qq.sendFace": {
+                const chatId = ensureCompositeId("onebot", String(args[0] ?? ""));
+                const faceId = String(args[1] ?? "").trim();
+                const opts = (args[2] ?? {}) as Record<string, unknown>;
+                await this.applyHumanizedDelay(chatId, 0);
+                return this.sendFace(chatId, faceId, opts);
+            }
             case "onebot.deleteMessages":
             case "qq.deleteMessages": {
                 const chatId = ensureCompositeId("onebot", String(args[0] ?? ""));
@@ -304,6 +327,84 @@ export class OneBotAdapter implements PlatformAdapter {
             fileName: typeof opts.fileName === "string" ? opts.fileName : path.basename(resolvedPath),
         };
         return this.sendMedia(chatId, payload, opts);
+    }
+
+    private async sendSticker(chatId: string, sticker: unknown, opts: Record<string, unknown>): Promise<unknown> {
+        let file: unknown = sticker;
+
+        if (typeof sticker === "string") {
+            const trimmed = sticker.trim();
+            const looksLikeDirectFile = trimmed.startsWith("http://")
+                || trimmed.startsWith("https://")
+                || trimmed.startsWith("file://")
+                || trimmed.startsWith("base64://")
+                || trimmed.includes("/")
+                || trimmed.includes("\\")
+                || /\.[a-zA-Z0-9]{2,5}$/.test(trimmed);
+
+            if (!looksLikeDirectFile && this.mediaDownloader) {
+                const cachedPath = this.mediaDownloader.getExistingPath(trimmed);
+                if (cachedPath) {
+                    if (cachedPath.toLowerCase().endsWith(".webm") || cachedPath.toLowerCase().endsWith(".tgs")) {
+                        throw new Error(`sendSticker: 暂不支持将动态 TG 贴纸转发到 QQ (${path.basename(cachedPath)})`);
+                    }
+                    file = cachedPath;
+                }
+            }
+        } else if (sticker && typeof sticker === "object") {
+            const rec = sticker as Record<string, unknown>;
+            let resolvedFile = rec.file;
+            if (typeof resolvedFile === "string") {
+                const cachedPath = this.mediaDownloader?.getExistingPath(resolvedFile);
+                if (cachedPath) {
+                    if (cachedPath.toLowerCase().endsWith(".webm") || cachedPath.toLowerCase().endsWith(".tgs")) {
+                        throw new Error(`sendSticker: 暂不支持将动态 TG 贴纸转发到 QQ (${path.basename(cachedPath)})`);
+                    }
+                    resolvedFile = cachedPath;
+                }
+            }
+            file = { ...rec, file: resolvedFile };
+        }
+
+        const payload: Record<string, unknown> = typeof file === "string"
+            ? {
+                type: "photo",
+                file,
+                caption: typeof opts.caption === "string" ? opts.caption : undefined,
+            }
+            : {
+                ...(file as Record<string, unknown>),
+                type: "photo",
+            };
+        return this.sendMedia(chatId, payload, opts);
+    }
+
+    private async sendFace(chatId: string, faceId: string, opts: Record<string, unknown>): Promise<unknown> {
+        if (!faceId) throw new Error("sendFace: faceId 为空");
+        const parsed = parseChatId(chatId);
+        const segments: OneBotMessageSegment[] = [];
+        if (opts.replyTo != null && opts.replyTo !== "") {
+            segments.push({ type: "reply", data: { id: String(opts.replyTo) } });
+        }
+        segments.push({ type: "face", data: { id: faceId } });
+        if (typeof opts.text === "string" && opts.text.trim()) {
+            segments.push({ type: "text", data: { text: opts.text } });
+        }
+        if (parsed.rawId.startsWith("group:")) {
+            const groupId = parsed.rawId.slice("group:".length);
+            return this.callAction("send_group_msg", {
+                group_id: Number(groupId),
+                message: segments,
+            });
+        }
+        if (parsed.rawId.startsWith("private:")) {
+            const userId = parsed.rawId.slice("private:".length);
+            return this.callAction("send_private_msg", {
+                user_id: Number(userId),
+                message: segments,
+            });
+        }
+        throw new Error(`Unsupported onebot chatId: ${chatId}`);
     }
 
     private async deleteMessages(chatId: string, messageIds: string[]): Promise<void> {

--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -273,7 +273,20 @@ export class OneBotAdapter implements PlatformAdapter {
             if (!resp.ok) throw new Error(`downloadMedia: HTTP ${resp.status} for ${mediaRef}`);
             return Buffer.from(await resp.arrayBuffer());
         }
-        throw new Error(`downloadMedia: unsupported mediaRef ${mediaRef}`);
+        // Fallback: try get_image OneBot API to resolve a downloadable URL
+        try {
+            const result = await this.callAction("get_image", { file: mediaRef }) as Record<string, unknown>;
+            const imgData = result?.data ?? result;
+            const imgUrl = (imgData as Record<string, unknown>)?.url;
+            if (typeof imgUrl === "string" && (imgUrl.startsWith("http://") || imgUrl.startsWith("https://"))) {
+                const resp = await fetch(imgUrl);
+                if (!resp.ok) throw new Error(`downloadMedia: HTTP ${resp.status} for resolved URL`);
+                return Buffer.from(await resp.arrayBuffer());
+            }
+        } catch (e) {
+            log.warn("get_image 回退失败", { mediaRef, error: String(e) });
+        }
+        throw new Error(`downloadMedia: cannot resolve mediaRef ${mediaRef}`);
     }
 
     private async sendMessage(chatId: string, text: string, opts: Record<string, unknown>): Promise<unknown> {
@@ -648,44 +661,44 @@ export class OneBotAdapter implements PlatformAdapter {
             const data = seg.data ?? {};
             if (seg.type === "image") {
                 const url = typeof data.url === "string" ? data.url : undefined;
-                const file = String(data.file ?? url ?? "");
+                const file = String(data.file ?? "");
                 return {
                     type: "photo",
                     url,
-                    fileId: file,
+                    fileId: url || file,
                     uniqueFileId: String(data.file_unique ?? data.file_id ?? file),
                     fileName: typeof data.file === "string" ? path.basename(String(data.file)) : undefined,
                 };
             }
             if (seg.type === "video") {
                 const url = typeof data.url === "string" ? data.url : undefined;
-                const file = String(data.file ?? url ?? "");
+                const file = String(data.file ?? "");
                 return {
                     type: "video",
                     url,
-                    fileId: file,
+                    fileId: url || file,
                     uniqueFileId: String(data.file_unique ?? data.file_id ?? file),
                     fileName: typeof data.file === "string" ? path.basename(String(data.file)) : undefined,
                 };
             }
             if (seg.type === "record") {
                 const url = typeof data.url === "string" ? data.url : undefined;
-                const file = String(data.file ?? url ?? "");
+                const file = String(data.file ?? "");
                 return {
                     type: "audio",
                     url,
-                    fileId: file,
+                    fileId: url || file,
                     uniqueFileId: String(data.file_unique ?? data.file_id ?? file),
                     fileName: typeof data.file === "string" ? path.basename(String(data.file)) : undefined,
                 };
             }
             if (seg.type === "file") {
                 const url = typeof data.url === "string" ? data.url : undefined;
-                const file = String(data.file ?? url ?? "");
+                const file = String(data.file ?? "");
                 return {
                     type: "document",
                     url,
-                    fileId: file,
+                    fileId: url || file,
                     uniqueFileId: String(data.file_unique ?? data.file_id ?? file),
                     fileName: typeof data.name === "string" ? data.name : (typeof data.file === "string" ? path.basename(String(data.file)) : undefined),
                 };

--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -11,7 +11,7 @@ import type { PlatformAdapter } from "./platform-adapter.js";
 import { composeChatId, ensureCompositeId, parseChatId } from "../core/chat-id.js";
 import { createLogger } from "../core/logger.js";
 import { WebSocket } from "ws";
-import { readFileSync, existsSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 const log = createLogger("onebot-adapter");
@@ -51,7 +51,7 @@ type OneBotActionResponse = {
 };
 
 type OneBotMediaInfo = {
-    type: "photo" | "video" | "document" | "other";
+    type: "photo" | "video" | "document" | "audio" | "other";
     url?: string;
     fileId: string;
     uniqueFileId: string;
@@ -66,6 +66,7 @@ export class OneBotAdapter implements PlatformAdapter {
     private ws: WebSocket | null = null;
     private started = false;
     private readonly pending = new Map<string, { resolve: (v: unknown) => void; reject: (err: Error) => void; timer: NodeJS.Timeout }>();
+    private readonly mutedChats = new Map<string, number>();
 
     constructor(
         private config: OneBotConfig,
@@ -129,10 +130,12 @@ export class OneBotAdapter implements PlatformAdapter {
             "onebot.sendMedia",
             "onebot.sendFile",
             "onebot.sendTyping",
+            "onebot.deleteMessages",
             "qq.sendText",
             "qq.sendMedia",
             "qq.sendFile",
             "qq.sendTyping",
+            "qq.deleteMessages",
         ];
     }
 
@@ -144,9 +147,53 @@ export class OneBotAdapter implements PlatformAdapter {
         // OneBot v11 / NapCat 通常没有统一的标记已读接口，静默忽略。
     }
 
+    muteChat(chatId: string, hours: number): void {
+        const h = Number.isFinite(hours) && hours > 0 ? hours : 1;
+        const expiryMs = Date.now() + h * 3600_000;
+        this.mutedChats.set(chatId, expiryMs);
+        log.info("muteChat (onebot)", { chatId, hours: h, expiryMs });
+    }
+
+    unmuteChat(chatId: string): void {
+        this.mutedChats.delete(chatId);
+        log.info("unmuteChat (onebot)", { chatId });
+    }
+
+    getMutedChats(): Array<{ chatId: string; expiry: number; remaining: string }> {
+        const now = Date.now();
+        const result: Array<{ chatId: string; expiry: number; remaining: string }> = [];
+        for (const [chatId, expiry] of this.mutedChats.entries()) {
+            if (expiry <= now) {
+                this.mutedChats.delete(chatId);
+                continue;
+            }
+            const mins = Math.max(1, Math.ceil((expiry - now) / 60000));
+            result.push({ chatId, expiry, remaining: `${mins}m` });
+        }
+        return result;
+    }
+
+    isChatMuted(chatId: string): boolean {
+        const expiry = this.mutedChats.get(chatId);
+        if (!expiry) return false;
+        if (expiry <= Date.now()) {
+            this.mutedChats.delete(chatId);
+            return false;
+        }
+        return true;
+    }
+
     async handleCall(method: string, args: unknown[]): Promise<unknown> {
         if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
             throw new Error("OneBotAdapter is not started");
+        }
+
+        const writeMethods = new Set(this.getWriteMethods());
+        if (writeMethods.has(method)) {
+            const chatId = ensureCompositeId("onebot", String(args[0] ?? ""));
+            if (this.isChatMuted(chatId)) {
+                throw new Error(`[禁言中] 你在该聊天已被 /mute，所有发送操作已被抑制。`);
+            }
         }
 
         switch (method) {
@@ -175,6 +222,12 @@ export class OneBotAdapter implements PlatformAdapter {
                 const caption = typeof opts.caption === "string" ? opts.caption : "";
                 await this.applyHumanizedDelay(chatId, caption.length);
                 return this.sendFile(chatId, filePath, opts);
+            }
+            case "onebot.deleteMessages":
+            case "qq.deleteMessages": {
+                const chatId = ensureCompositeId("onebot", String(args[0] ?? ""));
+                const ids = Array.isArray(args[1]) ? args[1].map(id => String(id)).filter(Boolean) : [];
+                return this.deleteMessages(chatId, ids);
             }
             case "onebot.sendTyping":
             case "qq.sendTyping": {
@@ -251,6 +304,17 @@ export class OneBotAdapter implements PlatformAdapter {
             fileName: typeof opts.fileName === "string" ? opts.fileName : path.basename(resolvedPath),
         };
         return this.sendMedia(chatId, payload, opts);
+    }
+
+    private async deleteMessages(chatId: string, messageIds: string[]): Promise<void> {
+        if (messageIds.length === 0) return;
+        const parsed = parseChatId(chatId);
+        if (!parsed.rawId.startsWith("group:")) {
+            throw new Error("deleteMessages: OneBot 目前仅支持群消息撤回");
+        }
+        for (const id of messageIds) {
+            await this.callAction("delete_msg", { message_id: Number(id) });
+        }
     }
 
     private async buildOutgoingSegments(media: Record<string, unknown>, opts: Record<string, unknown>): Promise<OneBotMessageSegment[]> {
@@ -397,13 +461,13 @@ export class OneBotAdapter implements PlatformAdapter {
             return null;
         }
 
+        const normalizedMessage = this.normalizeMessageSegments(event.message ?? event.raw_message ?? "");
         const displayName = event.sender?.card || event.sender?.nickname || userId;
-        const text = this.extractText(event.message ?? event.raw_message ?? "");
         const messageId = String(event.message_id ?? "");
-        const replyToMessageId = this.extractReplyTo(event.message) ?? (event.reply?.message_id != null ? String(event.reply.message_id) : undefined);
-        const mentionsAgent = this.hasAtSelf(event.message) || text.includes(String(this.config.selfId));
-        const mediaInfo = this.extractMediaInfo(event.message);
-
+        const mentionsAgent = this.hasAtSelf(normalizedMessage);
+        const mediaInfo = this.extractMediaInfo(normalizedMessage);
+        const text = this.extractText(normalizedMessage);
+        const replyToMessageId = this.extractReplyTo(normalizedMessage) ?? (event.reply?.message_id != null ? String(event.reply.message_id) : undefined);
         const normalizedText = text || (mediaInfo ? this.mediaPlaceholder(mediaInfo.type) : "");
 
         return {
@@ -423,9 +487,47 @@ export class OneBotAdapter implements PlatformAdapter {
         };
     }
 
-    private extractText(message: string | OneBotMessageSegment[]): string {
-        if (typeof message === "string") return message.replace(/\[CQ:[^\]]+\]/g, "").trim();
-        if (!Array.isArray(message)) return "";
+    private normalizeMessageSegments(message: string | OneBotMessageSegment[]): OneBotMessageSegment[] {
+        if (Array.isArray(message)) return message;
+        return this.parseCqString(message);
+    }
+
+    private parseCqString(input: string): OneBotMessageSegment[] {
+        const segments: OneBotMessageSegment[] = [];
+        const regex = /\[CQ:([^,\]]+)((?:,[^\]]*)?)\]/g;
+        let lastIndex = 0;
+        let match: RegExpExecArray | null;
+
+        while ((match = regex.exec(input)) !== null) {
+            const before = input.slice(lastIndex, match.index);
+            if (before) segments.push({ type: "text", data: { text: before } });
+
+            const type = match[1];
+            const rawAttrs = match[2] ?? "";
+            const data: Record<string, unknown> = {};
+            if (rawAttrs) {
+                for (const pair of rawAttrs.slice(1).split(",")) {
+                    const eqIdx = pair.indexOf("=");
+                    if (eqIdx === -1) continue;
+                    const key = pair.slice(0, eqIdx);
+                    const value = pair.slice(eqIdx + 1)
+                        .replaceAll("&#44;", ",")
+                        .replaceAll("&#91;", "[")
+                        .replaceAll("&#93;", "]")
+                        .replaceAll("&amp;", "&");
+                    data[key] = value;
+                }
+            }
+            segments.push({ type, data });
+            lastIndex = regex.lastIndex;
+        }
+
+        const rest = input.slice(lastIndex);
+        if (rest) segments.push({ type: "text", data: { text: rest } });
+        return segments;
+    }
+
+    private extractText(message: OneBotMessageSegment[]): string {
         return message.map(seg => {
             if (seg.type === "text") return String(seg.data?.text ?? "");
             if (seg.type === "at") return `[CQ:at,qq=${String(seg.data?.qq ?? "")}]`;
@@ -433,19 +535,14 @@ export class OneBotAdapter implements PlatformAdapter {
         }).join("").trim();
     }
 
-    private extractReplyTo(message: string | OneBotMessageSegment[] | undefined): string | undefined {
-        if (!Array.isArray(message)) {
-            const match = typeof message === "string" ? message.match(/\[CQ:reply,id=(\d+)\]/) : null;
-            return match?.[1];
-        }
+    private extractReplyTo(message: OneBotMessageSegment[]): string | undefined {
         const seg = message.find(seg => seg.type === "reply");
         if (!seg) return undefined;
         const id = seg.data?.id;
         return id == null ? undefined : String(id);
     }
 
-    private extractMediaInfo(message: string | OneBotMessageSegment[] | undefined): OneBotMediaInfo | undefined {
-        if (!Array.isArray(message)) return undefined;
+    private extractMediaInfo(message: OneBotMessageSegment[]): OneBotMediaInfo | undefined {
         for (const seg of message) {
             const data = seg.data ?? {};
             if (seg.type === "image") {
@@ -470,7 +567,18 @@ export class OneBotAdapter implements PlatformAdapter {
                     fileName: typeof data.file === "string" ? path.basename(String(data.file)) : undefined,
                 };
             }
-            if (seg.type === "file" || seg.type === "record") {
+            if (seg.type === "record") {
+                const url = typeof data.url === "string" ? data.url : undefined;
+                const file = String(data.file ?? url ?? "");
+                return {
+                    type: "audio",
+                    url,
+                    fileId: file,
+                    uniqueFileId: String(data.file_unique ?? data.file_id ?? file),
+                    fileName: typeof data.file === "string" ? path.basename(String(data.file)) : undefined,
+                };
+            }
+            if (seg.type === "file") {
                 const url = typeof data.url === "string" ? data.url : undefined;
                 const file = String(data.file ?? url ?? "");
                 return {
@@ -491,6 +599,8 @@ export class OneBotAdapter implements PlatformAdapter {
                 return "[📷 图片]";
             case "video":
                 return "[🎬 视频]";
+            case "audio":
+                return "[🎤 语音]";
             case "document":
                 return "[📎 文件]";
             default:
@@ -498,10 +608,7 @@ export class OneBotAdapter implements PlatformAdapter {
         }
     }
 
-    private hasAtSelf(message: string | OneBotMessageSegment[] | undefined): boolean {
-        if (!Array.isArray(message)) {
-            return typeof message === "string" && message.includes(`[CQ:at,qq=${this.config.selfId}]`);
-        }
+    private hasAtSelf(message: OneBotMessageSegment[]): boolean {
         return message.some(seg => seg.type === "at" && String(seg.data?.qq ?? "") === String(this.config.selfId));
     }
 

--- a/src/adapter/telegram-adapter.ts
+++ b/src/adapter/telegram-adapter.ts
@@ -1462,10 +1462,22 @@ export class TelegramAdapter implements PlatformAdapter {
 }
 
 async function defaultTelegramClientFactory(config: TelegramConfig): Promise<TelegramClientLike> {
-    const { TelegramClient } = await import("@mtcute/node");
-    return new TelegramClient({
+    const { TelegramClient, SocksProxyTcpTransport } = await import("@mtcute/node");
+    const proxyUrl = process.env.TG_PROXY || process.env.HTTPS_PROXY || "";
+    const clientOpts: Record<string, unknown> = {
         apiId: Number(config.apiId),
         apiHash: config.apiHash,
         storage: "workspace/tg-session/account",
-    }) as TelegramClientLike;
+    };
+    if (proxyUrl) {
+        const url = new URL(proxyUrl.replace(/^socks5:\/\//, "socks5h://").replace(/^socks:\/\//, "socks5h://"));
+        clientOpts.transport = new SocksProxyTcpTransport({
+            host: url.hostname,
+            port: Number(url.port),
+            version: 5,
+            user: url.username || undefined,
+            password: url.password || undefined,
+        });
+    }
+    return new TelegramClient(clientOpts as any) as TelegramClientLike;
 }

--- a/src/core/chat-id.ts
+++ b/src/core/chat-id.ts
@@ -15,7 +15,7 @@
  */
 
 /** 支持的平台名称 */
-export type PlatformName = "telegram" | "discord";
+export type PlatformName = "telegram" | "discord" | "onebot";
 
 /** parseChatId 的返回结构 */
 export interface ParsedChatId {
@@ -35,7 +35,7 @@ export interface ParsedChatId {
     channelId?: string;
 }
 
-const VALID_PLATFORMS = new Set<string>(["telegram", "discord"]);
+const VALID_PLATFORMS = new Set<string>(["telegram", "discord", "onebot"]);
 
 /**
  * 创建 composite chatId。
@@ -148,6 +148,13 @@ export function isTelegram(compositeId: string): boolean {
 }
 
 /**
+ * 判断 composite chatId 是否为 OneBot 平台。
+ */
+export function isOneBot(compositeId: string): boolean {
+    return compositeId.startsWith("onebot:");
+}
+
+/**
  * 获取 GroupModel 的存储 key。
  *
  * Discord guild == group：同一 Guild 下的不同 Channel 共享 GroupModel。
@@ -208,10 +215,10 @@ export function fileNameToChatId(fileName: string): string {
 
     const rest = base.slice(underscoreIdx + 1);
 
-    // Telegram: 直接还原 — telegram_-1001234567 → telegram:-1001234567
+    // Telegram / OneBot: 直接还原 — telegram_-1001234567 → telegram:-1001234567
     // 注意 Telegram chatId 可能包含负号，不会与 _ 冲突
-    if (platform === "telegram") {
-        return `telegram:${rest}`;
+    if (platform === "telegram" || platform === "onebot") {
+        return `${platform}:${rest}`;
     }
 
     // Discord: 需要将 _ 还原为 : — discord_guild_chan → discord:guild:chan

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -165,6 +165,28 @@ export interface DiscordConfig {
     applicationId?: string;
 }
 
+export interface OneBotConfig {
+    /** WebSocket 连接地址，如 ws://127.0.0.1:6099/onebot */
+    wsUrl: string;
+    /** Bot 的 QQ 号（用于识别自己的消息） */
+    selfId: string;
+    /** 入站白名单（可选） */
+    whitelist?: {
+        enabled: boolean;
+        /** 群号列表 */
+        groups: string[];
+        /** 私聊用户 QQ 号列表 */
+        users: string[];
+    };
+    /** 拟人化发送延迟配置 */
+    humanizedDelay?: {
+        enabled: boolean;
+        msPerChar: number;
+        minDelay: number;
+        maxDelay: number;
+    };
+}
+
 export interface ReflectionExternalConfig {
     /** Silence threshold in seconds before triggering reflection (default: 7200 = 2h) */
     silenceThreshold?: number;
@@ -388,6 +410,7 @@ export interface AppConfig {
     timezone?: string;
     telegram?: TelegramConfig;
     discord?: DiscordConfig;
+    onebot?: OneBotConfig;
     notification: NotificationConfig;
     reflection: ReflectionExternalConfig;
     contextBudget?: ContextBudgetConfig;
@@ -487,6 +510,7 @@ export function loadConfig(configPath?: string, forceReload?: boolean): AppConfi
     const filePersona = (fileConfig.persona ?? {}) as Record<string, unknown>;
     const fileTG = (fileConfig.telegram ?? {}) as Record<string, unknown>;
     const fileDC = (fileConfig.discord ?? {}) as Record<string, unknown>;
+    const fileOB = (fileConfig.onebot ?? {}) as Record<string, unknown>;
     const fileNotification = (fileConfig.notification ?? {}) as Record<string, unknown>;
     const fileReflection = (fileConfig.reflection ?? {}) as Record<string, unknown>;
     const fileMerge = (fileReflection.merge_thresholds ?? {}) as Record<string, unknown>;
@@ -538,6 +562,12 @@ export function loadConfig(configPath?: string, forceReload?: boolean): AppConfi
         discord: Object.keys(fileDC).length > 0 ? {
             botToken: str(fileDC.bot_token) ?? "",
             applicationId: str(fileDC.application_id),
+        } : undefined,
+        onebot: Object.keys(fileOB).length > 0 ? {
+            wsUrl: str(fileOB.ws_url) ?? "",
+            selfId: str(fileOB.self_id) ?? "",
+            whitelist: parseOneBotWhitelist(fileOB),
+            humanizedDelay: parseOneBotHumanizedDelay(fileOB),
         } : undefined,
         notification: {
             mentionKeywords: Array.isArray(fileNotification.mention_keywords)
@@ -981,6 +1011,29 @@ function parseTelegramWhitelist(fileTG: Record<string, unknown>): TelegramWhitel
     };
 }
 
+function parseOneBotWhitelist(fileOB: Record<string, unknown>): OneBotConfig["whitelist"] | undefined {
+    const raw = fileOB.whitelist as Record<string, unknown> | undefined;
+    if (!raw || typeof raw !== "object") return undefined;
+    const groups = Array.isArray(raw.groups)
+        ? (raw.groups as unknown[]).map(x => String(x).trim()).filter(Boolean)
+        : [];
+    const users = Array.isArray(raw.users)
+        ? (raw.users as unknown[]).map(x => String(x).trim()).filter(Boolean)
+        : [];
+    return { enabled: raw.enabled === true, groups, users };
+}
+
+function parseOneBotHumanizedDelay(fileOB: Record<string, unknown>): OneBotConfig["humanizedDelay"] | undefined {
+    const raw = fileOB.humanized_delay as Record<string, unknown> | undefined;
+    if (!raw || typeof raw !== "object") return undefined;
+    return {
+        enabled: raw.enabled === true,
+        msPerChar: typeof raw.ms_per_char === "number" ? raw.ms_per_char : 50,
+        minDelay: typeof raw.min_delay === "number" ? raw.min_delay : 500,
+        maxDelay: typeof raw.max_delay === "number" ? raw.max_delay : 5000,
+    };
+}
+
 // ─── 序列化 + 验证（Dashboard Config Editor 用） ───
 
 /** 将 AppConfig 序列化为 YAML 格式的对象（snake_case keys） */
@@ -1085,6 +1138,30 @@ export function serializeConfigToObject(config: AppConfig): Record<string, unkno
         };
         if (config.discord.applicationId) dc.application_id = config.discord.applicationId;
         obj.discord = dc;
+    }
+
+    // onebot
+    if (config.onebot) {
+        const ob: Record<string, unknown> = {
+            ws_url: config.onebot.wsUrl,
+            self_id: config.onebot.selfId,
+        };
+        if (config.onebot.whitelist) {
+            ob.whitelist = {
+                enabled: config.onebot.whitelist.enabled,
+                groups: config.onebot.whitelist.groups,
+                users: config.onebot.whitelist.users,
+            };
+        }
+        if (config.onebot.humanizedDelay) {
+            ob.humanized_delay = {
+                enabled: config.onebot.humanizedDelay.enabled,
+                ms_per_char: config.onebot.humanizedDelay.msPerChar,
+                min_delay: config.onebot.humanizedDelay.minDelay,
+                max_delay: config.onebot.humanizedDelay.maxDelay,
+            };
+        }
+        obj.onebot = ob;
     }
 
     // reflection
@@ -1380,6 +1457,21 @@ export function validateConfig(config: unknown): { valid: boolean; errors: strin
     const dc = c.discord as Record<string, unknown> | undefined;
     if (dc) {
         if (!dc.botToken) errors.push("discord.botToken 不能为空");
+    }
+
+    // onebot (optional)
+    const ob = c.onebot as Record<string, unknown> | undefined;
+    if (ob) {
+        if (!ob.wsUrl) errors.push("onebot.wsUrl 不能为空");
+        if (!ob.selfId) errors.push("onebot.selfId 不能为空");
+        const wl = ob.whitelist as Record<string, unknown> | undefined;
+        if (wl && typeof wl === "object" && wl.enabled === true) {
+            const g = Array.isArray(wl.groups) ? wl.groups.length : 0;
+            const u = Array.isArray(wl.users) ? wl.users.length : 0;
+            if (g === 0 && u === 0) {
+                errors.push("onebot.whitelist.enabled 为 true 时，groups 与 users 至少填写一项");
+            }
+        }
     }
 
     // contextBudget

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1433,14 +1433,7 @@ export function validateConfig(config: unknown): { valid: boolean; errors: strin
         if (!tg.mode || (tg.mode !== "bot" && tg.mode !== "userbot")) {
             errors.push("telegram.mode 必须是 \"bot\" 或 \"userbot\"");
         }
-        const wl = tg.whitelist as Record<string, unknown> | undefined;
-        if (wl && typeof wl === "object" && wl.enabled === true) {
-            const g = Array.isArray(wl.groups) ? wl.groups.length : 0;
-            const u = Array.isArray(wl.users) ? wl.users.length : 0;
-            if (g === 0 && u === 0) {
-                errors.push("telegram.whitelist.enabled 为 true 时，groups 与 users 至少填写一项");
-            }
-        }
+        // whitelist enabled + empty lists = reject all — valid config, no error
     }
 
     // dashboard (optional)
@@ -1464,14 +1457,7 @@ export function validateConfig(config: unknown): { valid: boolean; errors: strin
     if (ob) {
         if (!ob.wsUrl) errors.push("onebot.wsUrl 不能为空");
         if (!ob.selfId) errors.push("onebot.selfId 不能为空");
-        const wl = ob.whitelist as Record<string, unknown> | undefined;
-        if (wl && typeof wl === "object" && wl.enabled === true) {
-            const g = Array.isArray(wl.groups) ? wl.groups.length : 0;
-            const u = Array.isArray(wl.users) ? wl.users.length : 0;
-            if (g === 0 && u === 0) {
-                errors.push("onebot.whitelist.enabled 为 true 时，groups 与 users 至少填写一项");
-            }
-        }
+        // whitelist enabled + empty lists = reject all — valid config, no error
     }
 
     // contextBudget

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -428,6 +428,8 @@ export interface AppConfig {
     mcpServers?: McpServerPreConfig[];
     /** Grounding（联网事实查证）配置 */
     grounding?: GroundingConfig;
+    /** LLM 请求限速配置 */
+    rateLimiting?: import("./llm-rate-limiter.js").RateLimitConfig;
 }
 
 // ─── 默认值 ───
@@ -598,6 +600,7 @@ export function loadConfig(configPath?: string, forceReload?: boolean): AppConfi
         metrics: parseMetricsConfig(fileConfig),
         mcpServers: parseMcpServersConfig(fileConfig),
         grounding: parseGroundingConfig(fileConfig),
+        rateLimiting: parseRateLimitingConfig(fileConfig),
     };
 
     _cached = config;
@@ -871,6 +874,29 @@ function parseGroundingConfig(fileConfig: Record<string, unknown>): GroundingCon
         apiKey,
         baseUrl: str(raw.base_url),
         model: str(raw.model),
+    };
+}
+
+// ─── Rate Limiting 配置解析 ───
+
+function parseRateLimitingConfig(fileConfig: Record<string, unknown>): import("./llm-rate-limiter.js").RateLimitConfig | undefined {
+    const raw = fileConfig.rate_limiting as Record<string, unknown> | undefined;
+    if (!raw || typeof raw !== "object") return undefined;
+    const perProfileRaw = (raw.per_profile ?? {}) as Record<string, Record<string, unknown>>;
+    const perProfile: Record<string, { maxConcurrency?: number; requestsPerMinute?: number }> = {};
+    for (const [name, val] of Object.entries(perProfileRaw)) {
+        if (typeof val === "object" && val !== null) {
+            perProfile[name] = {
+                maxConcurrency: val.max_concurrency != null ? num(val.max_concurrency, 0) : undefined,
+                requestsPerMinute: val.requests_per_minute != null ? num(val.requests_per_minute, 0) : undefined,
+            };
+        }
+    }
+    return {
+        enabled: raw.enabled === true,
+        maxConcurrency: num(raw.max_concurrency, 0),
+        requestsPerMinute: num(raw.requests_per_minute, 0),
+        perProfile: Object.keys(perProfile).length > 0 ? perProfile : undefined,
     };
 }
 
@@ -1347,6 +1373,25 @@ export function serializeConfigToObject(config: AppConfig): Record<string, unkno
         if (config.grounding.baseUrl) g.base_url = config.grounding.baseUrl;
         if (config.grounding.model) g.model = config.grounding.model;
         obj.grounding = g;
+    }
+
+    // rate_limiting
+    if (config.rateLimiting) {
+        const rl: Record<string, unknown> = {
+            enabled: config.rateLimiting.enabled,
+            max_concurrency: config.rateLimiting.maxConcurrency,
+            requests_per_minute: config.rateLimiting.requestsPerMinute,
+        };
+        if (config.rateLimiting.perProfile && Object.keys(config.rateLimiting.perProfile).length > 0) {
+            const pp: Record<string, Record<string, unknown>> = {};
+            for (const [name, val] of Object.entries(config.rateLimiting.perProfile)) {
+                pp[name] = {};
+                if (val.maxConcurrency != null) pp[name].max_concurrency = val.maxConcurrency;
+                if (val.requestsPerMinute != null) pp[name].requests_per_minute = val.requestsPerMinute;
+            }
+            rl.per_profile = pp;
+        }
+        obj.rate_limiting = rl;
     }
 
     return obj;

--- a/src/core/llm-rate-limiter.ts
+++ b/src/core/llm-rate-limiter.ts
@@ -1,0 +1,266 @@
+/**
+ * llm-rate-limiter.ts — LLM 请求限速器
+ *
+ * 支持两种限制维度：
+ * 1. 并发数（maxConcurrency）：同时进行的 LLM 请求数上限
+ * 2. RPM（requestsPerMinute）：每分钟请求数上限（滑动窗口）
+ *
+ * 可以全局设置，也可以按 profile 设置（profile 级别覆盖全局）。
+ * 超限请求会排队等待，不会被拒绝。
+ */
+
+import { createLogger } from "./logger.js";
+import { EventEmitter } from "node:events";
+
+const log = createLogger("rate-limiter");
+
+/** 限速配置 */
+export interface RateLimitConfig {
+    /** 是否启用限速 */
+    enabled: boolean;
+    /** 全局最大并发 LLM 请求数。0 = 不限制 */
+    maxConcurrency: number;
+    /** 全局每分钟最大请求数。0 = 不限制 */
+    requestsPerMinute: number;
+    /** 按 profile 覆盖。key 为 profile 名称 */
+    perProfile?: Record<string, {
+        maxConcurrency?: number;
+        requestsPerMinute?: number;
+    }>;
+}
+
+/** 限速器状态（供 Dashboard 展示） */
+export interface RateLimiterStats {
+    activeConcurrency: number;
+    queueLength: number;
+    recentRPM: number;
+    config: RateLimitConfig;
+    perProfile: Record<string, {
+        activeConcurrency: number;
+        queueLength: number;
+        recentRPM: number;
+    }>;
+}
+
+interface QueueEntry {
+    resolve: () => void;
+    profileName?: string;
+    enqueuedAt: number;
+}
+
+/** 限速事件（供 Dashboard 订阅） */
+export const rateLimitEvents = new EventEmitter();
+rateLimitEvents.setMaxListeners(20);
+
+class LLMRateLimiter {
+    private _config: RateLimitConfig = {
+        enabled: false,
+        maxConcurrency: 0,
+        requestsPerMinute: 0,
+    };
+
+    // Global tracking
+    private _activeConcurrency = 0;
+    private _timestamps: number[] = []; // RPM sliding window
+    private _queue: QueueEntry[] = [];
+
+    // Per-profile tracking
+    private _profileActive = new Map<string, number>();
+    private _profileTimestamps = new Map<string, number[]>();
+    private _profileQueues = new Map<string, QueueEntry[]>();
+
+    private _drainTimer: ReturnType<typeof setInterval> | null = null;
+
+    updateConfig(config: RateLimitConfig): void {
+        this._config = { ...config };
+        log.info("Rate limiter config updated", {
+            enabled: config.enabled,
+            maxConcurrency: config.maxConcurrency,
+            rpm: config.requestsPerMinute,
+            profiles: Object.keys(config.perProfile ?? {}),
+        });
+        this._drain();
+    }
+
+    getConfig(): RateLimitConfig {
+        return { ...this._config };
+    }
+
+    getStats(): RateLimiterStats {
+        this._pruneTimestamps();
+        const perProfile: RateLimiterStats["perProfile"] = {};
+        for (const name of new Set([
+            ...this._profileActive.keys(),
+            ...this._profileTimestamps.keys(),
+            ...this._profileQueues.keys(),
+        ])) {
+            perProfile[name] = {
+                activeConcurrency: this._profileActive.get(name) ?? 0,
+                queueLength: (this._profileQueues.get(name) ?? []).length,
+                recentRPM: (this._profileTimestamps.get(name) ?? []).length,
+            };
+        }
+        return {
+            activeConcurrency: this._activeConcurrency,
+            queueLength: this._queue.length,
+            recentRPM: this._timestamps.length,
+            config: { ...this._config },
+            perProfile,
+        };
+    }
+
+    /**
+     * Acquire a slot. Resolves when the request is allowed to proceed.
+     * Returns a release function that MUST be called when the request completes.
+     */
+    async acquire(profileName?: string): Promise<() => void> {
+        if (!this._config.enabled) {
+            return () => {};
+        }
+
+        // Wait until we have a slot. The _drain mechanism or immediate check
+        // will record the slot in counters before resolving.
+        const reservedByDrain = await this._waitForSlot(profileName);
+
+        if (!reservedByDrain) {
+            // We got through immediately — record now
+            this._recordSlot(profileName);
+        }
+        // If reservedByDrain === true, _drain already recorded the slot
+
+        let released = false;
+        return () => {
+            if (released) return;
+            released = true;
+            this._activeConcurrency = Math.max(0, this._activeConcurrency - 1);
+            if (profileName) {
+                const cur = this._profileActive.get(profileName) ?? 1;
+                this._profileActive.set(profileName, Math.max(0, cur - 1));
+            }
+            this._drain();
+        };
+    }
+
+    private _recordSlot(profileName?: string): void {
+        this._activeConcurrency++;
+        this._timestamps.push(Date.now());
+        if (profileName) {
+            this._profileActive.set(profileName, (this._profileActive.get(profileName) ?? 0) + 1);
+            const pts = this._profileTimestamps.get(profileName) ?? [];
+            pts.push(Date.now());
+            this._profileTimestamps.set(profileName, pts);
+        }
+    }
+
+    /**
+     * Returns true if the slot was reserved by drain (queued then released),
+     * false if it proceeded immediately.
+     */
+    private async _waitForSlot(profileName?: string): Promise<boolean> {
+        if (this._canProceed(profileName)) return false;
+
+        return new Promise<boolean>((resolve) => {
+            const entry: QueueEntry = {
+                resolve: () => resolve(true),
+                profileName,
+                enqueuedAt: Date.now(),
+            };
+            this._queue.push(entry);
+            if (profileName) {
+                const pq = this._profileQueues.get(profileName) ?? [];
+                pq.push(entry);
+                this._profileQueues.set(profileName, pq);
+            }
+
+            rateLimitEvents.emit("rate-limit:queued", {
+                profileName,
+                queueLength: this._queue.length,
+                timestamp: new Date().toISOString(),
+            });
+
+            this._ensureDrainTimer();
+        });
+    }
+
+    private _canProceed(profileName?: string): boolean {
+        this._pruneTimestamps();
+
+        const globalMaxC = this._config.maxConcurrency;
+        if (globalMaxC > 0 && this._activeConcurrency >= globalMaxC) return false;
+
+        const globalRPM = this._config.requestsPerMinute;
+        if (globalRPM > 0 && this._timestamps.length >= globalRPM) return false;
+
+        if (profileName && this._config.perProfile?.[profileName]) {
+            const override = this._config.perProfile[profileName];
+            if (override.maxConcurrency != null && override.maxConcurrency > 0) {
+                if ((this._profileActive.get(profileName) ?? 0) >= override.maxConcurrency) return false;
+            }
+            if (override.requestsPerMinute != null && override.requestsPerMinute > 0) {
+                if ((this._profileTimestamps.get(profileName) ?? []).length >= override.requestsPerMinute) return false;
+            }
+        }
+
+        return true;
+    }
+
+    private _drain(): void {
+        if (this._queue.length === 0) {
+            this._stopDrainTimer();
+            return;
+        }
+
+        let i = 0;
+        while (i < this._queue.length) {
+            const entry = this._queue[i];
+            if (this._canProceed(entry.profileName)) {
+                this._queue.splice(i, 1);
+                if (entry.profileName) {
+                    const pq = this._profileQueues.get(entry.profileName);
+                    if (pq) {
+                        const idx = pq.indexOf(entry);
+                        if (idx >= 0) pq.splice(idx, 1);
+                    }
+                }
+                // Reserve the slot before resolving
+                this._recordSlot(entry.profileName);
+
+                const waitMs = Date.now() - entry.enqueuedAt;
+                if (waitMs > 100) {
+                    log.debug("Request dequeued", { profile: entry.profileName, waitMs, remaining: this._queue.length });
+                }
+
+                entry.resolve();
+            } else {
+                i++;
+            }
+        }
+
+        if (this._queue.length === 0) {
+            this._stopDrainTimer();
+        }
+    }
+
+    private _pruneTimestamps(): void {
+        const cutoff = Date.now() - 60_000;
+        this._timestamps = this._timestamps.filter(t => t > cutoff);
+        for (const [name, ts] of this._profileTimestamps) {
+            this._profileTimestamps.set(name, ts.filter(t => t > cutoff));
+        }
+    }
+
+    private _ensureDrainTimer(): void {
+        if (this._drainTimer) return;
+        this._drainTimer = setInterval(() => this._drain(), 1000);
+    }
+
+    private _stopDrainTimer(): void {
+        if (this._drainTimer) {
+            clearInterval(this._drainTimer);
+            this._drainTimer = null;
+        }
+    }
+}
+
+/** Singleton */
+export const rateLimiter = new LLMRateLimiter();

--- a/src/core/llm.ts
+++ b/src/core/llm.ts
@@ -18,6 +18,8 @@ export { type ImagePart, type ChatMessage, type LLMResponse } from "./llm/types.
 import type { LLMConfig } from "./config.js";
 import type { ChatMessage, LLMResponse } from "./llm/types.js";
 import { getOrCreatePool } from "./llm-pool.js";
+import { rateLimiter } from "./llm-rate-limiter.js";
+import { loadConfig } from "./config.js";
 import { createLogger } from "./logger.js";
 import { EventEmitter } from "node:events";
 
@@ -126,6 +128,8 @@ export interface LLMCallOptions {
     stop?: string[];
     /** 请求超时（毫秒）。来自 llmRouting.timeouts[component]，未设置则使用默认 60000 */
     timeoutMs?: number;
+    /** Profile 名称（用于限速器按 profile 限速） */
+    profileName?: string;
 }
 
 let _callIdCounter = 0;
@@ -299,6 +303,33 @@ async function callLLMWithPool(
  * 单 key 模式调用（原有 callLLM 逻辑，含内部 3 次重试）
  */
 async function callLLMSingleKey(
+    messages: ChatMessage[],
+    config: LLMConfig,
+    options?: LLMCallOptions,
+): Promise<LLMResponse> {
+    // ── Rate Limiting ──
+    // Auto-detect profile name by matching config object against loaded profiles
+    let profileName = options?.profileName;
+    if (!profileName) {
+        try {
+            const appConfig = loadConfig();
+            for (const [name, p] of Object.entries(appConfig.llmProfiles)) {
+                if (p === config || (p.model === config.model && p.baseUrl === config.baseUrl && p.apiKey === config.apiKey)) {
+                    profileName = name;
+                    break;
+                }
+            }
+        } catch {}
+    }
+    const releaseSlot = await rateLimiter.acquire(profileName);
+    try {
+        return await _callLLMSingleKeyInner(messages, config, options);
+    } finally {
+        releaseSlot();
+    }
+}
+
+async function _callLLMSingleKeyInner(
     messages: ChatMessage[],
     config: LLMConfig,
     options?: LLMCallOptions,

--- a/src/core/message-enricher.ts
+++ b/src/core/message-enricher.ts
@@ -329,6 +329,7 @@ function parseMediaAttachments(messages: RawMessage[], fallbackChatId?: string):
                 type: info.type,
                 fileId: info.fileId,
                 uniqueFileId: info.uniqueFileId ?? info.fileId,
+                url: info.url,
                 emoji: info.emoji,
                 mimeType: info.mimeType,
                 fileName: info.fileName,

--- a/src/core/vision-processor.ts
+++ b/src/core/vision-processor.ts
@@ -24,6 +24,7 @@ export interface MediaAttachment {
     type: "photo" | "sticker" | "video" | "document" | "animation" | "other";
     fileId: string;
     uniqueFileId: string;
+    url?: string;
     emoji?: string;       // sticker only
     mimeType?: string;
     fileName?: string;

--- a/src/dashboard/api-routes.ts
+++ b/src/dashboard/api-routes.ts
@@ -11,6 +11,7 @@ import type { EventBridge } from "./event-bridge.js";
 import type { CodeActExecutor } from "../subagent/code-act-executor.js";
 import { createLogger } from "../core/logger.js";
 import { loadConfig, validateConfig, saveConfig } from "../core/config.js";
+import { rateLimiter } from "../core/llm-rate-limiter.js";
 import {
     listAllPrompts,
     loadOriginalPrompt,
@@ -830,6 +831,11 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
 
     router.get("/token-pricing", (_req, res) => {
         res.json(deps.tokenStats.getPricing() ?? {});
+    });
+
+    // ─── Rate Limiter Stats ───
+    router.get("/rate-limiter/stats", (_req, res) => {
+        res.json(rateLimiter.getStats());
     });
 
     // ─── Config Editor ───

--- a/src/dashboard/event-bridge.ts
+++ b/src/dashboard/event-bridge.ts
@@ -188,9 +188,20 @@ export class EventBridge {
     }
 
     private hookNC(): void {
-        // NC 消息事件
+        // NC 消息事件 + Adapter 状态事件
         this.deps.nc.onPush(event => {
             const type = String(event.type ?? "");
+
+            // Adapter 状态广播到 dashboard
+            if (type === "system.adapter_status") {
+                this.broadcast({
+                    type: "adapter:status",
+                    timestamp: new Date().toISOString(),
+                    data: event,
+                });
+                return;
+            }
+
             if (type !== "nc.message") return;
             this.broadcast({
                 type: "nc:message",

--- a/src/dashboard/ui/package-lock.json
+++ b/src/dashboard/ui/package-lock.json
@@ -877,7 +877,6 @@
       "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
         "debug": "^4.4.1",
@@ -1218,7 +1217,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1780,7 +1778,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1878,7 +1875,6 @@
       "integrity": "sha512-TTDxwYnHkova6Wsyj1PGt9TByuWqvMoeY1bQiuAf2DM/JeDSMw7FjRKzk8K/5mJ99vGOKhbCqTDpyAKwjp4igg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1944,7 +1940,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/src/dashboard/ui/src/app.css
+++ b/src/dashboard/ui/src/app.css
@@ -281,6 +281,18 @@
   border: 1px solid color-mix(in srgb, #5865F2 20%, transparent);
 }
 
+.platform-badge.platform-onebot {
+  background: color-mix(in srgb, #12b7f5 18%, transparent);
+  color: #12b7f5;
+  border: 1px solid color-mix(in srgb, #12b7f5 25%, transparent);
+}
+
+[data-theme="light"] .platform-badge.platform-onebot {
+  background: color-mix(in srgb, #12b7f5 12%, transparent);
+  color: #0b8fc2;
+  border: 1px solid color-mix(in srgb, #12b7f5 20%, transparent);
+}
+
 .platform-badge.platform-unknown {
   background: color-mix(in srgb, var(--color-base-content) 10%, transparent);
   color: color-mix(in srgb, var(--color-base-content) 50%, transparent);

--- a/src/dashboard/ui/src/lib/utils.js
+++ b/src/dashboard/ui/src/lib/utils.js
@@ -58,6 +58,7 @@ export function platformIcon(platform) {
   switch (platform) {
     case 'telegram': return '✈️';
     case 'discord': return '🎮';
+    case 'onebot': return '🐧';
     default: return '';
   }
 }
@@ -69,6 +70,7 @@ export function platformLabel(platform) {
   switch (platform) {
     case 'telegram': return 'TG';
     case 'discord': return 'DC';
+    case 'onebot': return 'QQ';
     default: return platform.toUpperCase().slice(0, 2);
   }
 }

--- a/src/dashboard/ui/src/panels/ConfigPanel.svelte
+++ b/src/dashboard/ui/src/panels/ConfigPanel.svelte
@@ -8,6 +8,7 @@
   import TimezoneTab from "./config/TimezoneTab.svelte";
   import TelegramTab from "./config/TelegramTab.svelte";
   import DiscordTab from "./config/DiscordTab.svelte";
+  import OneBotTab from "./config/OneBotTab.svelte";
   import ReflectionTab from "./config/ReflectionTab.svelte";
   import ContextBudgetTab from "./config/ContextBudgetTab.svelte";
   import EmbeddingTab from "./config/EmbeddingTab.svelte";
@@ -27,6 +28,7 @@
   let toastTimer = null;
   let telegramEnabled = false;
   let discordEnabled = false;
+  let onebotEnabled = false;
 
   /** Password 输入框：focus 显示明文，blur 恢复隐藏 */
   function pwFocus(e) { e.target.type = 'text'; }
@@ -48,6 +50,7 @@
     { id: "timezone", label: "时区", icon: "fa-clock" },
     { id: "telegram", label: "Telegram", icon: "fa-paper-plane" },
     { id: "discord", label: "Discord", icon: "fa-gamepad" },
+    { id: "onebot", label: "QQ / OneBot", icon: "fa-comments" },
     { id: "reflection", label: "反思引擎", icon: "fa-brain" },
     { id: "contextBudget", label: "上下文预算", icon: "fa-sliders" },
     { id: "embedding", label: "Embedding", icon: "fa-vector-square" },
@@ -64,6 +67,7 @@
   const RESTART_FIELDS = {
     telegram: ["mode", "botToken", "apiId", "apiHash", "phone"],
     discord: ["botToken"],
+    onebot: ["wsUrl", "selfId"],
     subagent: ["maxSandboxInstances"],
   };
 
@@ -109,12 +113,25 @@
         (config.telegram?.apiId && config.telegram?.apiHash && config.telegram?.phone)
       );
       discordEnabled = !!config.discord?.botToken;
+      onebotEnabled = !!(config.onebot?.wsUrl && config.onebot?.selfId);
       // 始终确保 UI 有空对象可绑定
       if (!config.telegram) config.telegram = { mode: 'bot', botToken: '', apiId: '', apiHash: '', phone: '' };
       if (!config.telegram.whitelist) {
         config.telegram.whitelist = { enabled: false, groups: [], users: [] };
       }
       if (!config.discord) config.discord = { botToken: "", applicationId: "" };
+      if (!config.onebot) config.onebot = { wsUrl: '', selfId: '' };
+      if (!config.onebot.whitelist) {
+        config.onebot.whitelist = { enabled: false, groups: [], users: [] };
+      }
+      if (!config.onebot.humanizedDelay) {
+        config.onebot.humanizedDelay = {
+          enabled: false,
+          msPerChar: 50,
+          minDelay: 500,
+          maxDelay: 5000,
+        };
+      }
       if (config.telegram && !config.telegram.humanizedDelay) {
         config.telegram.humanizedDelay = {
           enabled: false,
@@ -150,6 +167,11 @@
       JSON.stringify(originalConfig.telegram?.whitelist)
     )
       return true;
+    if (
+      JSON.stringify(config.onebot?.whitelist) !==
+      JSON.stringify(originalConfig.onebot?.whitelist)
+    )
+      return true;
     return false;
   }
 
@@ -161,6 +183,7 @@
       const payload = JSON.parse(JSON.stringify(config));
       if (!telegramEnabled) delete payload.telegram;
       if (!discordEnabled) delete payload.discord;
+      if (!onebotEnabled) delete payload.onebot;
       const res = await api("/config", { method: "PUT", body: payload });
       if (res.ok) {
         originalConfig = JSON.parse(JSON.stringify(config));
@@ -548,6 +571,8 @@
             <TelegramTab bind:config bind:telegramEnabled {pwFocus} {pwBlur} />
           {:else if currentSection === "discord"}
             <DiscordTab bind:config bind:discordEnabled {pwFocus} {pwBlur} />
+          {:else if currentSection === "onebot"}
+            <OneBotTab bind:config bind:onebotEnabled {pwFocus} {pwBlur} />
           {:else if currentSection === "reflection"}
             <ReflectionTab bind:config />
           {:else if currentSection === "contextBudget"}

--- a/src/dashboard/ui/src/panels/ConfigPanel.svelte
+++ b/src/dashboard/ui/src/panels/ConfigPanel.svelte
@@ -19,6 +19,7 @@
   import EnvVarsTab from "./config/EnvVarsTab.svelte";
   import SystemPromptsTab from "./config/SystemPromptsTab.svelte";
   import GroundingTab from "./config/GroundingTab.svelte";
+  import RateLimitingTab from "./config/RateLimitingTab.svelte";
 
   let config = null;
   let originalConfig = null;
@@ -60,6 +61,7 @@
     { id: "recordingPipeline", label: "Recording", icon: "fa-tape" },
     { id: "systemPrompts", label: "System Prompts", icon: "fa-file-lines" },
     { id: "grounding", label: "Grounding", icon: "fa-globe" },
+    { id: "rateLimiting", label: "请求限速", icon: "fa-gauge-high" },
     { id: "envVars", label: "环境变量", icon: "fa-key" },
   ];
 
@@ -106,6 +108,8 @@
       if (!config.recordingPipeline) config.recordingPipeline = {};
       if (!config.envVars) config.envVars = [];
       if (!config.grounding) config.grounding = { provider: 'google', apiKey: '' };
+      if (!config.rateLimiting) config.rateLimiting = { enabled: false, maxConcurrency: 0, requestsPerMinute: 0, perProfile: {} };
+      if (!config.rateLimiting.perProfile) config.rateLimiting.perProfile = {};
       // Adapter 启用状态：根据后端是否返回了有效配置来判断
       // bot 模式看 botToken，userbot 模式看 apiId + apiHash + phone
       telegramEnabled = !!(
@@ -595,6 +599,8 @@
             <RecordingPipelineTab bind:config />
           {:else if currentSection === "envVars"}
             <EnvVarsTab bind:config {pwFocus} {pwBlur} {addEnvVar} {removeEnvVar} />
+          {:else if currentSection === "rateLimiting"}
+            <RateLimitingTab bind:config profileNames={Object.keys(config.llmProfiles ?? {})} />
           {:else if currentSection === "grounding"}
             <GroundingTab bind:config {pwFocus} {pwBlur} />
           {:else if currentSection === "systemPrompts"}

--- a/src/dashboard/ui/src/panels/config/OneBotTab.svelte
+++ b/src/dashboard/ui/src/panels/config/OneBotTab.svelte
@@ -1,0 +1,127 @@
+<script>
+  export let config;
+  export let onebotEnabled = false;
+  export let pwFocus;
+  export let pwBlur;
+</script>
+
+<h3 class="card-title text-sm">
+  <i class="fa-solid fa-comments opacity-50 mr-1"></i> QQ / OneBot 设置
+</h3>
+<label class="cfg-check mb-2">
+  <input
+    type="checkbox"
+    class="toggle toggle-sm"
+    bind:checked={onebotEnabled}
+  />
+  <span class="text-sm font-medium">启用 OneBot Adapter</span>
+</label>
+{#if !onebotEnabled}
+  <p class="text-xs opacity-40 italic mb-3">未启用，设置不会保存到配置文件。</p>
+{/if}
+<div class:opacity-40={!onebotEnabled} class:pointer-events-none={!onebotEnabled}>
+  <p class="text-xs opacity-50 mb-3">通过 OneBot v11 协议连接 NapCat / go-cqhttp 等 QQ 框架。</p>
+  <div class="cfg-grid-2">
+    <label class="cfg-field"
+      ><span class="cfg-label"
+        ><i class="fa-solid fa-rotate-right restart-icon"></i> WebSocket 地址</span
+      >
+      <input
+        type="text"
+        class="input input-xs input-bordered w-full font-mono"
+        bind:value={config.onebot.wsUrl}
+        placeholder="ws://127.0.0.1:3001"
+      /></label
+    >
+    <label class="cfg-field"
+      ><span class="cfg-label"
+        ><i class="fa-solid fa-rotate-right restart-icon"></i> Bot QQ 号</span
+      >
+      <input
+        type="text"
+        class="input input-xs input-bordered w-full font-mono"
+        bind:value={config.onebot.selfId}
+        placeholder="123456789"
+      /></label
+    >
+  </div>
+  <div class="divider text-xs opacity-50 my-3">拟人化发送延迟</div>
+  <label class="cfg-check mb-2">
+    <input
+      type="checkbox"
+      class="toggle toggle-xs"
+      bind:checked={config.onebot.humanizedDelay.enabled}
+    />
+    <span>启用拟人化延迟</span>
+  </label>
+  {#if config.onebot.humanizedDelay.enabled}
+    <div class="cfg-grid-3">
+      <label class="cfg-field"
+        ><span class="cfg-label">每字符 ms</span>
+        <input
+          type="number"
+          class="input input-xs input-bordered w-full"
+          bind:value={config.onebot.humanizedDelay.msPerChar}
+        /></label
+      >
+      <label class="cfg-field"
+        ><span class="cfg-label">最小 ms</span>
+        <input
+          type="number"
+          class="input input-xs input-bordered w-full"
+          bind:value={config.onebot.humanizedDelay.minDelay}
+        /></label
+      >
+      <label class="cfg-field"
+        ><span class="cfg-label">最大 ms</span>
+        <input
+          type="number"
+          class="input input-xs input-bordered w-full"
+          bind:value={config.onebot.humanizedDelay.maxDelay}
+        /></label
+      >
+    </div>
+  {/if}
+  <div class="divider text-xs opacity-50 my-3">
+    入站白名单 <span class="restart-hint"
+      ><i class="fa-solid fa-rotate-right"></i> 修改需重启</span
+    >
+  </div>
+  <p class="text-xs opacity-50 mb-2">启用后仅处理列表中的群聊或私聊；私聊按对方 QQ 号匹配。</p>
+  <label class="cfg-check mb-2">
+    <input
+      type="checkbox"
+      class="toggle toggle-xs"
+      bind:checked={config.onebot.whitelist.enabled}
+    />
+    <span>启用白名单</span>
+  </label>
+  <div class="cfg-grid-2">
+    <label class="cfg-field col-span-2"
+      ><span class="cfg-label">群号（每行一个）</span>
+      <textarea
+        class="textarea textarea-bordered textarea-xs w-full font-mono min-h-[4rem]"
+        value={config.onebot.whitelist.groups.join("\n")}
+        on:input={(e) => {
+          config.onebot.whitelist.groups = e.target.value
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter(Boolean);
+        }}
+      ></textarea></label
+    >
+    <label class="cfg-field col-span-2"
+      ><span class="cfg-label">私聊 QQ 号（每行一个）</span>
+      <textarea
+        class="textarea textarea-bordered textarea-xs w-full font-mono min-h-[4rem]"
+        value={config.onebot.whitelist.users.join("\n")}
+        on:input={(e) => {
+          config.onebot.whitelist.users = e.target.value
+            .split(/\r?\n/)
+            .map((s) => s.trim())
+            .filter(Boolean);
+        }}
+      ></textarea></label
+    >
+  </div>
+</div>

--- a/src/dashboard/ui/src/panels/config/RateLimitingTab.svelte
+++ b/src/dashboard/ui/src/panels/config/RateLimitingTab.svelte
@@ -158,18 +158,27 @@
     <div class="divider text-xs opacity-50 my-3">
       <i class="fa-solid fa-chart-bar mr-1"></i>实时状态
     </div>
-    <div class="grid grid-cols-3 gap-2 text-center">
-      <div class="stat-card">
-        <div class="text-2xl font-bold">{stats.activeConcurrency}</div>
-        <div class="text-xs opacity-50">活跃并发</div>
+    <div class="grid grid-cols-3 gap-3 text-center">
+      <div class="stat-card" class:stat-active={stats.activeConcurrency > 0}>
+        <div class="stat-icon"><i class="fa-solid fa-bolt"></i></div>
+        <div class="stat-value">{stats.activeConcurrency}</div>
+        <div class="stat-label">活跃并发</div>
+        {#if config.rateLimiting.maxConcurrency > 0}
+          <div class="stat-limit">/ {config.rateLimiting.maxConcurrency}</div>
+        {/if}
       </div>
-      <div class="stat-card">
-        <div class="text-2xl font-bold">{stats.queueLength}</div>
-        <div class="text-xs opacity-50">排队中</div>
+      <div class="stat-card" class:stat-warning={stats.queueLength > 0}>
+        <div class="stat-icon"><i class="fa-solid fa-hourglass-half"></i></div>
+        <div class="stat-value">{stats.queueLength}</div>
+        <div class="stat-label">排队中</div>
       </div>
-      <div class="stat-card">
-        <div class="text-2xl font-bold">{stats.recentRPM}</div>
-        <div class="text-xs opacity-50">近 1min 请求</div>
+      <div class="stat-card" class:stat-active={stats.recentRPM > 0}>
+        <div class="stat-icon"><i class="fa-solid fa-chart-line"></i></div>
+        <div class="stat-value">{stats.recentRPM}</div>
+        <div class="stat-label">近 1min 请求</div>
+        {#if config.rateLimiting.requestsPerMinute > 0}
+          <div class="stat-limit">/ {config.rateLimiting.requestsPerMinute}</div>
+        {/if}
       </div>
     </div>
     {#if Object.keys(stats.perProfile).length > 0}
@@ -201,8 +210,42 @@
 
 <style>
   .stat-card {
-    background: oklch(0.25 0 0);
-    border-radius: 0.5rem;
-    padding: 0.5rem;
+    background: oklch(0.22 0.01 260);
+    border: 1px solid oklch(0.35 0.02 260);
+    border-radius: 0.75rem;
+    padding: 0.75rem 0.5rem;
+    transition: all 0.3s ease;
+  }
+  .stat-card.stat-active {
+    background: oklch(0.22 0.04 160);
+    border-color: oklch(0.45 0.1 160);
+  }
+  .stat-card.stat-warning {
+    background: oklch(0.22 0.04 60);
+    border-color: oklch(0.5 0.12 60);
+  }
+  .stat-icon {
+    font-size: 0.75rem;
+    opacity: 0.5;
+    margin-bottom: 0.25rem;
+  }
+  .stat-active .stat-icon { opacity: 0.8; color: oklch(0.75 0.15 160); }
+  .stat-warning .stat-icon { opacity: 0.8; color: oklch(0.75 0.15 60); }
+  .stat-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+    line-height: 1;
+    margin-bottom: 0.15rem;
+  }
+  .stat-active .stat-value { color: oklch(0.8 0.15 160); }
+  .stat-warning .stat-value { color: oklch(0.8 0.15 60); }
+  .stat-label {
+    font-size: 0.7rem;
+    opacity: 0.5;
+  }
+  .stat-limit {
+    font-size: 0.65rem;
+    opacity: 0.35;
+    margin-top: 0.1rem;
   }
 </style>

--- a/src/dashboard/ui/src/panels/config/RateLimitingTab.svelte
+++ b/src/dashboard/ui/src/panels/config/RateLimitingTab.svelte
@@ -1,0 +1,208 @@
+<script>
+  import { onMount, onDestroy } from "svelte";
+  import { api } from "../../lib/api.js";
+
+  export let config;
+  export let profileNames = [];
+
+  let stats = null;
+  let statsTimer = null;
+  let newProfileOverride = "";
+
+  // Ensure rateLimiting object exists
+  $: if (!config.rateLimiting) {
+    config.rateLimiting = {
+      enabled: false,
+      maxConcurrency: 0,
+      requestsPerMinute: 0,
+      perProfile: {},
+    };
+  }
+  $: if (!config.rateLimiting.perProfile) {
+    config.rateLimiting.perProfile = {};
+  }
+
+  async function fetchStats() {
+    try {
+      stats = await api("/rate-limiter/stats");
+    } catch {}
+  }
+
+  function addProfileOverride() {
+    const name = newProfileOverride.trim();
+    if (!name || config.rateLimiting.perProfile[name]) return;
+    config.rateLimiting.perProfile[name] = { maxConcurrency: 0, requestsPerMinute: 0 };
+    config.rateLimiting = config.rateLimiting; // trigger reactivity
+    newProfileOverride = "";
+  }
+
+  function removeProfileOverride(name) {
+    delete config.rateLimiting.perProfile[name];
+    config.rateLimiting = config.rateLimiting;
+  }
+
+  onMount(() => {
+    fetchStats();
+    statsTimer = setInterval(fetchStats, 3000);
+  });
+  onDestroy(() => {
+    if (statsTimer) clearInterval(statsTimer);
+  });
+</script>
+
+<h3 class="card-title text-sm">
+  <i class="fa-solid fa-gauge-high opacity-50 mr-1"></i> LLM 请求限速
+</h3>
+<p class="text-xs opacity-50 mb-3">
+  控制 LLM API 的并发数和每分钟请求数（RPM），防止超限。超限请求会排队等待。
+</p>
+
+<!-- Enable toggle -->
+<label class="cfg-check mb-3">
+  <input type="checkbox" class="toggle toggle-sm toggle-primary" bind:checked={config.rateLimiting.enabled} />
+  <span class="ml-2">启用限速</span>
+</label>
+
+{#if config.rateLimiting.enabled}
+  <!-- Global limits -->
+  <div class="divider text-xs opacity-50 my-2">
+    <i class="fa-solid fa-globe mr-1"></i>全局限制
+  </div>
+  <div class="cfg-grid-2">
+    <label class="cfg-field">
+      <span class="cfg-label">最大并发数</span>
+      <input
+        type="number"
+        class="input input-xs input-bordered w-full"
+        bind:value={config.rateLimiting.maxConcurrency}
+        min="0"
+        placeholder="0 = 不限制"
+      />
+      <span class="text-xs opacity-40">0 = 不限制</span>
+    </label>
+    <label class="cfg-field">
+      <span class="cfg-label">RPM (每分钟请求数)</span>
+      <input
+        type="number"
+        class="input input-xs input-bordered w-full"
+        bind:value={config.rateLimiting.requestsPerMinute}
+        min="0"
+        placeholder="0 = 不限制"
+      />
+      <span class="text-xs opacity-40">0 = 不限制</span>
+    </label>
+  </div>
+
+  <!-- Per-profile overrides -->
+  <div class="divider text-xs opacity-50 my-3">
+    <i class="fa-solid fa-layer-group mr-1"></i>按 Profile 覆盖
+  </div>
+  <p class="text-xs opacity-40 mb-2">
+    为特定 Profile 设置独立的限速参数，覆盖全局设置。
+  </p>
+
+  {#each Object.entries(config.rateLimiting.perProfile) as [name, override]}
+    <div class="profile-card mb-2">
+      <div class="flex justify-between items-center mb-2">
+        <span class="font-mono font-bold text-sm">{name}</span>
+        <button
+          class="btn btn-xs btn-outline btn-error"
+          on:click={() => removeProfileOverride(name)}
+        >
+          <i class="fa-solid fa-trash-can"></i>
+        </button>
+      </div>
+      <div class="cfg-grid-2">
+        <label class="cfg-field">
+          <span class="cfg-label">最大并发数</span>
+          <input
+            type="number"
+            class="input input-xs input-bordered w-full"
+            bind:value={override.maxConcurrency}
+            min="0"
+            placeholder="0 = 跟随全局"
+          />
+        </label>
+        <label class="cfg-field">
+          <span class="cfg-label">RPM</span>
+          <input
+            type="number"
+            class="input input-xs input-bordered w-full"
+            bind:value={override.requestsPerMinute}
+            min="0"
+            placeholder="0 = 跟随全局"
+          />
+        </label>
+      </div>
+    </div>
+  {/each}
+
+  <div class="flex items-center gap-2 mt-2">
+    <select class="select select-xs select-bordered" bind:value={newProfileOverride}>
+      <option value="">选择 Profile...</option>
+      {#each profileNames.filter(n => !config.rateLimiting.perProfile[n]) as name}
+        <option value={name}>{name}</option>
+      {/each}
+    </select>
+    <button
+      class="btn btn-xs btn-outline btn-primary"
+      on:click={addProfileOverride}
+      disabled={!newProfileOverride}
+    >
+      <i class="fa-solid fa-plus"></i> 添加覆盖
+    </button>
+  </div>
+
+  <!-- Live stats -->
+  {#if stats}
+    <div class="divider text-xs opacity-50 my-3">
+      <i class="fa-solid fa-chart-bar mr-1"></i>实时状态
+    </div>
+    <div class="grid grid-cols-3 gap-2 text-center">
+      <div class="stat-card">
+        <div class="text-2xl font-bold">{stats.activeConcurrency}</div>
+        <div class="text-xs opacity-50">活跃并发</div>
+      </div>
+      <div class="stat-card">
+        <div class="text-2xl font-bold">{stats.queueLength}</div>
+        <div class="text-xs opacity-50">排队中</div>
+      </div>
+      <div class="stat-card">
+        <div class="text-2xl font-bold">{stats.recentRPM}</div>
+        <div class="text-xs opacity-50">近 1min 请求</div>
+      </div>
+    </div>
+    {#if Object.keys(stats.perProfile).length > 0}
+      <div class="mt-2">
+        <table class="table table-xs w-full">
+          <thead>
+            <tr>
+              <th>Profile</th>
+              <th class="text-center">并发</th>
+              <th class="text-center">排队</th>
+              <th class="text-center">RPM</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each Object.entries(stats.perProfile) as [name, ps]}
+              <tr>
+                <td class="font-mono text-xs">{name}</td>
+                <td class="text-center">{ps.activeConcurrency}</td>
+                <td class="text-center">{ps.queueLength}</td>
+                <td class="text-center">{ps.recentRPM}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  {/if}
+{/if}
+
+<style>
+  .stat-card {
+    background: oklch(0.25 0 0);
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+  }
+</style>

--- a/src/main-agent/attend-handler.ts
+++ b/src/main-agent/attend-handler.ts
@@ -130,8 +130,12 @@ export function createAttendHandler(
         const adapter = adapterList.find(a => chatId.startsWith(a.platform + ":"));
         if (!adapter) return undefined;
         return async (fileId: string, _chatId?: string, _messageId?: string, _uniqueFileId?: string): Promise<Buffer> => {
-            const result = await adapter.handleCall(`${adapter.platform}.downloadMedia`, [fileId, _chatId, _messageId, _uniqueFileId]) as { buffer: string; size: number };
-            return Buffer.from(result.buffer, "base64");
+            const result = await adapter.handleCall(`${adapter.platform}.downloadMedia`, [fileId]);
+            if (Buffer.isBuffer(result)) return result;
+            if (result && typeof result === "object" && "buffer" in result) {
+                return Buffer.from((result as { buffer: string }).buffer, "base64");
+            }
+            throw new Error(`downloadMedia: unexpected result type: ${typeof result}`);
         };
     };
 

--- a/src/main-agent/dispatch-handler.ts
+++ b/src/main-agent/dispatch-handler.ts
@@ -70,8 +70,12 @@ export function createDispatchHandler(
         const adapter = adapterList.find(a => chatId.startsWith(a.platform + ":"));
         if (!adapter) return undefined;
         return async (fileId: string, _chatId?: string, _messageId?: string, _uniqueFileId?: string): Promise<Buffer> => {
-            const result = await adapter.handleCall(`${adapter.platform}.downloadMedia`, [fileId, _chatId, _messageId, _uniqueFileId]) as { buffer: string; size: number };
-            return Buffer.from(result.buffer, "base64");
+            const result = await adapter.handleCall(`${adapter.platform}.downloadMedia`, [fileId]);
+            if (Buffer.isBuffer(result)) return result;
+            if (result && typeof result === "object" && "buffer" in result) {
+                return Buffer.from((result as { buffer: string }).buffer, "base64");
+            }
+            throw new Error(`downloadMedia: unexpected result type: ${typeof result}`);
         };
     };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ import { createLogger } from "./core/logger.js";
 import { setGlobalTimezone, getGlobalTimezone } from "./core/timezone.js";
 import { TelegramAdapter } from "./adapter/telegram-adapter.js";
 import { DiscordAdapter } from "./adapter/discord-adapter.js";
+import { OneBotAdapter } from "./adapter/onebot-adapter.js";
 import type { PlatformAdapter } from "./adapter/platform-adapter.js";
 
 import { SubagentManager } from "./subagent/subagent-manager.js";
@@ -209,6 +210,13 @@ async function main(): Promise<void> {
         log.info("Discord 配置", {
             botToken: appConfig.discord.botToken ? "✓" : "✗",
             applicationId: appConfig.discord.applicationId ? "✓" : "✗",
+        });
+    }
+    if (appConfig.onebot) {
+        log.info("OneBot 配置", {
+            wsUrl: appConfig.onebot.wsUrl ? "✓" : "✗",
+            selfId: appConfig.onebot.selfId ? "✓" : "✗",
+            whitelist: appConfig.onebot.whitelist?.enabled ? "on" : "off",
         });
     }
 
@@ -597,8 +605,13 @@ async function main(): Promise<void> {
         adapters.push(discordAdapter);
     }
 
+    if (appConfig.onebot) {
+        const onebotAdapter = new OneBotAdapter(appConfig.onebot, nc);
+        adapters.push(onebotAdapter);
+    }
+
     if (adapters.length === 0) {
-        throw new Error("至少需要配置一个平台 adapter（telegram 或 discord）");
+        throw new Error("至少需要配置一个平台 adapter（telegram / discord / onebot）");
     }
 
     // 通用路由函数

--- a/src/main.ts
+++ b/src/main.ts
@@ -757,7 +757,7 @@ async function main(): Promise<void> {
             memory.storeMessageBatch([{
                 messageId: String(event.messageId ?? event.id ?? `msg_${Date.now()}`),
                 chatId,
-                userId: String(event.userId ?? event.user_id ?? event.senderId ?? ""),
+                userId: ensureCompositeId(getPlatform(chatId), String(event.userId ?? event.user_id ?? event.senderId ?? "")),
                 displayName: String(event.displayName ?? event.senderName ?? event.userName ?? ""),
                 text: String(event.text ?? event.message ?? ""),
                 replyToMessageId: event.replyToMessageId ? String(event.replyToMessageId) : undefined,
@@ -775,7 +775,8 @@ async function main(): Promise<void> {
             const eventUserId = String(event.userId ?? event.user_id ?? event.senderId ?? "");
             if (eventUserId) {
                 try {
-                    memory.upsertPersonIdentity(eventUserId, { username: eventUsername });
+                    const compositeUid2 = ensureCompositeId(getPlatform(chatId), eventUserId);
+                    memory.upsertPersonIdentity(compositeUid2, { username: eventUsername });
                 } catch { /* 非关键路径 */ }
             }
         }
@@ -846,7 +847,8 @@ async function main(): Promise<void> {
             // 记录入方向交互（用户 → agent，此刻已发生）
             // 配合 feedback-loop.ts 的 agent_replied 出方向记录，构成完整双向交互链
             try {
-                const userId = String(event.userId ?? event.senderId ?? "");
+                const rawUserId = String(event.userId ?? event.senderId ?? "");
+                const userId = rawUserId ? ensureCompositeId(getPlatform(chatId), rawUserId) : "";
                 const displayName = String(event.displayName ?? event.senderName ?? event.userName ?? "");
                 const messageText = String(event.text ?? event.message ?? "").slice(0, 200);
                 // Issue 4: 包含发言人信息的交互摘要

--- a/src/main.ts
+++ b/src/main.ts
@@ -172,6 +172,11 @@ async function main(): Promise<void> {
 
     const appConfig = loadConfig();
 
+    // ─── Rate Limiter 初始化 ───
+    const { rateLimiter } = await import("./core/llm-rate-limiter.js");
+    if (appConfig.rateLimiting) {
+        rateLimiter.updateConfig(appConfig.rateLimiting);
+    }
 
     // ─── 全局时区初始化 ───
     setGlobalTimezone(appConfig.timezone);
@@ -1105,6 +1110,9 @@ async function main(): Promise<void> {
                 adapters,
                 onConfigSaved: async (config) => {
                     tokenStats.setProfiles(config.llmProfiles ?? {});
+                    if (config.rateLimiting) {
+                        rateLimiter.updateConfig(config.rateLimiting);
+                    }
                     const normalized = normalizeEnvVars(config.envVars);
                     currentEnvPlan = buildEnvPlan(normalized);
                     applyHostManagedEnv(currentEnvPlan);

--- a/src/main.ts
+++ b/src/main.ts
@@ -606,7 +606,7 @@ async function main(): Promise<void> {
     }
 
     if (appConfig.onebot) {
-        const onebotAdapter = new OneBotAdapter(appConfig.onebot, nc);
+        const onebotAdapter = new OneBotAdapter(appConfig.onebot, nc, sharedMediaDownloader);
         adapters.push(onebotAdapter);
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1230,11 +1230,36 @@ async function main(): Promise<void> {
     }, 30_000);
     if (schedulerWatchdogInterval.unref) schedulerWatchdogInterval.unref();
 
-    // ─── 启动 ───
-    for (const adapter of adapters) {
+    // ─── 启动（并行 + 超时容错） ───
+    const ADAPTER_START_TIMEOUT_MS = 30_000;
+    const adapterStatuses: Array<{ platform: string; status: "ok" | "failed" | "timeout"; error?: string }> = [];
+
+    await Promise.all(adapters.map(async (adapter) => {
         log.info(`启动 ${adapter.platform} adapter...`);
-        await adapter.start();
-        log.info(`${adapter.platform} adapter 就绪`);
+        try {
+            await Promise.race([
+                adapter.start(),
+                new Promise<never>((_, reject) =>
+                    setTimeout(() => reject(new Error(`启动超时 (${ADAPTER_START_TIMEOUT_MS / 1000}s)`)), ADAPTER_START_TIMEOUT_MS)
+                ),
+            ]);
+            log.info(`${adapter.platform} adapter 就绪`);
+            adapterStatuses.push({ platform: adapter.platform, status: "ok" });
+        } catch (err) {
+            const errMsg = String((err as Error)?.message ?? err);
+            log.error(`${adapter.platform} adapter 启动失败，已跳过`, { error: errMsg });
+            adapterStatuses.push({ platform: adapter.platform, status: errMsg.includes("超时") ? "timeout" : "failed", error: errMsg });
+        }
+    }));
+
+    // 广播 adapter 状态到 dashboard
+    nc.push({ type: "system.adapter_status", adapters: adapterStatuses });
+    const failedAdapters = adapterStatuses.filter(a => a.status !== "ok");
+    if (failedAdapters.length > 0) {
+        log.warn("部分 adapter 未就绪", { failed: failedAdapters.map(a => `${a.platform}: ${a.error}`) });
+    }
+    if (adapterStatuses.every(a => a.status !== "ok")) {
+        log.error("所有 adapter 均启动失败，但保持进程运行以允许 dashboard 访问");
     }
 
     // ─── 启动主 Agent 注意力循环 ───

--- a/src/pipeline/recording-pipeline.ts
+++ b/src/pipeline/recording-pipeline.ts
@@ -23,7 +23,7 @@ import type { MemoryStoreV2 } from "../memory-v2/index.js";
 import { embed } from "../memory-v2/embedding.js";
 import type { EmbeddingConfig } from "../core/config.js";
 import type { TopicRegistry } from "./topic-registry.js";
-import { getRawId, getGroupModelKey, getDunbarTierLabel } from "../core/chat-id.js";
+import { getRawId, getGroupModelKey, getDunbarTierLabel, ensureCompositeId, getPlatform } from "../core/chat-id.js";
 import type {
     Message,
     TopicClusteringResult,
@@ -247,7 +247,7 @@ export class RecordingPipeline extends EventEmitter {
                     this.memory.storeMessageBatch(chatMessages.map(m => ({
                         messageId: m.id,
                         chatId: String(m.chatId),
-                        userId: String(m.senderId),
+                        userId: ensureCompositeId(getPlatform(chatId), String(m.senderId)),
                         displayName: m.senderName,
                         text: m.text,
                         replyToMessageId: m.replyToMessageId,
@@ -263,7 +263,7 @@ export class RecordingPipeline extends EventEmitter {
                     for (const m of chatMessages) {
                         if (!seenUsers.has(m.senderId)) {
                             seenUsers.add(m.senderId);
-                            this.memory.upsertPersonIdentity(String(m.senderId), {
+                            this.memory.upsertPersonIdentity(ensureCompositeId(getPlatform(chatId), String(m.senderId)), {
                                 displayName: m.senderName,
                                 ...(m.senderUsername ? { username: m.senderUsername } : {}),
                                 lastSeenAt: new Date(m.timestamp).toISOString(),

--- a/src/sandbox/api-intent-extractor.ts
+++ b/src/sandbox/api-intent-extractor.ts
@@ -24,8 +24,12 @@ const TRIVIAL_CALLS = new Set([
     "discord.sendMedia",
     "onebot.sendText",
     "onebot.sendMedia",
+    "onebot.sendSticker",
+    "onebot.sendFace",
     "qq.sendText",
     "qq.sendMedia",
+    "qq.sendSticker",
+    "qq.sendFace",
     // fs 模块：简单操作不需要完整文档
     "fs.exists",
     "fs.readdir",

--- a/src/sandbox/api-intent-extractor.ts
+++ b/src/sandbox/api-intent-extractor.ts
@@ -22,6 +22,10 @@ const TRIVIAL_CALLS = new Set([
     "telegram.sendMedia",
     "discord.sendText",
     "discord.sendMedia",
+    "onebot.sendText",
+    "onebot.sendMedia",
+    "qq.sendText",
+    "qq.sendMedia",
     // fs 模块：简单操作不需要完整文档
     "fs.exists",
     "fs.readdir",

--- a/src/sandbox/capability-registry.ts
+++ b/src/sandbox/capability-registry.ts
@@ -11,6 +11,7 @@ import { installActions } from "./modules/actions/index.js";
 import { installSkills } from "./modules/skills/index.js";
 import { createTelegramClientProxy } from "./modules/telegram/index.js";
 import { createDiscordClientProxy } from "./modules/discord/index.js";
+import { createOneBotClientProxy } from "./modules/onebot/index.js";
 
 // ─── 环境接口 ───
 
@@ -61,9 +62,12 @@ export function installCapabilityRegistry(env: CapabilityRegistryEnv): Record<st
     const platform = currentPlatform;
     let telegram: unknown = undefined;
     let discord: unknown = undefined;
+    let onebot: unknown = undefined;
 
     if (platform === "discord") {
         discord = createDiscordClientProxy(env, sentHistory);
+    } else if (platform === "onebot") {
+        onebot = createOneBotClientProxy(env, sentHistory);
     } else {
         // 默认 telegram（向后兼容）
         telegram = createTelegramClientProxy(env, sentHistory);
@@ -76,5 +80,6 @@ export function installCapabilityRegistry(env: CapabilityRegistryEnv): Record<st
         skills: installSkills(env, sentHistory),
         telegram,
         discord,
+        onebot,
     };
 }

--- a/src/sandbox/modules/modules-docs.json
+++ b/src/sandbox/modules/modules-docs.json
@@ -571,6 +571,16 @@
         "fullDoc": ""
       },
       {
+        "name": "sendSticker",
+        "brief": "sendSticker(chatId, sticker, opts?): 发送图片作为 QQ 表情包",
+        "fullDoc": ""
+      },
+      {
+        "name": "sendFace",
+        "brief": "sendFace(chatId, faceId, opts?): 发送 QQ 系统表情（CQ face）",
+        "fullDoc": ""
+      },
+      {
         "name": "sendTyping",
         "brief": "sendTyping(chatId): 发送输入状态（OneBot 不支持，静默忽略）",
         "fullDoc": ""
@@ -604,6 +614,16 @@
       {
         "name": "sendFile",
         "brief": "sendFile(chatId, filePath, opts?): 发送文件到 QQ 群或私聊",
+        "fullDoc": ""
+      },
+      {
+        "name": "sendSticker",
+        "brief": "sendSticker(chatId, sticker, opts?): 发送图片作为 QQ 表情包",
+        "fullDoc": ""
+      },
+      {
+        "name": "sendFace",
+        "brief": "sendFace(chatId, faceId, opts?): 发送 QQ 系统表情（CQ face）",
         "fullDoc": ""
       },
       {

--- a/src/sandbox/modules/modules-docs.json
+++ b/src/sandbox/modules/modules-docs.json
@@ -550,5 +550,77 @@
       }
     ],
     "typeDefs": "interface VisionModule {\n    /**\n     * 看图：读取一张或多张图片文件，返回每张图片的文字描述。\n     * 使用 Vision LLM 分析图片内容，支持 JPEG、PNG、WebP 等常见格式。\n     *\n     * @param imagePaths - 图片文件路径（支持绝对路径或相对于 workspace/ 的相对路径），可传入多个参数\n     * @returns 每张图片的详细文字描述数组（与输入路径一一对应）\n     *\n     * @example\n     * // 查看单张图片\n     * const [desc] = await vision.see(\"screenshots/page.png\");\n     * console.log(desc);\n     *\n     * @example\n     * // 同时查看多张图片\n     * const descriptions = await vision.see(\"img1.jpg\", \"img2.png\", \"data/chart.png\");\n     * descriptions.forEach((d, i) => console.log(`图片${i+1}: ${d}`));\n     */\n    see(...imagePaths: string[]): Promise<string[]>;\n}"
+  },
+  {
+    "name": "onebot",
+    "description": "QQ 消息客户端（通过 OneBot v11 协议）。也可通过 qq 别名访问。",
+    "methods": [
+      {
+        "name": "sendText",
+        "brief": "sendText(chatId, text, opts?): 发送文本消息到 QQ 群或私聊",
+        "fullDoc": ""
+      },
+      {
+        "name": "sendMedia",
+        "brief": "sendMedia(chatId, media, opts?): 发送图片/媒体到 QQ 群或私聊",
+        "fullDoc": ""
+      },
+      {
+        "name": "sendFile",
+        "brief": "sendFile(chatId, filePath, opts?): 发送文件到 QQ 群或私聊",
+        "fullDoc": ""
+      },
+      {
+        "name": "sendTyping",
+        "brief": "sendTyping(chatId): 发送输入状态（OneBot 不支持，静默忽略）",
+        "fullDoc": ""
+      },
+      {
+        "name": "deleteMessages",
+        "brief": "deleteMessages(chatId, messageIds): 撤回消息",
+        "fullDoc": ""
+      },
+      {
+        "name": "downloadMedia",
+        "brief": "downloadMedia(mediaRef): 下载媒体文件",
+        "fullDoc": ""
+      }
+    ]
+  },
+  {
+    "name": "qq",
+    "description": "onebot 模块的别名，提供相同的 QQ 消息 API。",
+    "methods": [
+      {
+        "name": "sendText",
+        "brief": "sendText(chatId, text, opts?): 发送文本消息到 QQ 群或私聊",
+        "fullDoc": ""
+      },
+      {
+        "name": "sendMedia",
+        "brief": "sendMedia(chatId, media, opts?): 发送图片/媒体到 QQ 群或私聊",
+        "fullDoc": ""
+      },
+      {
+        "name": "sendFile",
+        "brief": "sendFile(chatId, filePath, opts?): 发送文件到 QQ 群或私聊",
+        "fullDoc": ""
+      },
+      {
+        "name": "sendTyping",
+        "brief": "sendTyping(chatId): 发送输入状态（OneBot 不支持，静默忽略）",
+        "fullDoc": ""
+      },
+      {
+        "name": "deleteMessages",
+        "brief": "deleteMessages(chatId, messageIds): 撤回消息",
+        "fullDoc": ""
+      },
+      {
+        "name": "downloadMedia",
+        "brief": "downloadMedia(mediaRef): 下载媒体文件",
+        "fullDoc": ""
+      }
+    ]
   }
 ]

--- a/src/sandbox/modules/onebot/index.ts
+++ b/src/sandbox/modules/onebot/index.ts
@@ -1,0 +1,165 @@
+/**
+ * modules/onebot/index.ts — OneBot (QQ) 客户端代理模块
+ *
+ * 包含 QQ 客户端 proxy 的完整实现：
+ * - 重复消息拦截（per-session 去重）
+ * - ACK 格式化 & agent_message_sent 事件发射
+ * - 所有 onebot.* / qq.* 方法的 callHost 转发
+ */
+
+import type { CapabilityRegistryEnv } from "../../capability-registry.js";
+import { resolve as pathResolve } from "node:path";
+import { existsSync } from "node:fs";
+
+// ─── 工具函数 ───
+
+export function formatOneBotAck(prefix: string, payload: unknown): string {
+    if (!payload || typeof payload !== "object") return prefix;
+    const raw = payload as Record<string, unknown>;
+    const chatId = raw.chatId ?? raw.group_id ?? raw.user_id;
+    const msgId = raw.message_id ?? raw.id;
+    const parts = [prefix];
+    if (chatId !== undefined) parts.push(`chat=${String(chatId)}`);
+    if (msgId !== undefined) parts.push(`msg=${String(msgId)}`);
+    return parts.join(" ");
+}
+
+// ─── OneBot 客户端代理 ───
+
+export function createOneBotClientProxy(env: CapabilityRegistryEnv, sentHistory: Map<string, Set<string>>) {
+    /**
+     * 将可能的工作区相对路径解析为绝对路径。
+     */
+    function resolveLocalFile(file: unknown): unknown {
+        if (typeof file !== "string") return file;
+        if (file.startsWith("http://") || file.startsWith("https://") || file.startsWith("data:")) return file;
+        const absPath = pathResolve(process.cwd(), file);
+        if (existsSync(absPath)) return absPath;
+        return file;
+    }
+
+    /**
+     * 检查消息是否是重复发送。
+     */
+    function isDuplicate(chatId: string, text: string): boolean {
+        const key = String(chatId);
+        const existing = sentHistory.get(key);
+        if (existing && existing.has(text)) return true;
+        if (!existing) {
+            sentHistory.set(key, new Set([text]));
+        } else {
+            existing.add(text);
+        }
+        return false;
+    }
+
+    return {
+        sendText: async (chatId: string, text: string, opts?: { replyTo?: string | number }) => {
+            if (isDuplicate(String(chatId), text)) {
+                const warning = `[⚠ 运行时警告: 重复消息已拦截] 目标 chat=${String(chatId)} 的消息 "${text.length > 80 ? text.slice(0, 80) + '...' : text}" 与本次 session 中已发送的消息内容完全一致，已自动拦截。`;
+                env.emitOutput(warning);
+                env.notifyHost({
+                    type: "system.duplicate_message_blocked",
+                    scene: "onebot",
+                    chatId: String(chatId),
+                    text,
+                    timestamp: new Date().toISOString(),
+                });
+                return null;
+            }
+            const sent = await env.callHost("onebot.sendText", [chatId, text, opts]);
+            env.emitOutput(formatOneBotAck("[QQ] sendText ok", sent));
+            env.notifyHost({
+                type: "system.agent_message_sent",
+                scene: "onebot",
+                chatId: String(chatId),
+                messageId: typeof sent === "object" && sent && "message_id" in sent ? (sent as { message_id?: unknown }).message_id : undefined,
+                text,
+                replyToMessageId: opts?.replyTo,
+                timestamp: new Date().toISOString(),
+            });
+            return sent;
+        },
+        sendMedia: async (chatId: string, media: unknown, opts?: { replyTo?: string | number; caption?: string }) => {
+            let mediaIdentifier = "[media]";
+            if (media && typeof media === "object") {
+                const m = media as Record<string, unknown>;
+                if (typeof m.file === "string") mediaIdentifier = `[media:file=${m.file}]`;
+                else if (typeof m.url === "string") mediaIdentifier = `[media:url=${m.url}]`;
+                else if (typeof m.type === "string") mediaIdentifier = `[media:type=${m.type}]`;
+            }
+            const mediaText = opts?.caption ? `${opts.caption}|${mediaIdentifier}` : mediaIdentifier;
+            if (isDuplicate(String(chatId), mediaText)) {
+                const preview = mediaText.length > 80 ? mediaText.slice(0, 80) + '...' : mediaText;
+                const warning = `[⚠ 运行时警告: 重复消息已拦截] 目标 chat=${String(chatId)} 的媒体消息 "${preview}" 与本次 session 中已发送的内容一致，已自动拦截。`;
+                env.emitOutput(warning);
+                env.notifyHost({
+                    type: "system.duplicate_message_blocked",
+                    scene: "onebot",
+                    chatId: String(chatId),
+                    text: mediaText,
+                    timestamp: new Date().toISOString(),
+                });
+                return null;
+            }
+
+            let processedMedia = media;
+            if (typeof media === "string") {
+                processedMedia = resolveLocalFile(media);
+            } else if (media && typeof media === "object") {
+                const m = media as Record<string, unknown>;
+                processedMedia = { ...m, file: resolveLocalFile(m.file) };
+            }
+
+            const sent = await env.callHost("onebot.sendMedia", [chatId, processedMedia, opts]);
+            env.emitOutput(formatOneBotAck("[QQ] sendMedia ok", sent));
+            env.notifyHost({
+                type: "system.agent_message_sent",
+                scene: "onebot",
+                chatId: String(chatId),
+                messageId: typeof sent === "object" && sent && "message_id" in sent ? (sent as { message_id?: unknown }).message_id : undefined,
+                text: opts?.caption ?? "[media]",
+                timestamp: new Date().toISOString(),
+            });
+            return sent;
+        },
+        sendFile: async (chatId: string, filePath: string, opts?: { replyTo?: string | number; caption?: string; fileName?: string }) => {
+            const fileText = opts?.caption ?? `[file:${filePath}]`;
+            if (isDuplicate(String(chatId), fileText)) {
+                const warning = `[⚠ 运行时警告: 重复消息已拦截] 目标 chat=${String(chatId)} 的文件消息已重复，已自动拦截。`;
+                env.emitOutput(warning);
+                env.notifyHost({
+                    type: "system.duplicate_message_blocked",
+                    scene: "onebot",
+                    chatId: String(chatId),
+                    text: fileText,
+                    timestamp: new Date().toISOString(),
+                });
+                return null;
+            }
+
+            const absFilePath = typeof filePath === "string" ? String(resolveLocalFile(filePath)) : filePath;
+            const sent = await env.callHost("onebot.sendFile", [chatId, absFilePath, opts]);
+            env.emitOutput(formatOneBotAck("[QQ] sendFile ok", sent));
+            env.notifyHost({
+                type: "system.agent_message_sent",
+                scene: "onebot",
+                chatId: String(chatId),
+                messageId: typeof sent === "object" && sent && "message_id" in sent ? (sent as { message_id?: unknown }).message_id : undefined,
+                text: opts?.caption ?? `[file:${filePath}]`,
+                timestamp: new Date().toISOString(),
+            });
+            return sent;
+        },
+        sendTyping: async (_chatId: string) => {
+            // OneBot 没有 typing 指示，静默忽略
+        },
+        deleteMessages: async (chatId: string, messageIds: (string | number)[]) => {
+            await env.callHost("onebot.deleteMessages", [chatId, messageIds]);
+            env.emitOutput(`[QQ] deleteMessages ok chat=${String(chatId)} ids=[${messageIds.join(",")}]`);
+        },
+        downloadMedia: async (mediaRef: string) => {
+            return env.callHost("onebot.downloadMedia", [mediaRef]);
+        },
+    };
+}

--- a/src/sandbox/modules/onebot/index.ts
+++ b/src/sandbox/modules/onebot/index.ts
@@ -151,6 +151,61 @@ export function createOneBotClientProxy(env: CapabilityRegistryEnv, sentHistory:
             });
             return sent;
         },
+        sendSticker: async (chatId: string, sticker: string | Record<string, unknown>, opts?: { replyTo?: string | number; caption?: string }) => {
+            const stickerText = opts?.caption ?? (typeof sticker === "string" ? `[sticker:${sticker}]` : "[sticker]");
+            if (isDuplicate(String(chatId), stickerText)) {
+                const warning = `[⚠ 运行时警告: 重复消息已拦截] 目标 chat=${String(chatId)} 的表情包消息已重复，已自动拦截。`;
+                env.emitOutput(warning);
+                env.notifyHost({
+                    type: "system.duplicate_message_blocked",
+                    scene: "onebot",
+                    chatId: String(chatId),
+                    text: stickerText,
+                    timestamp: new Date().toISOString(),
+                });
+                return null;
+            }
+            const processedSticker = typeof sticker === "string"
+                ? sticker
+                : { ...sticker, file: resolveLocalFile((sticker as Record<string, unknown>).file) };
+            const sent = await env.callHost("onebot.sendSticker", [chatId, processedSticker, opts]);
+            env.emitOutput(formatOneBotAck("[QQ] sendSticker ok", sent));
+            env.notifyHost({
+                type: "system.agent_message_sent",
+                scene: "onebot",
+                chatId: String(chatId),
+                messageId: typeof sent === "object" && sent && "message_id" in sent ? (sent as { message_id?: unknown }).message_id : undefined,
+                text: stickerText,
+                timestamp: new Date().toISOString(),
+            });
+            return sent;
+        },
+        sendFace: async (chatId: string, faceId: string | number, opts?: { replyTo?: string | number; text?: string }) => {
+            const text = `[face:${String(faceId)}]${opts?.text ? ` ${opts.text}` : ""}`;
+            if (isDuplicate(String(chatId), text)) {
+                const warning = `[⚠ 运行时警告: 重复消息已拦截] 目标 chat=${String(chatId)} 的 QQ 表情消息已重复，已自动拦截。`;
+                env.emitOutput(warning);
+                env.notifyHost({
+                    type: "system.duplicate_message_blocked",
+                    scene: "onebot",
+                    chatId: String(chatId),
+                    text,
+                    timestamp: new Date().toISOString(),
+                });
+                return null;
+            }
+            const sent = await env.callHost("onebot.sendFace", [chatId, String(faceId), opts]);
+            env.emitOutput(formatOneBotAck("[QQ] sendFace ok", sent));
+            env.notifyHost({
+                type: "system.agent_message_sent",
+                scene: "onebot",
+                chatId: String(chatId),
+                messageId: typeof sent === "object" && sent && "message_id" in sent ? (sent as { message_id?: unknown }).message_id : undefined,
+                text,
+                timestamp: new Date().toISOString(),
+            });
+            return sent;
+        },
         sendTyping: async (_chatId: string) => {
             // OneBot 没有 typing 指示，静默忽略
         },

--- a/src/sandbox/sandbox-worker.ts
+++ b/src/sandbox/sandbox-worker.ts
@@ -317,7 +317,7 @@ async function executeCode(id: string, code: string): Promise<void> {
             notifyHost(event);
         };
 
-        const { runtime, memory, scene, actions, skills, telegram, discord } = installCapabilityRegistry({
+        const { runtime, memory, scene, actions, skills, telegram, discord, onebot } = installCapabilityRegistry({
             ctx,
             emitOutput: (line) => {
                 outputLines.push(line);
@@ -337,6 +337,7 @@ async function executeCode(id: string, code: string): Promise<void> {
             skills: unknown;
             telegram: unknown;
             discord: unknown;
+            onebot: unknown;
         };
 
         // 用 PromiseTracker 包装注入的 API，追踪所有返回的 Promise
@@ -346,9 +347,10 @@ async function executeCode(id: string, code: string): Promise<void> {
         const act = tracker.wrap(actions as Record<string, unknown>);
         const sk = tracker.wrap(skills as Record<string, unknown>);
 
-        // 包装平台 API（互斥：telegram 或 discord 有一个是 undefined）
+        // 包装平台 API（互斥：telegram / discord / onebot 只有一个是有值的）
         const tg = telegram ? tracker.wrap(telegram as Record<string, unknown>) : undefined;
         const dc = discord ? tracker.wrap(discord as Record<string, unknown>) : undefined;
+        const ob = onebot ? tracker.wrap(onebot as Record<string, unknown>) : undefined;
 
         // ─── 动态注入 TS Skills ───
         const skillArgNames: string[] = [];
@@ -364,8 +366,8 @@ async function executeCode(id: string, code: string): Promise<void> {
         // 构造参数列表：固定参数 + 平台 API + 动态 Skill 参数
         // ctx 保留为纯用户 state bag（LLM 可跨 turn 存取任意属性）
         const sh = installShell();
-        const fixedArgNames = ["ctx", "runtime", "memory", "scene", "docs", "actions", "skills", "fs", "mcp", "cron", "events", "kv", "http", "vision", "shell", "telegram", "discord"];
-        const fixedArgValues = [ctx, rt, mem, scene, docs, act, sk, filesystem, mcpBridge, tracker.wrap(cronModule as unknown as Record<string, unknown>), eventsModule, tracker.wrap(kvModule as unknown as Record<string, unknown>), tracker.wrap(httpModule as unknown as Record<string, unknown>), tracker.wrap(visionModule as unknown as Record<string, unknown>), sh, tg, dc];
+        const fixedArgNames = ["ctx", "runtime", "memory", "scene", "docs", "actions", "skills", "fs", "mcp", "cron", "events", "kv", "http", "vision", "shell", "telegram", "discord", "onebot", "qq"];
+        const fixedArgValues = [ctx, rt, mem, scene, docs, act, sk, filesystem, mcpBridge, tracker.wrap(cronModule as unknown as Record<string, unknown>), eventsModule, tracker.wrap(kvModule as unknown as Record<string, unknown>), tracker.wrap(httpModule as unknown as Record<string, unknown>), tracker.wrap(visionModule as unknown as Record<string, unknown>), sh, tg, dc, ob, ob];
         const allArgNames = [...fixedArgNames, ...skillArgNames];
         const allArgValues = [...fixedArgValues, ...skillArgValues];
 

--- a/src/subagent/code-act-executor.ts
+++ b/src/subagent/code-act-executor.ts
@@ -71,6 +71,7 @@ export function getModuleRegistryCache(): ModuleEntry[] {
 const PLATFORM_MODULES: Record<string, string> = {
     telegram: "telegram",
     discord: "discord",
+    onebot: "onebot",
 };
 
 /**
@@ -460,10 +461,13 @@ export class CodeActExecutor {
             // 主 Agent 指定的额外模块
             ...(task.useSkills ?? []),
         ]);
+        const platform = getPlatform(this.chatId);
+        const platformModule = platform === "onebot" ? "qq" : platform;
         const systemVars = {
             personaName: this.personaName,
             personaDescription: this.personaDescription,
-            apiTypeDefs: loadApiTypeDefs(getPlatform(this.chatId), allowedSkills),
+            apiTypeDefs: loadApiTypeDefs(platform, allowedSkills),
+            platformModule,
         };
         const systemPrompt = renderPrompt("EXECUTION", systemVars);
 
@@ -522,7 +526,6 @@ export class CodeActExecutor {
         const sandbox = await this.sandboxPool!.acquire(this.chatId);
 
         // 设置平台标识，供 capability-registry 和 scene.current 使用
-        const platform = getPlatform(this.chatId);
         await sandbox.execute(`__setPlatform(${JSON.stringify(platform)})`, 5000);
         // 注册 notify 监听器收集已发消息
         const rawChatId = getRawId(this.chatId);

--- a/system-prompts/executor/subagent-execution-task.md
+++ b/system-prompts/executor/subagent-execution-task.md
@@ -18,7 +18,7 @@
 
 {{#availableStickers}}
 ## 可用贴纸
-以下贴纸可通过 telegram.sendSticker 发送（适合用贴纸表达情绪或活跃气氛时使用，不要强行发送）：
+以下贴纸可通过 sendSticker 发送（适合用贴纸表达情绪或活跃气氛时使用，不要强行发送）：
 {{availableStickers}}
 {{/availableStickers}}
 

--- a/system-prompts/executor/subagent-execution.md
+++ b/system-prompts/executor/subagent-execution.md
@@ -177,6 +177,12 @@ const result = await memory.browseHistory({
 
 一部分图片被用文字说明来代替，请通过文字说明来理解图片，好像你亲眼看到了图片一样。
 
+## 图片发送规则（重要）
+- **优先使用本地文件路径**发送图片：`sendMedia(chatId, { type: 'photo', file: 'Downloads/photos/xxx.jpg' })`
+- workspace/Downloads/ 下已缓存的媒体文件可直接使用，发送前先确认文件存在
+- 只有在本地确实没有对应文件时才使用 URL
+- **禁止**上传到任何外部图床（imgbb、imgur、smms、telegraph 等）再发送 URL
+
 # 可用 API
 
 {{apiTypeDefs}}

--- a/system-prompts/executor/subagent-execution.md
+++ b/system-prompts/executor/subagent-execution.md
@@ -50,7 +50,7 @@ curl -s "https://api.example.com/data" -o /tmp/data.json
 → 系统返回执行结果 →
 ```javascript
 const data = JSON.parse(fs.readFile("/tmp/data.json"));
-await telegram.sendText(chatId, `查询结果: ${data.result}`);
+await {{platformModule}}.sendText(chatId, `查询结果: ${data.result}`);
 ```
 
 ## 关键规则：一个代码块只做一件事
@@ -98,10 +98,10 @@ console.log("跑分数据:", benchmarks);
 让{{personaName}}想想，信息够了，组织回复。
 
 ```javascript
-await telegram.sendText(chatId, "上次给你推的4070现在跑分又涨了...", {
+await {{platformModule}}.sendText(chatId, "上次给你推的4070现在跑分又涨了...", {
   replyTo: 12345 // 可选，只有第一条回复需要明确指定回复；如果上下文中互动不复杂，可不明确回复；只填写你能确定的消息id,无法确定时不要填。
 });
-await telegram.sendText(chatId, "现在市场价格大概...");
+await {{platformModule}}.sendText(chatId, "现在市场价格大概...");
 console.log("回复已发送");
 ```
 
@@ -123,9 +123,9 @@ console.log("回复已发送");
 ## 谁能看到你的输出
 
 - 自然语言、console.log → **只有沙盒能看到**，别人看不到
-- `telegram.sendText()`、`telegram.sendSticker()`→ **别人能看到**
+- `{{platformModule}}.sendText()`、`{{platformModule}}.sendMedia()` 等→ **别人能看到**
 
-要说话就必须调 sendText、sendSticker、sendMedia等，否则等于没说。
+要说话就必须调 {{platformModule}}.sendText、sendMedia 等，否则等于没说。
 
 # 记忆系统
 


### PR DESCRIPTION
## Summary
- **新增 OneBot v11 (QQ) 适配器**：通过 WebSocket 连接 NapCat / go-cqhttp 等 QQ 框架，支持群聊和私聊消息收发
- **完整的 QQ 消息能力**：支持文本、图片/媒体、文件、表情包(sticker)、QQ 系统表情(face) 发送，消息撤回，媒体下载
- **Dashboard 集成**：新增 OneBot 配置面板、QQ 平台徽章、adapter 状态广播
- **Sandbox 模块**：新增 `onebot` / `qq` 沙盒模块，agent 可通过 `onebot.sendText()` / `qq.sendText()` 等 API 发送消息
- **Adapter 并行启动容错**：多个 adapter 并行启动，单个失败不阻塞整体；30s 超时保护
- **System prompt 平台无关化**：执行器 prompt 中 `telegram.sendText` 等硬编码改为 `{{platformModule}}.sendText` 模板变量
- **图片发送规则**：禁止上传图床，优先使用本地文件路径发送媒体
## Commits
| Commit | Description |
|--------|-------------|
| `7461777` | feat: add initial OneBot/NapCat adapter support |
| `227ac02` | feat: add OneBot/QQ sandbox module & dashboard config tab |
| `cbff490` | feat: support QQ face/sticker sending and TG sticker reuse |
| `602426b` | feat: adapter并行启动容错 + prompt禁止图床 |
| `5e6f85a` | fix: 修复 OneBot 图片无法查看的问题 |
## Changed Files (26 files, +1495 / -45)
**新增文件：**
- `src/adapter/onebot-adapter.ts` — OneBot v11 适配器核心实现（~770 行）
- `src/sandbox/modules/onebot/index.ts` — 沙盒 QQ 客户端代理模块
- `src/dashboard/ui/src/panels/config/OneBotTab.svelte` — Dashboard QQ 配置面板
**核心改动：**
- `src/core/config.ts` — 新增 `OneBotConfig` 类型、配置解析/序列化/校验
- `src/main.ts` — 注册 OneBot adapter、并行启动逻辑、adapter 状态广播
- `src/sandbox/sandbox-worker.ts` — 注入 `onebot` / `qq` 模块到沙盒执行环境
- `src/subagent/code-act-executor.ts` — 平台模块名动态注入 system prompt
- `system-prompts/executor/subagent-execution.md` — 模板化平台 API 引用 + 图片发送规则
- `src/main-agent/attend-handler.ts` / `dispatch-handler.ts` — downloadMedia 兼容 Buffer 直返
**Dashboard UI：**
- `ConfigPanel.svelte` — 新增 OneBot 配置 tab
- `app.css` — QQ 平台徽章样式
- `utils.js` — QQ 平台图标和标签
- `event-bridge.ts` — adapter 状态事件广播
## Configuration Example
```yaml
onebot:
  ws_url: "ws://127.0.0.1:3001"
  self_id: "123456789"
  whitelist:
    enabled: true
    groups: ["987654321"]
    users: ["123456789"]
  humanized_delay:
    enabled: true
    ms_per_char: 50
    min_delay: 500
    max_delay: 5000
```