### PR TITLE
Pr/recording fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ config.yaml
 
 # Temporal Project Files
 .tmp
+
+# Runtime data (bind mounts)
+data/
+
+# Agent instructions (local only)
+AGENTS.md
+CLAUDE.md

--- a/src/memory-v2/memory-v2.ts
+++ b/src/memory-v2/memory-v2.ts
@@ -434,6 +434,22 @@ export class MemoryStoreV2 implements IMemoryStoreV2 {
             );
             CREATE INDEX IF NOT EXISTS idx_todo_chat_due ON todo_items(chat_id, due_at);
         `);
+
+        // 回填 person_identities.total_message_count（历史数据从 person_group_profiles 汇总）
+        this.db.exec(`
+            UPDATE person_identities
+            SET total_message_count = COALESCE((
+                SELECT SUM(message_count)
+                FROM person_group_profiles
+                WHERE person_group_profiles.user_id = person_identities.user_id
+            ), 0)
+            WHERE total_message_count = 0
+              AND EXISTS (
+                SELECT 1 FROM person_group_profiles
+                WHERE person_group_profiles.user_id = person_identities.user_id
+                  AND person_group_profiles.message_count > 0
+              )
+        `);
     }
 
     // ─── 写入方法 ───
@@ -881,6 +897,16 @@ export class MemoryStoreV2 implements IMemoryStoreV2 {
                 ts,
             );
             log.debug("incrementProfileStats: INSERT", { userId, chatId, count: stats.messageCountDelta });
+        }
+
+        // 同步更新 person_identities.total_message_count
+        if (stats.messageCountDelta > 0) {
+            this.db.prepare(`
+                UPDATE person_identities
+                SET total_message_count = total_message_count + ?,
+                    updated_at = ?
+                WHERE user_id = ?
+            `).run(stats.messageCountDelta, ts, userId);
         }
     }
 

--- a/src/pipeline/recording-pipeline.ts
+++ b/src/pipeline/recording-pipeline.ts
@@ -234,7 +234,7 @@ export class RecordingPipeline extends EventEmitter {
                             // 仅在有 triage 结果时写入 summary，避免后续 flush 覆写已有数据
                             ...(triage?.summary ? { summary: triage.summary } : {}),
                             keywords: topic.keywords,
-                            participants: [...topic.participantIds].map(String),
+                            participants: [...topic.participantIds].map(id => ensureCompositeId(getPlatform(chatId), String(id))),
                             messageRange: {
                                 messageIds: topic.messageIds,
                                 count: topic.messageCount,
@@ -285,7 +285,7 @@ export class RecordingPipeline extends EventEmitter {
 
                     // 批量更新群内画像统计（messageCount/activeHours/lastSeenAt）
                     for (const [uid, s] of userStats) {
-                        this.memory.incrementProfileStats(String(uid), String(chatId), {
+                        this.memory.incrementProfileStats(ensureCompositeId(getPlatform(chatId), String(uid)), String(chatId), {
                             messageCountDelta: s.count,
                             activeHoursDelta: s.hours,
                             lastSeenAt: s.lastTs,


### PR DESCRIPTION
Title: fix: composite ID deduplication & message count backfill in recording pipeline

修复 recording pipeline 的两个数据一致性问题：

1. 使用 composite ID 防止重复 profile — 同一用户跨平台/群组时，recording pipeline 可能创建重复的 person_identities 记录。改用 composite ID（平台 + 用户 ID）正确去重。
2. 回填同步 person_identities.total_message_count — total_message_count 字段可能与各群组的分计数不一致，新增回填步骤自动对齐。
