### PR TITLE
feat: OneBot 偷表情包 — 基于出现次数的自动收集

### DIFF
--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -9,6 +9,7 @@ import type { NotificationCenter } from "../event/notification-center.js";
 import type { OneBotConfig } from "../core/config.js";
 import type { PlatformAdapter } from "./platform-adapter.js";
 import type { MediaDownloader } from "../core/media-downloader.js";
+import type { StickerStealer } from "../core/sticker-stealer.js";
 import { composeChatId, ensureCompositeId, parseChatId } from "../core/chat-id.js";
 import { createLogger } from "../core/logger.js";
 import { WebSocket } from "ws";
@@ -73,6 +74,7 @@ export class OneBotAdapter implements PlatformAdapter {
         private config: OneBotConfig,
         private nc: NotificationCenter,
         private mediaDownloader?: MediaDownloader,
+        private stickerStealer?: StickerStealer,
     ) {}
 
     async start(): Promise<void> {
@@ -504,6 +506,19 @@ export class OneBotAdapter implements PlatformAdapter {
 
         const normalized = this.normalizeIncomingMessage(event);
         if (!normalized) return;
+
+        if (normalized.mediaInfo?.type === "photo" && this.stickerStealer && this.config.stickerSteal?.enabled) {
+            const mi = normalized.mediaInfo;
+            this.stickerStealer.processImage({
+                uniqueFileId: mi.uniqueFileId,
+                fileId: mi.fileId,
+                url: mi.url,
+                chatId: normalized.chatId,
+                messageId: normalized.messageId,
+            }).catch(err => {
+                log.debug("偷表情包处理失败", { uniqueFileId: mi.uniqueFileId, error: String(err) });
+            });
+        }
 
         this.nc.push({
             type: "nc.message",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -185,6 +185,15 @@ export interface OneBotConfig {
         minDelay: number;
         maxDelay: number;
     };
+    /** 偷表情包配置 */
+    stickerSteal?: {
+        /** 总开关 */
+        enabled: boolean;
+        /** 图片出现次数阈值，达到后触发 VLM 确认（默认 3） */
+        occurrenceThreshold?: number;
+        /** 跳过 VLM 确认，达到阈值直接保存（默认 false） */
+        skipVlmConfirm?: boolean;
+    };
 }
 
 export interface ReflectionExternalConfig {
@@ -570,6 +579,7 @@ export function loadConfig(configPath?: string, forceReload?: boolean): AppConfi
             selfId: str(fileOB.self_id) ?? "",
             whitelist: parseOneBotWhitelist(fileOB),
             humanizedDelay: parseOneBotHumanizedDelay(fileOB),
+            stickerSteal: parseOneBotStickerSteal(fileOB),
         } : undefined,
         notification: {
             mentionKeywords: Array.isArray(fileNotification.mention_keywords)
@@ -1057,6 +1067,16 @@ function parseOneBotHumanizedDelay(fileOB: Record<string, unknown>): OneBotConfi
         msPerChar: typeof raw.ms_per_char === "number" ? raw.ms_per_char : 50,
         minDelay: typeof raw.min_delay === "number" ? raw.min_delay : 500,
         maxDelay: typeof raw.max_delay === "number" ? raw.max_delay : 5000,
+    };
+}
+
+function parseOneBotStickerSteal(fileOB: Record<string, unknown>): OneBotConfig["stickerSteal"] | undefined {
+    const raw = fileOB.sticker_steal as Record<string, unknown> | undefined;
+    if (!raw || typeof raw !== "object") return undefined;
+    return {
+        enabled: raw.enabled === true,
+        occurrenceThreshold: typeof raw.occurrence_threshold === "number" ? raw.occurrence_threshold : 3,
+        skipVlmConfirm: raw.skip_vlm_confirm === true,
     };
 }
 

--- a/src/core/sticker-steal-db.ts
+++ b/src/core/sticker-steal-db.ts
@@ -1,0 +1,92 @@
+/**
+ * sticker-steal-db.ts — OneBot 偷表情包：图片出现次数追踪（独立 SQLite）
+ *
+ * 独立于 memory.db 的专用数据库，追踪 OneBot 群聊中图片的出现次数。
+ * 同一图片（以 unique_file_id 去重）累计出现 N 次后触发 VLM 确认。
+ */
+
+import Database from "better-sqlite3";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("sticker-steal-db");
+
+export interface ImageOccurrence {
+    uniqueFileId: string;
+    fileId: string;
+    url?: string;
+    occurrenceCount: number;
+    firstSeenAt: string;
+    lastSeenAt: string;
+}
+
+export class StickerStealDB {
+    private db: Database.Database;
+
+    constructor(dbPath: string) {
+        mkdirSync(dirname(dbPath), { recursive: true });
+        this.db = new Database(dbPath);
+        this.db.pragma("journal_mode = WAL");
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS image_occurrences (
+                unique_file_id TEXT PRIMARY KEY,
+                file_id TEXT NOT NULL,
+                url TEXT,
+                occurrence_count INTEGER DEFAULT 1,
+                first_seen_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL
+            )
+        `);
+        log.info("StickerStealDB 已初始化", { dbPath });
+    }
+
+    incrementImageOccurrence(uniqueFileId: string, fileId: string, url?: string): number {
+        const now = new Date().toISOString();
+        const existing = this.db.prepare(
+            "SELECT occurrence_count FROM image_occurrences WHERE unique_file_id = ?"
+        ).get(uniqueFileId) as { occurrence_count: number } | undefined;
+
+        if (existing) {
+            const newCount = existing.occurrence_count + 1;
+            this.db.prepare(`
+                UPDATE image_occurrences
+                SET file_id = ?, url = ?, occurrence_count = ?, last_seen_at = ?
+                WHERE unique_file_id = ?
+            `).run(fileId, url ?? null, newCount, now, uniqueFileId);
+            return newCount;
+        }
+
+        this.db.prepare(`
+            INSERT INTO image_occurrences (unique_file_id, file_id, url, occurrence_count, first_seen_at, last_seen_at)
+            VALUES (?, ?, ?, 1, ?, ?)
+        `).run(uniqueFileId, fileId, url ?? null, now, now);
+        return 1;
+    }
+
+    getImageOccurrence(uniqueFileId: string): ImageOccurrence | null {
+        const row = this.db.prepare(
+            "SELECT unique_file_id, file_id, url, occurrence_count, first_seen_at, last_seen_at FROM image_occurrences WHERE unique_file_id = ?"
+        ).get(uniqueFileId) as { unique_file_id: string; file_id: string; url: string | null; occurrence_count: number; first_seen_at: string; last_seen_at: string } | undefined;
+        if (!row) return null;
+        return {
+            uniqueFileId: row.unique_file_id,
+            fileId: row.file_id,
+            url: row.url ?? undefined,
+            occurrenceCount: row.occurrence_count,
+            firstSeenAt: row.first_seen_at,
+            lastSeenAt: row.last_seen_at,
+        };
+    }
+
+    removeImageOccurrence(uniqueFileId: string): void {
+        this.db.prepare(
+            "DELETE FROM image_occurrences WHERE unique_file_id = ?"
+        ).run(uniqueFileId);
+    }
+
+    close(): void {
+        this.db.close();
+        log.info("StickerStealDB 已关闭");
+    }
+}

--- a/src/core/sticker-stealer.ts
+++ b/src/core/sticker-stealer.ts
@@ -1,0 +1,151 @@
+/**
+ * sticker-stealer.ts — OneBot 偷表情包核心逻辑
+ *
+ * 协调图片出现次数追踪、下载、VLM 确认、保存。
+ * 流程：图片出现 N 次 → 下载 → VLM 确认 → 保存到 sticker_descriptions
+ * 全程静默，仅写日志。
+ */
+
+import { StickerStealDB } from "./sticker-steal-db.js";
+import type { MediaDownloader } from "./media-downloader.js";
+import type { MemoryStoreV2 } from "../memory-v2/index.js";
+import { classifyAndDescribeMeme, ensureSupportedFormat } from "./vision-processor.js";
+import type { LLMConfig, VisionConfig } from "./config.js";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("sticker-stealer");
+
+export interface StickerStealConfig {
+    enabled: boolean;
+    occurrenceThreshold: number;
+    skipVlmConfirm: boolean;
+}
+
+const EXT_MIME_MAP: Record<string, string> = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+};
+
+function inferMimeType(fileIdOrUrl: string): string {
+    const lower = fileIdOrUrl.toLowerCase();
+    for (const [ext, mime] of Object.entries(EXT_MIME_MAP)) {
+        if (lower.includes(ext)) return mime;
+    }
+    return "image/jpeg";
+}
+
+export class StickerStealer {
+    private db: StickerStealDB;
+    private mediaDownloader: MediaDownloader;
+    private memory: MemoryStoreV2;
+    private visionConfigs: LLMConfig[];
+    private config: StickerStealConfig;
+    private visionConfig?: VisionConfig;
+
+    constructor(options: {
+        dbPath: string;
+        mediaDownloader: MediaDownloader;
+        memory: MemoryStoreV2;
+        visionConfigs: LLMConfig[];
+        config: StickerStealConfig;
+        visionConfig?: VisionConfig;
+    }) {
+        this.db = new StickerStealDB(options.dbPath);
+        this.mediaDownloader = options.mediaDownloader;
+        this.memory = options.memory;
+        this.visionConfigs = options.visionConfigs;
+        this.config = options.config;
+        this.visionConfig = options.visionConfig;
+    }
+
+    async processImage(params: {
+        uniqueFileId: string;
+        fileId: string;
+        url?: string;
+        chatId: string;
+        messageId: string;
+    }): Promise<void> {
+        const { uniqueFileId, fileId, url, chatId, messageId } = params;
+
+        const existing = this.memory.getStickerDescription(uniqueFileId);
+        if (existing) return;
+
+        const count = this.db.incrementImageOccurrence(uniqueFileId, fileId, url);
+        if (count < this.config.occurrenceThreshold) {
+            log.debug("图片计数未达阈值", { uniqueFileId, count, threshold: this.config.occurrenceThreshold });
+            return;
+        }
+
+        log.info("图片计数达到阈值，开始偷表情包", { uniqueFileId, count });
+
+        try {
+            const { buffer, mimeType } = await this.downloadImage(url, fileId);
+            const { buffer: convBuf, mimeType: convMime } = await ensureSupportedFormat(buffer, mimeType);
+
+            if (this.config.skipVlmConfirm) {
+                this.saveAsSticker(convBuf, convMime, uniqueFileId, chatId, messageId, `QQ表情包-${uniqueFileId.slice(0, 8)}`);
+                return;
+            }
+
+            const result = await classifyAndDescribeMeme(convBuf, convMime, this.visionConfigs);
+            if (result.isMeme && result.description) {
+                this.saveAsSticker(convBuf, convMime, uniqueFileId, chatId, messageId, result.description, result.emoji);
+            } else {
+                log.debug("图片非表情包，跳过收集", { uniqueFileId });
+            }
+        } catch (err) {
+            log.warn("偷表情包处理失败", { uniqueFileId, error: String(err) });
+        } finally {
+            this.db.removeImageOccurrence(uniqueFileId);
+        }
+    }
+
+    private async downloadImage(url?: string, fileId?: string): Promise<{ buffer: Buffer; mimeType: string }> {
+        const downloadUrl = url;
+        if (downloadUrl) {
+            const resp = await fetch(downloadUrl, { signal: AbortSignal.timeout(30000) });
+            if (!resp.ok) throw new Error(`下载图片失败: HTTP ${resp.status}`);
+            const buffer = Buffer.from(await resp.arrayBuffer());
+            const mimeType = inferMimeType(downloadUrl);
+            return { buffer, mimeType };
+        }
+
+        if (fileId) {
+            const mimeType = inferMimeType(fileId);
+            throw new Error(`无法下载图片：无 URL，fileId=${fileId}（需要 OneBot 图片 URL）`);
+        }
+
+        throw new Error("无法下载图片：无 URL 且无 fileId");
+    }
+
+    private saveAsSticker(
+        buffer: Buffer,
+        mimeType: string,
+        uniqueFileId: string,
+        chatId: string,
+        messageId: string,
+        description: string,
+        emoji?: string,
+    ): void {
+        this.mediaDownloader.saveMedia(buffer, {
+            chatId,
+            messageId,
+            uniqueFileId,
+            mediaType: "sticker",
+            mimeType,
+        });
+
+        const newDefault = this.visionConfig?.newStickerDefault !== "disabled";
+        this.memory.setStickerDescription(uniqueFileId, description, emoji, newDefault);
+
+        log.info("自动收集 QQ 表情包", { uniqueFileId, description, emoji });
+    }
+
+    close(): void {
+        this.db.close();
+    }
+}

--- a/src/core/vision-processor.ts
+++ b/src/core/vision-processor.ts
@@ -104,6 +104,63 @@ export async function ensureSupportedFormat(
 /** 图片描述内存缓存（Path B）: uniqueFileId → description */
 const photoDescriptionCache = new Map<string, string>();
 
+// ─── 表情包检测 ───
+
+/** 表情包尺寸阈值：宽高均 ≤ 此值的图片视为候选表情包 */
+const MEME_MAX_DIMENSION = 512;
+/** 最小尺寸，过小的缩略图不算 */
+const MEME_MIN_DIMENSION = 48;
+
+/**
+ * 判断一张图片是否可能是表情包（基于尺寸启发式）
+ */
+function looksLikeMeme(att: MediaAttachment): boolean {
+    if (!att.width || !att.height) return false;
+    if (att.fileName) return false;
+    const maxDim = Math.max(att.width, att.height);
+    const minDim = Math.min(att.width, att.height);
+    return maxDim <= MEME_MAX_DIMENSION && minDim >= MEME_MIN_DIMENSION;
+}
+
+/**
+ * 调用 Vision LLM 分析图片是否为表情包/梗图，如果是则返回描述和 emoji
+ */
+export async function classifyAndDescribeMeme(
+    imageBuffer: Buffer,
+    mimeType: string,
+    visionConfigs: LLMConfig[],
+): Promise<{ isMeme: boolean; description?: string; emoji?: string }> {
+    const b64 = imageBuffer.toString("base64");
+    const dataUri = `data:${mimeType};base64,${b64}`;
+
+    const messages: ChatMessage[] = [
+        {
+            role: "user",
+            content: `判断这张图片是否是表情包/梗图/搞笑图片（通常含有夸张表情、配文、emoji 风格画面、或网络流行梗元素）。
+
+请用以下 JSON 格式回复（仅返回 JSON）：
+- 如果是表情包：{"isMeme": true, "description": "简短描述表情包含义和情绪", "emoji": "最贴切的单个emoji"}
+- 如果不是：{"isMeme": false}`,
+            imageParts: [{ url: dataUri }],
+        },
+    ];
+
+    const response = await callLLMWithFallback(messages, visionConfigs, { caller: "vision-meme", timeoutMs: resolveComponentTimeout("vision") });
+    const raw = response.content.trim();
+    try {
+        const jsonStr = raw.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+        const parsed = JSON.parse(jsonStr);
+        return {
+            isMeme: !!parsed.isMeme,
+            description: parsed.description ? String(parsed.description) : undefined,
+            emoji: typeof parsed.emoji === "string" ? parsed.emoji : undefined,
+        };
+    } catch {
+        log.debug("classifyAndDescribeMeme: JSON 解析失败", { raw: raw.slice(0, 100) });
+        return { isMeme: false };
+    }
+}
+
 // ─── 核心处理函数 ───
 
 /**
@@ -251,6 +308,52 @@ export async function processMediaBatch(
 
     const photoResults = await Promise.all(photoTasks);
     results.push(...photoResults);
+
+    // ─── 表情包自动收集：对尺寸符合的图片做 meme 分类 ───
+    if (stickerCache && downloadFn && (isPathA || isPathB) && mediaDownloader) {
+        const visionCfgs = isPathA ? [llmConfig] : visionLlmConfigs!;
+        for (let i = 0; i < photos.length; i++) {
+            const photo = photos[i];
+            if (!looksLikeMeme(photo)) continue;
+            const cached = stickerCache.getStickerDescription(photo.uniqueFileId);
+            if (cached) continue;
+
+            try {
+                let buf: Buffer;
+                const stored = pathBBuffers.get(photo.uniqueFileId);
+                if (stored) {
+                    buf = stored.buffer;
+                } else {
+                    buf = await downloadFn(photo.fileId, photo.chatId, photo.messageId, photo.uniqueFileId);
+                }
+                const { buffer: convBuf, mimeType: convMime } = await ensureSupportedFormat(buf, photo.mimeType ?? "image/jpeg");
+                const memeResult = await classifyAndDescribeMeme(convBuf, convMime, visionCfgs);
+                if (memeResult.isMeme && memeResult.description) {
+                    mediaDownloader.saveMedia(buf, {
+                        chatId: photo.chatId,
+                        messageId: photo.messageId,
+                        uniqueFileId: photo.uniqueFileId,
+                        mediaType: "sticker",
+                        mimeType: photo.mimeType ?? "image/jpeg",
+                    });
+                    const newDefault = config?.newStickerDefault !== "disabled";
+                    stickerCache.setStickerDescription(
+                        photo.uniqueFileId,
+                        memeResult.description,
+                        memeResult.emoji,
+                        newDefault,
+                    );
+                    log.info("自动收集图片表情包", {
+                        uniqueFileId: photo.uniqueFileId,
+                        description: memeResult.description,
+                        emoji: memeResult.emoji,
+                    });
+                }
+            } catch (err) {
+                log.debug("表情包分类失败，跳过", { uniqueFileId: photo.uniqueFileId, error: String(err) });
+            }
+        }
+    }
 
     // ─── 保存 photo/sticker 到磁盘（如果有 mediaDownloader） ───
     if (mediaDownloader && downloadFn) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -611,7 +611,28 @@ async function main(): Promise<void> {
     }
 
     if (appConfig.onebot) {
-        const onebotAdapter = new OneBotAdapter(appConfig.onebot, nc, sharedMediaDownloader);
+        let stickerStealer: import("./core/sticker-stealer.js").StickerStealer | undefined;
+        if (appConfig.onebot.stickerSteal?.enabled) {
+            const { StickerStealer } = await import("./core/sticker-stealer.js");
+            const visionConfigs = resolveComponentProfiles("vision", appConfig);
+            stickerStealer = new StickerStealer({
+                dbPath: join(DATA_DIR, "onebot-sticker-steal.db"),
+                mediaDownloader: sharedMediaDownloader,
+                memory,
+                visionConfigs,
+                config: {
+                    enabled: true,
+                    occurrenceThreshold: appConfig.onebot.stickerSteal.occurrenceThreshold ?? 3,
+                    skipVlmConfirm: appConfig.onebot.stickerSteal.skipVlmConfirm ?? false,
+                },
+                visionConfig: appConfig.vision,
+            });
+            log.info("偷表情包已启用", {
+                occurrenceThreshold: appConfig.onebot.stickerSteal.occurrenceThreshold ?? 3,
+                skipVlmConfirm: appConfig.onebot.stickerSteal.skipVlmConfirm ?? false,
+            });
+        }
+        const onebotAdapter = new OneBotAdapter(appConfig.onebot, nc, sharedMediaDownloader, stickerStealer);
         adapters.push(onebotAdapter);
     }
 


### PR DESCRIPTION
- 新增 StickerStealDB: 独立 SQLite 追踪图片出现次数
- 新增 StickerStealer: 计数→下载→VLM 分类→保存到 sticker_descriptions
- vision-processor: 新增 classifyAndDescribeMeme + processMediaBatch 中自动收集
- onebot-adapter: 每条图片消息触发 processImage
- config: 新增 onebot.sticker_steal 配置段
- 双路收集: 即时计数路径 + vision 富化时尺寸启发式路径