### PR TITLE
feat: enhanced sticker stealing with perceptual hashing and dashboard controls

### DIFF
--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -55,13 +55,16 @@ type OneBotActionResponse = {
 };
 
 type OneBotMediaInfo = {
-    type: "photo" | "video" | "document" | "audio" | "other";
+    type: "photo" | "sticker" | "video" | "document" | "audio" | "other";
     url?: string;
     fileId: string;
     uniqueFileId: string;
     fileName?: string;
     mimeType?: string;
     fileSize?: number;
+    width?: number;
+    height?: number;
+    emoji?: string;
 };
 
 export class OneBotAdapter implements PlatformAdapter {
@@ -271,6 +274,12 @@ export class OneBotAdapter implements PlatformAdapter {
     }
 
     async downloadMedia(_rawMessage: unknown, mediaRef: string): Promise<Buffer> {
+        if (mediaRef.startsWith("face:")) {
+            throw new Error(`downloadMedia: QQ内置表情无法下载 (${mediaRef})`);
+        }
+        if (mediaRef.startsWith("mface:")) {
+            throw new Error(`downloadMedia: QQ商城表情需通过URL下载 (${mediaRef})`);
+        }
         if (mediaRef.startsWith("http://") || mediaRef.startsWith("https://")) {
             const resp = await fetch(mediaRef);
             if (!resp.ok) throw new Error(`downloadMedia: HTTP ${resp.status} for ${mediaRef}`);
@@ -793,6 +802,15 @@ export class OneBotAdapter implements PlatformAdapter {
         return message.map(seg => {
             if (seg.type === "text") return String(seg.data?.text ?? "");
             if (seg.type === "at") return `[CQ:at,qq=${String(seg.data?.qq ?? "")}]`;
+            if (seg.type === "face") {
+                const id = String(seg.data?.id ?? "");
+                const result = typeof seg.data?.result === "string" ? seg.data.result : "";
+                return result ? `[🎭 QQ表情:${result}]` : `[🎭 QQ表情:${id}]`;
+            }
+            if (seg.type === "mface") {
+                const summary = typeof seg.data?.summary === "string" ? seg.data.summary : "";
+                return summary ? `[🎭 商城表情:${summary}]` : "[🎭 商城表情]";
+            }
             return "";
         }).join("").trim();
     }
@@ -810,12 +828,40 @@ export class OneBotAdapter implements PlatformAdapter {
             if (seg.type === "image") {
                 const url = typeof data.url === "string" ? data.url : undefined;
                 const file = String(data.file ?? "");
+                const subType = typeof data.sub_type === "number" ? data.sub_type
+                    : typeof data.sub_type === "string" ? Number(data.sub_type) : undefined;
+                const isSticker = subType === 1;
                 return {
-                    type: "photo",
+                    type: isSticker ? "sticker" : "photo",
                     url,
                     fileId: url || file,
                     uniqueFileId: String(data.file_unique ?? data.file_id ?? file),
                     fileName: typeof data.file === "string" ? path.basename(String(data.file)) : undefined,
+                    width: typeof data.width === "number" ? data.width : (typeof data.width === "string" ? Number(data.width) || undefined : undefined),
+                    height: typeof data.height === "number" ? data.height : (typeof data.height === "string" ? Number(data.height) || undefined : undefined),
+                    mimeType: typeof data.mime_type === "string" ? data.mime_type : undefined,
+                    fileSize: typeof data.file_size === "number" ? data.file_size : (typeof data.file_size === "string" ? Number(data.file_size) || undefined : undefined),
+                };
+            }
+            if (seg.type === "face") {
+                const faceId = String(data.id ?? "");
+                return {
+                    type: "sticker",
+                    fileId: `face:${faceId}`,
+                    uniqueFileId: `face:${faceId}`,
+                    emoji: typeof data.result === "string" ? data.result : undefined,
+                };
+            }
+            if (seg.type === "mface") {
+                const url = typeof data.url === "string" ? data.url : undefined;
+                const emojiPackageId = String(data.emoji_package_id ?? "");
+                const emojiId = String(data.emoji_id ?? "");
+                return {
+                    type: "sticker",
+                    url,
+                    fileId: url ?? `mface:${emojiPackageId}_${emojiId}`,
+                    uniqueFileId: `mface:${emojiPackageId}_${emojiId}`,
+                    emoji: typeof data.summary === "string" ? data.summary : undefined,
                 };
             }
             if (seg.type === "video") {
@@ -859,6 +905,8 @@ export class OneBotAdapter implements PlatformAdapter {
         switch (type) {
             case "photo":
                 return "[📷 图片]";
+            case "sticker":
+                return "[🎭 表情包]";
             case "video":
                 return "[🎬 视频]";
             case "audio":

--- a/src/adapter/telegram-adapter.ts
+++ b/src/adapter/telegram-adapter.ts
@@ -643,7 +643,27 @@ export class TelegramAdapter implements PlatformAdapter {
                 if (stickerPath.toLowerCase().endsWith(".webm")) {
                     throw new Error("sendSticker: 禁止发送 webm 格式贴纸 (通常为视频贴纸)");
                 }
-                const stickerBuffer = fs.readFileSync(stickerPath);
+                let stickerBuffer = fs.readFileSync(stickerPath);
+                // 非 webp/png 格式的贴纸（如来自 QQ 的 jpg）需要转换为 PNG
+                // Telegram sticker 要求: webp/png, ≤512x512, ≤512KB
+                const lowerPath = stickerPath.toLowerCase();
+                if (!lowerPath.endsWith(".webp") && !lowerPath.endsWith(".png")) {
+                    try {
+                        const { ensureSupportedFormat } = await import("../core/vision-processor.js");
+                        const ext = path.extname(stickerPath).toLowerCase();
+                        const mimeMap: Record<string, string> = {
+                            ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+                            ".gif": "image/gif", ".bmp": "image/bmp",
+                            ".tiff": "image/tiff", ".tif": "image/tiff",
+                            ".avif": "image/avif",
+                        };
+                        const mime = mimeMap[ext] ?? "image/jpeg";
+                        const { buffer: converted } = await ensureSupportedFormat(stickerBuffer, mime);
+                        stickerBuffer = Buffer.from(converted);
+                    } catch (err) {
+                        log.warn("sendSticker: 格式转换失败，使用原始文件", { error: String(err) });
+                    }
+                }
                 const stickerOpts = args[2] ?? undefined;
                 return this.handleCall("telegram.sendMedia", [
                     stickerTarget,

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -312,6 +312,14 @@ export interface VisionConfig {
     stickerSendingMode?: "allow_all" | "allow_listed" | "disallow_all";
     /** 新收集的贴纸默认状态。默认 "enabled" */
     newStickerDefault?: "enabled" | "disabled";
+    /** 是否启用偷表情包（ImageCatalog + StickerDetector 管线）。默认 true */
+    stickerStealingEnabled?: boolean;
+    /** 图片出现次数达到此阈值后才进行表情包分类。默认 3 */
+    stickerStealingMinFrequency?: number;
+    /** 表情包检测扫描间隔（分钟）。默认 10 */
+    stickerStealingIntervalMin?: number;
+    /** 被判定为非表情包的图片保留天数。默认 30 */
+    catalogRetentionDays?: number;
 }
 
 /** Recording Pipeline 缓冲/触发配置 */
@@ -847,6 +855,10 @@ function parseVisionConfig(fileConfig: Record<string, unknown>): VisionConfig | 
         mediaRetentionDays: raw.media_retention_days != null ? num(raw.media_retention_days, 3) : undefined,
         stickerSendingMode: (str(raw.sticker_sending_mode) as VisionConfig["stickerSendingMode"]) ?? undefined,
         newStickerDefault: (str(raw.new_sticker_default) as VisionConfig["newStickerDefault"]) ?? undefined,
+        stickerStealingEnabled: raw.sticker_stealing_enabled != null ? !!raw.sticker_stealing_enabled : undefined,
+        stickerStealingMinFrequency: raw.sticker_stealing_min_frequency != null ? num(raw.sticker_stealing_min_frequency, 3) : undefined,
+        stickerStealingIntervalMin: raw.sticker_stealing_interval_min != null ? num(raw.sticker_stealing_interval_min, 10) : undefined,
+        catalogRetentionDays: raw.catalog_retention_days != null ? num(raw.catalog_retention_days, 30) : undefined,
     };
 }
 
@@ -1260,6 +1272,10 @@ export function serializeConfigToObject(config: AppConfig): Record<string, unkno
         if (config.vision.mediaRetentionDays != null) v.media_retention_days = config.vision.mediaRetentionDays;
         if (config.vision.stickerSendingMode != null) v.sticker_sending_mode = config.vision.stickerSendingMode;
         if (config.vision.newStickerDefault != null) v.new_sticker_default = config.vision.newStickerDefault;
+        if (config.vision.stickerStealingEnabled != null) v.sticker_stealing_enabled = config.vision.stickerStealingEnabled;
+        if (config.vision.stickerStealingMinFrequency != null) v.sticker_stealing_min_frequency = config.vision.stickerStealingMinFrequency;
+        if (config.vision.stickerStealingIntervalMin != null) v.sticker_stealing_interval_min = config.vision.stickerStealingIntervalMin;
+        if (config.vision.catalogRetentionDays != null) v.catalog_retention_days = config.vision.catalogRetentionDays;
         obj.vision = v;
     }
 

--- a/src/core/image-catalog.ts
+++ b/src/core/image-catalog.ts
@@ -264,6 +264,37 @@ export class ImageCatalog {
         this.db.prepare("UPDATE image_catalog SET file_path = ? WHERE content_hash = ?").run(filePath, contentHash);
     }
 
+    getStats(): {
+        totalImages: number;
+        pendingCandidates: number;
+        confirmedStickers: number;
+        rejectedImages: number;
+        unclassified: number;
+        recentPromotions: Array<{ contentHash: string; description: string | null; emoji: string | null; promotedAt: string | null }>;
+    } {
+        const total = (this.db.prepare("SELECT COUNT(*) as cnt FROM image_catalog").get() as { cnt: number }).cnt;
+        const confirmed = (this.db.prepare("SELECT COUNT(*) as cnt FROM image_catalog WHERE is_sticker = 1").get() as { cnt: number }).cnt;
+        const rejected = (this.db.prepare("SELECT COUNT(*) as cnt FROM image_catalog WHERE is_sticker = 0").get() as { cnt: number }).cnt;
+        const unclassified = (this.db.prepare("SELECT COUNT(*) as cnt FROM image_catalog WHERE is_sticker IS NULL").get() as { cnt: number }).cnt;
+        const pending = (this.db.prepare("SELECT COUNT(*) as cnt FROM image_catalog WHERE is_sticker IS NULL AND frequency >= 3").get() as { cnt: number }).cnt;
+        const recentRows = this.db.prepare(
+            "SELECT content_hash, description, emoji, promoted_at FROM image_catalog WHERE is_sticker = 1 AND promoted_at IS NOT NULL ORDER BY promoted_at DESC LIMIT 5"
+        ).all() as Array<{ content_hash: string; description: string | null; emoji: string | null; promoted_at: string | null }>;
+        return {
+            totalImages: total,
+            pendingCandidates: pending,
+            confirmedStickers: confirmed,
+            rejectedImages: rejected,
+            unclassified,
+            recentPromotions: recentRows.map(r => ({
+                contentHash: r.content_hash,
+                description: r.description,
+                emoji: r.emoji,
+                promotedAt: r.promoted_at,
+            })),
+        };
+    }
+
     cleanup(retentionDays: number): number {
         const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
         const cutoffStr = new Date(cutoffMs).toISOString();

--- a/src/core/image-catalog.ts
+++ b/src/core/image-catalog.ts
@@ -1,0 +1,306 @@
+/**
+ * image-catalog.ts — 独立图片目录数据库
+ *
+ * 管理待判定和已判定的图片，与 memory.db 完全隔离。
+ * 确认是表情包的图片才提升到正式贴纸库 (sticker_descriptions)。
+ *
+ * 数据库文件: data/image-catalog.db
+ */
+
+import Database from "better-sqlite3";
+import { createLogger } from "./logger.js";
+import { findSimilarEntries, hammingDistance, type SimilarityResult } from "./perceptual-hash.js";
+
+const log = createLogger("image-catalog");
+
+// ─── 类型 ───
+
+export interface ImageCatalogEntry {
+    contentHash: string;
+    phash: string | null;
+    dhash: string | null;
+    sourcePlatform: string;
+    sourceChatId: string | null;
+    uniqueFileId: string | null;
+    filePath: string | null;
+    mimeType: string | null;
+    width: number | null;
+    height: number | null;
+    fileSize: number | null;
+    frequency: number;
+    isSticker: number | null;
+    description: string | null;
+    emoji: string | null;
+    promotedAt: string | null;
+    createdAt: string;
+    lastSeenAt: string;
+}
+
+export interface RecordSightingParams {
+    contentHash: string;
+    phash?: string;
+    dhash?: string;
+    sourcePlatform: string;
+    sourceChatId?: string;
+    uniqueFileId?: string;
+    filePath?: string;
+    mimeType?: string;
+    width?: number;
+    height?: number;
+    fileSize?: number;
+    messageId?: string;
+}
+
+export interface RecordSightingResult {
+    isNew: boolean;
+    frequency: number;
+    isSticker: number | null;
+    needsClassification: boolean;
+}
+
+export interface StickerVerdictParams {
+    contentHash: string;
+    isSticker: boolean;
+    description?: string;
+    emoji?: string;
+}
+
+// ─── ImageCatalog ───
+
+export class ImageCatalog {
+    private db: Database.Database;
+
+    constructor(dbPath: string) {
+        this.db = new Database(dbPath);
+        this.db.pragma("journal_mode = WAL");
+        this.initTables();
+        log.info("ImageCatalog 初始化完成", { dbPath });
+    }
+
+    private initTables(): void {
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS image_catalog (
+                content_hash TEXT PRIMARY KEY,
+                phash TEXT,
+                dhash TEXT,
+                source_platform TEXT NOT NULL,
+                source_chat_id TEXT,
+                unique_file_id TEXT,
+                file_path TEXT,
+                mime_type TEXT,
+                width INTEGER,
+                height INTEGER,
+                file_size INTEGER,
+                frequency INTEGER DEFAULT 1,
+                is_sticker INTEGER DEFAULT NULL,
+                description TEXT,
+                emoji TEXT,
+                promoted_at TEXT,
+                created_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS image_sightings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                content_hash TEXT NOT NULL REFERENCES image_catalog(content_hash),
+                chat_id TEXT NOT NULL,
+                message_id TEXT,
+                seen_at TEXT NOT NULL,
+                UNIQUE(content_hash, chat_id, message_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_image_catalog_phash ON image_catalog(phash);
+            CREATE INDEX IF NOT EXISTS idx_image_catalog_dhash ON image_catalog(dhash);
+            CREATE INDEX IF NOT EXISTS idx_image_catalog_is_sticker ON image_catalog(is_sticker);
+            CREATE INDEX IF NOT EXISTS idx_image_sightings_hash ON image_sightings(content_hash);
+        `);
+
+        try { this.db.exec(`ALTER TABLE image_catalog ADD COLUMN phash TEXT`); } catch { /* 列已存在 */ }
+        try { this.db.exec(`ALTER TABLE image_catalog ADD COLUMN dhash TEXT`); } catch { /* 列已存在 */ }
+        try { this.db.exec(`ALTER TABLE image_catalog ADD COLUMN width INTEGER`); } catch { /* 列已存在 */ }
+        try { this.db.exec(`ALTER TABLE image_catalog ADD COLUMN height INTEGER`); } catch { /* 列已存在 */ }
+        try { this.db.exec(`ALTER TABLE image_catalog ADD COLUMN file_size INTEGER`); } catch { /* 列已存在 */ }
+        try { this.db.exec(`CREATE INDEX IF NOT EXISTS idx_image_catalog_phash ON image_catalog(phash)`); } catch { /* index exists */ }
+    }
+
+    recordSighting(params: RecordSightingParams): RecordSightingResult {
+        const now = new Date().toISOString();
+        const existing = this.db.prepare(
+            "SELECT frequency, is_sticker, unique_file_id, file_path FROM image_catalog WHERE content_hash = ?"
+        ).get(params.contentHash) as { frequency: number; is_sticker: number | null; unique_file_id: string | null; file_path: string | null } | undefined;
+
+        if (existing) {
+            const newFreq = existing.frequency + 1;
+            const updateFields: string[] = ["frequency = ?", "last_seen_at = ?"];
+            const updateValues: unknown[] = [newFreq, now];
+
+            if (params.phash && !this.db.prepare("SELECT phash FROM image_catalog WHERE content_hash = ? AND phash IS NOT NULL").get(params.contentHash)) {
+                updateFields.push("phash = ?");
+                updateValues.push(params.phash);
+            }
+            if (params.dhash && !this.db.prepare("SELECT dhash FROM image_catalog WHERE content_hash = ? AND dhash IS NOT NULL").get(params.contentHash)) {
+                updateFields.push("dhash = ?");
+                updateValues.push(params.dhash);
+            }
+            if (params.filePath && !existing.file_path) {
+                updateFields.push("file_path = ?");
+                updateValues.push(params.filePath);
+            }
+            if (params.uniqueFileId && !existing.unique_file_id) {
+                updateFields.push("unique_file_id = ?");
+                updateValues.push(params.uniqueFileId);
+            }
+
+            updateValues.push(params.contentHash);
+            this.db.prepare(`UPDATE image_catalog SET ${updateFields.join(", ")} WHERE content_hash = ?`).run(...updateValues);
+
+            if (params.sourceChatId && params.messageId) {
+                try {
+                    this.db.prepare(
+                        "INSERT OR IGNORE INTO image_sightings (content_hash, chat_id, message_id, seen_at) VALUES (?, ?, ?, ?)"
+                    ).run(params.contentHash, params.sourceChatId, params.messageId, now);
+                } catch { /* ignore duplicate */ }
+            }
+
+            const needsClassification = existing.is_sticker === null && newFreq >= 3;
+            return { isNew: false, frequency: newFreq, isSticker: existing.is_sticker, needsClassification };
+        }
+
+        this.db.prepare(`
+            INSERT INTO image_catalog (content_hash, phash, dhash, source_platform, source_chat_id, unique_file_id, file_path, mime_type, width, height, file_size, frequency, is_sticker, created_at, last_seen_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, NULL, ?, ?)
+        `).run(
+            params.contentHash,
+            params.phash ?? null,
+            params.dhash ?? null,
+            params.sourcePlatform,
+            params.sourceChatId ?? null,
+            params.uniqueFileId ?? null,
+            params.filePath ?? null,
+            params.mimeType ?? null,
+            params.width ?? null,
+            params.height ?? null,
+            params.fileSize ?? null,
+            now, now,
+        );
+
+        if (params.sourceChatId && params.messageId) {
+            this.db.prepare(
+                "INSERT OR IGNORE INTO image_sightings (content_hash, chat_id, message_id, seen_at) VALUES (?, ?, ?, ?)"
+            ).run(params.contentHash, params.sourceChatId, params.messageId, now);
+        }
+
+        return { isNew: true, frequency: 1, isSticker: null, needsClassification: false };
+    }
+
+    getPendingStickerCandidates(minFrequency: number): ImageCatalogEntry[] {
+        const rows = this.db.prepare(
+            "SELECT * FROM image_catalog WHERE is_sticker IS NULL AND frequency >= ? ORDER BY frequency DESC, last_seen_at DESC"
+        ).all(minFrequency) as Record<string, unknown>[];
+        return rows.map(r => this.rowToEntry(r));
+    }
+
+    setStickerVerdict(params: StickerVerdictParams): void {
+        const isSticker = params.isSticker ? 1 : 0;
+        const now = new Date().toISOString();
+        if (params.description !== undefined) {
+            this.db.prepare(
+                "UPDATE image_catalog SET is_sticker = ?, description = ?, emoji = ?, last_seen_at = ? WHERE content_hash = ?"
+            ).run(isSticker, params.description ?? null, params.emoji ?? null, now, params.contentHash);
+        } else {
+            this.db.prepare(
+                "UPDATE image_catalog SET is_sticker = ?, last_seen_at = ? WHERE content_hash = ?"
+            ).run(isSticker, now, params.contentHash);
+        }
+        log.info("setStickerVerdict", { contentHash: params.contentHash, isSticker: params.isSticker, descPreview: params.description?.slice(0, 50) });
+    }
+
+    getByContentHash(contentHash: string): ImageCatalogEntry | null {
+        const row = this.db.prepare("SELECT * FROM image_catalog WHERE content_hash = ?").get(contentHash) as Record<string, unknown> | undefined;
+        return row ? this.rowToEntry(row) : null;
+    }
+
+    getStickerEntries(): ImageCatalogEntry[] {
+        const rows = this.db.prepare(
+            "SELECT * FROM image_catalog WHERE is_sticker = 1 ORDER BY promoted_at DESC NULLS LAST, last_seen_at DESC"
+        ).all() as Record<string, unknown>[];
+        return rows.map(r => this.rowToEntry(r));
+    }
+
+    getAllEntries(limit = 100, offset = 0): { items: ImageCatalogEntry[]; total: number } {
+        const total = (this.db.prepare("SELECT COUNT(*) as cnt FROM image_catalog").get() as { cnt: number }).cnt;
+        const rows = this.db.prepare("SELECT * FROM image_catalog ORDER BY last_seen_at DESC LIMIT ? OFFSET ?").all(limit, offset) as Record<string, unknown>[];
+        return { items: rows.map(r => this.rowToEntry(r)), total };
+    }
+
+    markPromoted(contentHash: string, uniqueFileId: string, filePath: string): void {
+        const now = new Date().toISOString();
+        this.db.prepare(
+            "UPDATE image_catalog SET promoted_at = ?, unique_file_id = ?, file_path = ? WHERE content_hash = ?"
+        ).run(now, uniqueFileId, filePath, contentHash);
+        log.info("markPromoted", { contentHash, uniqueFileId, filePath });
+    }
+
+    findSimilar(phash: string | null, dhash: string | null, maxPHashDistance: number = 14, maxDHashDistance: number = 10): SimilarityResult[] {
+        if (!phash && !dhash) return [];
+        const allRows = this.db.prepare(
+            "SELECT * FROM image_catalog WHERE phash IS NOT NULL OR dhash IS NOT NULL"
+        ).all() as Record<string, unknown>[];
+        const entries = allRows.map(r => this.rowToEntry(r));
+        return findSimilarEntries(entries, phash, dhash, maxPHashDistance, maxDHashDistance);
+    }
+
+    updateHashes(contentHash: string, phash: string | null, dhash: string | null): void {
+        const fields: string[] = [];
+        const values: unknown[] = [];
+        if (phash !== undefined) { fields.push("phash = ?"); values.push(phash); }
+        if (dhash !== undefined) { fields.push("dhash = ?"); values.push(dhash); }
+        if (fields.length === 0) return;
+        values.push(contentHash);
+        this.db.prepare(`UPDATE image_catalog SET ${fields.join(", ")} WHERE content_hash = ?`).run(...values);
+    }
+
+    updateFilePath(contentHash: string, filePath: string): void {
+        this.db.prepare("UPDATE image_catalog SET file_path = ? WHERE content_hash = ?").run(filePath, contentHash);
+    }
+
+    cleanup(retentionDays: number): number {
+        const cutoffMs = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+        const cutoffStr = new Date(cutoffMs).toISOString();
+        const result = this.db.prepare(
+            "DELETE FROM image_catalog WHERE is_sticker = 0 AND last_seen_at < ?"
+        ).run(cutoffStr);
+        if (result.changes > 0) {
+            this.db.prepare("DELETE FROM image_sightings WHERE content_hash NOT IN (SELECT content_hash FROM image_catalog)").run();
+            log.info("cleanup: 已清理过期非表情包条目", { removed: result.changes, retentionDays });
+        }
+        return result.changes;
+    }
+
+    dispose(): void {
+        this.db.close();
+    }
+
+    private rowToEntry(r: Record<string, unknown>): ImageCatalogEntry {
+        return {
+            contentHash: r.content_hash as string,
+            phash: (r.phash as string) ?? null,
+            dhash: (r.dhash as string) ?? null,
+            sourcePlatform: r.source_platform as string,
+            sourceChatId: (r.source_chat_id as string) ?? null,
+            uniqueFileId: (r.unique_file_id as string) ?? null,
+            filePath: (r.file_path as string) ?? null,
+            mimeType: (r.mime_type as string) ?? null,
+            width: (r.width as number) ?? null,
+            height: (r.height as number) ?? null,
+            fileSize: (r.file_size as number) ?? null,
+            frequency: r.frequency as number,
+            isSticker: r.is_sticker as number | null,
+            description: (r.description as string) ?? null,
+            emoji: (r.emoji as string) ?? null,
+            promotedAt: (r.promoted_at as string) ?? null,
+            createdAt: r.created_at as string,
+            lastSeenAt: r.last_seen_at as string,
+        };
+    }
+}

--- a/src/core/media-downloader.ts
+++ b/src/core/media-downloader.ts
@@ -99,15 +99,17 @@ function resolveExt(mimeType?: string, fileName?: string): string {
 
 export class MediaDownloader {
     private readonly downloadDir: string;
+    private readonly manifestPath: string;
     private readonly retentionDays: number;
     private readonly maxFileSize: number;
     private cleanupTimer: ReturnType<typeof setInterval> | null = null;
-    /** uniqueFileId → relative path 索引 (内存) */
+    /** uniqueFileId → absolute path 索引 (内存) */
     private readonly pathIndex = new Map<string, string>();
 
     constructor(config?: MediaDownloaderConfig) {
         // 始终 resolve 为绝对路径，确保从任意 cwd 都能正确访问
         this.downloadDir = path.resolve(config?.downloadDir ?? DEFAULT_DOWNLOAD_DIR);
+        this.manifestPath = path.join(this.downloadDir, "_manifest.json");
         this.retentionDays = config?.retentionDays ?? DEFAULT_RETENTION_DAYS;
         this.maxFileSize = config?.maxFileSize ?? DEFAULT_MAX_FILE_SIZE;
 
@@ -194,6 +196,7 @@ export class MediaDownloader {
         try {
             fs.writeFileSync(filePath, buffer);
             this.pathIndex.set(opts.uniqueFileId, filePath);
+            this.saveManifest();
             log.debug("saveMedia: 已保存", { filePath, size: buffer.length });
             return {
                 path: filePath,
@@ -240,34 +243,77 @@ export class MediaDownloader {
         }
 
         if (removed > 0) {
+            this.saveManifest();
             log.info("cleanupExpired: 已清理过期文件", { removed, retentionDays: this.retentionDays });
         }
     }
 
+    private loadManifest(): boolean {
+        try {
+            if (!fs.existsSync(this.manifestPath)) return false;
+            const raw = JSON.parse(fs.readFileSync(this.manifestPath, "utf-8"));
+            if (typeof raw !== "object" || raw === null) return false;
+            let loaded = 0;
+            for (const [uniqueFileId, filePath] of Object.entries(raw)) {
+                if (typeof filePath !== "string") continue;
+                if (fs.existsSync(filePath)) {
+                    this.pathIndex.set(uniqueFileId, filePath);
+                    loaded++;
+                }
+            }
+            log.debug("loadManifest: 已加载", { loaded });
+            return loaded > 0;
+        } catch (err) {
+            log.warn("loadManifest: 读取失败", { error: String(err) });
+            return false;
+        }
+    }
+
+    private saveManifest(): void {
+        try {
+            const obj: Record<string, string> = {};
+            for (const [k, v] of this.pathIndex.entries()) {
+                obj[k] = v;
+            }
+            fs.writeFileSync(this.manifestPath, JSON.stringify(obj, null, 2));
+        } catch (err) {
+            log.warn("saveManifest: 写入失败", { error: String(err) });
+        }
+    }
+
     /**
-     * 从磁盘重建 uniqueFileId → path 索引
-     * 通过解析文件名中的第三段 (chatId_msgId_uniqueFileId.ext) 提取
+     * 从 manifest + 磁盘重建 uniqueFileId → path 索引
      */
     private rebuildIndex(): void {
+        this.loadManifest();
+
+        // 回退：扫描磁盘文件，补充 manifest 中缺失的条目
+        let added = 0;
         for (const cat of ["photos", "videos", "stickers", "documents", "other"]) {
             const dir = path.join(this.downloadDir, cat);
             try {
                 const files = fs.readdirSync(dir);
                 for (const file of files) {
-                    // 文件名格式: platform_chatId_msgId_uniqueFileId.ext
+                    if (file.startsWith("_")) continue;
                     const dotIndex = file.lastIndexOf(".");
                     const base = dotIndex > 0 ? file.slice(0, dotIndex) : file;
                     const parts = base.split("_");
-                    // platform(0) + chatId(1) + msgId(2) + uniqueFileId(3+)
                     if (parts.length >= 4) {
                         const uniqueFileId = parts.slice(3).join("_");
-                        this.pathIndex.set(uniqueFileId, path.join(dir, file));
+                        if (!this.pathIndex.has(uniqueFileId)) {
+                            this.pathIndex.set(uniqueFileId, path.join(dir, file));
+                            added++;
+                        }
                     }
                 }
             } catch { /* ignore */ }
         }
+
         if (this.pathIndex.size > 0) {
-            log.debug("rebuildIndex: 已索引文件", { count: this.pathIndex.size });
+            log.debug("rebuildIndex: 已索引文件", { count: this.pathIndex.size, addedFromDisk: added });
+        }
+        if (added > 0) {
+            this.saveManifest();
         }
     }
 

--- a/src/core/message-enricher.ts
+++ b/src/core/message-enricher.ts
@@ -15,6 +15,7 @@
 import { processMediaBatch, type MediaAttachment, type ProcessedMedia, type DownloadFn, type StickerCache } from "./vision-processor.js";
 import { resolveComponentTimeout, type LLMConfig, type VisionConfig } from "./config.js";
 import type { MediaDownloader } from "./media-downloader.js";
+import type { ImageCatalog } from "./image-catalog.js";
 import { formatTsForDisplay } from "./timezone.js";
 import { createLogger } from "./logger.js";
 import { extractUrls, fetchOpenGraphBatch, downloadOgImage, type OGResult } from "./opengraph.js";
@@ -75,6 +76,8 @@ export interface EnrichOptions {
     chatId?: string;
     /** 媒体下载管理器（可选，启用后保存文件到磁盘） */
     mediaDownloader?: MediaDownloader;
+    /** 图片目录（可选，启用后追踪图片频率用于表情包检测） */
+    imageCatalog?: ImageCatalog;
     /** 仅处理指定类型的媒体（如 ["sticker"]），未指定时处理所有类型 */
     mediaTypes?: Array<"photo" | "sticker" | "video" | "document" | "animation" | "other">;
     /** 是否启用 URL OpenGraph 预览（默认 true） */
@@ -125,6 +128,7 @@ export async function enrichMessages(
                 options.downloadFn,
                 options.stickerCache,
                 options.mediaDownloader,
+                options.imageCatalog,
                 { forceTextDescriptions: options.forceTextDescriptions },
             );
             // 将处理结果写回 messages

--- a/src/core/perceptual-hash.ts
+++ b/src/core/perceptual-hash.ts
@@ -1,0 +1,206 @@
+/**
+ * perceptual-hash.ts — 感知哈希 (pHash + dHash 双哈希)
+ *
+ * pHash (DCT-based): 对格式转换、压缩、缩放更鲁棒，适合跨平台场景
+ * dHash (Difference Hash): 对缩放/压缩鲁棒，与 pHash 互补
+ *
+ * 使用 sharp 库实现，安装失败时回退到纯 SHA256 模式。
+ */
+
+import { createLogger } from "./logger.js";
+
+const log = createLogger("phash");
+
+let sharpAvailable = false;
+let sharpInstance: any = null;
+
+try {
+    // @ts-expect-error sharp is an optional native dependency
+    const mod = await import("sharp");
+    sharpInstance = mod.default;
+    sharpAvailable = true;
+    log.info("sharp 库已加载，pHash + dHash 功能可用");
+} catch {
+    log.info("sharp 库不可用，pHash + dHash 功能禁用（仅使用 SHA256 精确匹配）");
+}
+
+export function isPerceptualHashAvailable(): boolean {
+    return sharpAvailable;
+}
+
+export interface PerceptualHashResult {
+    phash: string | null;
+    dhash: string | null;
+}
+
+export async function computePerceptualHashes(buffer: Buffer): Promise<PerceptualHashResult> {
+    if (!sharpAvailable || !sharpInstance) return { phash: null, dhash: null };
+
+    try {
+        const phash = await computePHash(buffer);
+        const dhash = await computeDHash(buffer);
+        return { phash, dhash };
+    } catch (err) {
+        log.debug("computePerceptualHashes: 计算失败", { error: String(err) });
+        return { phash: null, dhash: null };
+    }
+}
+
+async function computeDHash(buffer: Buffer): Promise<string | null> {
+    try {
+        const { data, info } = await sharpInstance(buffer)
+            .grayscale()
+            .resize(9, 8, { fit: "fill" })
+            .raw()
+            .toBuffer({ resolveWithObject: true });
+
+        if (info.width !== 9 || info.height !== 8) return null;
+
+        let hash = 0n;
+        for (let row = 0; row < 8; row++) {
+            for (let col = 0; col < 8; col++) {
+                const left = data[row * 9 + col];
+                const right = data[row * 9 + col + 1];
+                if (left > right) hash |= 1n;
+                hash <<= 1n;
+            }
+        }
+
+        return hash.toString(16).padStart(16, "0");
+    } catch (err) {
+        log.debug("computeDHash: 计算失败", { error: String(err) });
+        return null;
+    }
+}
+
+async function computePHash(buffer: Buffer): Promise<string | null> {
+    try {
+        const { data, info } = await sharpInstance(buffer)
+            .grayscale()
+            .resize(32, 32, { fit: "fill" })
+            .raw()
+            .toBuffer({ resolveWithObject: true });
+
+        if (info.width !== 32 || info.height !== 32) return null;
+
+        const pixels = new Float64Array(32 * 32);
+        for (let i = 0; i < 32 * 32; i++) {
+            pixels[i] = data[i];
+        }
+
+        const dct = dct2d(pixels, 32, 32);
+
+        const lowFreq: number[] = [];
+        for (let row = 0; row < 8; row++) {
+            for (let col = 0; col < 8; col++) {
+                if (row === 0 && col === 0) continue;
+                lowFreq.push(dct[row * 32 + col]);
+            }
+        }
+
+        const median = medianValue(lowFreq);
+
+        let hash = 0n;
+        for (const val of lowFreq) {
+            hash <<= 1n;
+            if (val > median) hash |= 1n;
+        }
+
+        return hash.toString(16).padStart(16, "0");
+    } catch (err) {
+        log.debug("computePHash: 计算失败", { error: String(err) });
+        return null;
+    }
+}
+
+function dct2d(input: Float64Array, rows: number, cols: number): Float64Array {
+    const output = new Float64Array(rows * cols);
+
+    const temp = new Float64Array(rows * cols);
+    for (let i = 0; i < rows; i++) {
+        for (let k = 0; k < cols; k++) {
+            let sum = 0;
+            for (let n = 0; n < cols; n++) {
+                sum += input[i * cols + n] * Math.cos(Math.PI * (2 * n + 1) * k / (2 * cols));
+            }
+            const c = k === 0 ? Math.sqrt(1 / cols) : Math.sqrt(2 / cols);
+            temp[i * cols + k] = sum * c;
+        }
+    }
+
+    for (let k = 0; k < rows; k++) {
+        for (let j = 0; j < cols; j++) {
+            let sum = 0;
+            for (let n = 0; n < rows; n++) {
+                sum += temp[n * cols + j] * Math.cos(Math.PI * (2 * n + 1) * k / (2 * rows));
+            }
+            const c = k === 0 ? Math.sqrt(1 / rows) : Math.sqrt(2 / rows);
+            output[k * cols + j] = sum * c;
+        }
+    }
+
+    return output;
+}
+
+function medianValue(arr: number[]): number {
+    const sorted = [...arr].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 !== 0 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export function hammingDistance(hash1: string, hash2: string): number {
+    if (!hash1 || !hash2 || hash1.length !== hash2.length) return Infinity;
+    const big1 = BigInt("0x" + hash1);
+    const big2 = BigInt("0x" + hash2);
+    let xor = big1 ^ big2;
+    let dist = 0;
+    while (xor !== 0n) {
+        dist += Number(xor & 1n);
+        xor >>= 1n;
+    }
+    return dist;
+}
+
+export interface SimilarityResult {
+    entry: import("./image-catalog.js").ImageCatalogEntry;
+    phashDistance?: number;
+    dhashDistance?: number;
+    minDistance: number;
+}
+
+export function findSimilarEntries(
+    allEntries: import("./image-catalog.js").ImageCatalogEntry[],
+    phash: string | null,
+    dhash: string | null,
+    maxPHashDistance: number = 14,
+    maxDHashDistance: number = 10,
+): SimilarityResult[] {
+    const results: SimilarityResult[] = [];
+
+    for (const entry of allEntries) {
+        let phashDist: number | undefined;
+        let dhashDist: number | undefined;
+        let matched = false;
+
+        if (phash && entry.phash) {
+            phashDist = hammingDistance(phash, entry.phash);
+            if (phashDist <= maxPHashDistance) matched = true;
+        }
+
+        if (dhash && entry.dhash) {
+            dhashDist = hammingDistance(dhash, entry.dhash);
+            if (dhashDist <= maxDHashDistance) matched = true;
+        }
+
+        if (matched) {
+            const minDist = Math.min(
+                phashDist ?? Infinity,
+                dhashDist ?? Infinity,
+            );
+            results.push({ entry, phashDistance: phashDist, dhashDistance: dhashDist, minDistance: minDist });
+        }
+    }
+
+    results.sort((a, b) => a.minDistance - b.minDistance);
+    return results;
+}

--- a/src/core/sticker-detector.ts
+++ b/src/core/sticker-detector.ts
@@ -22,6 +22,7 @@ export interface StickerDetectorDeps {
     mediaDownloader: MediaDownloader;
     memory: MemoryStoreV2;
     visionConfigs: LLMConfig[];
+    minFrequency?: number;
 }
 
 export class StickerDetector {
@@ -39,7 +40,7 @@ export class StickerDetector {
         }
         this.processing = true;
         try {
-            const candidates = this.deps.imageCatalog.getPendingStickerCandidates(3);
+            const candidates = this.deps.imageCatalog.getPendingStickerCandidates(this.deps.minFrequency ?? 3);
             if (candidates.length === 0) return 0;
 
             log.info("processCandidates: 开始处理", { count: candidates.length });

--- a/src/core/sticker-detector.ts
+++ b/src/core/sticker-detector.ts
@@ -1,0 +1,176 @@
+/**
+ * sticker-detector.ts — 异步表情包检测器
+ *
+ * 扫描 image_catalog 中频率达标的待判定图片，
+ * 调用 Vision LLM 判断是否为表情包，
+ * 确认后提升到正式贴纸库 (sticker_descriptions)。
+ */
+
+import { callLLMWithFallback, type ChatMessage } from "./llm.js";
+import { ensureSupportedFormat } from "./vision-processor.js";
+import type { LLMConfig } from "./config.js";
+import type { ImageCatalog, ImageCatalogEntry } from "./image-catalog.js";
+import type { MediaDownloader } from "./media-downloader.js";
+import type { MemoryStoreV2 } from "../memory-v2/index.js";
+import { readFileSync, copyFileSync, existsSync } from "node:fs";
+import { createLogger } from "./logger.js";
+
+const log = createLogger("sticker-detector");
+
+export interface StickerDetectorDeps {
+    imageCatalog: ImageCatalog;
+    mediaDownloader: MediaDownloader;
+    memory: MemoryStoreV2;
+    visionConfigs: LLMConfig[];
+}
+
+export class StickerDetector {
+    private deps: StickerDetectorDeps;
+    private processing = false;
+
+    constructor(deps: StickerDetectorDeps) {
+        this.deps = deps;
+    }
+
+    async processCandidates(): Promise<number> {
+        if (this.processing) {
+            log.debug("processCandidates: 已有处理进行中，跳过");
+            return 0;
+        }
+        this.processing = true;
+        try {
+            const candidates = this.deps.imageCatalog.getPendingStickerCandidates(3);
+            if (candidates.length === 0) return 0;
+
+            log.info("processCandidates: 开始处理", { count: candidates.length });
+            let processed = 0;
+
+            for (const entry of candidates) {
+                if (!entry.filePath || !existsSync(entry.filePath)) {
+                    log.debug("processCandidates: 文件不存在，跳过", { contentHash: entry.contentHash, filePath: entry.filePath });
+                    continue;
+                }
+
+                try {
+                    await this.classifyImage(entry);
+                    processed++;
+                } catch (err) {
+                    log.warn("processCandidates: 分类失败", { contentHash: entry.contentHash, error: String(err) });
+                }
+
+                if (processed >= 5) break;
+            }
+
+            log.info("processCandidates: 完成", { processed, total: candidates.length });
+            return processed;
+        } finally {
+            this.processing = false;
+        }
+    }
+
+    private async classifyImage(entry: ImageCatalogEntry): Promise<void> {
+        const filePath = entry.filePath!;
+        const rawBuffer = readFileSync(filePath);
+        const mimeType = entry.mimeType ?? inferMimeType(filePath);
+        const { buffer, mimeType: processedMime } = await ensureSupportedFormat(rawBuffer, mimeType);
+
+        const b64 = buffer.toString("base64");
+        const dataUri = `data:${processedMime};base64,${b64}`;
+
+        const messages: ChatMessage[] = [
+            {
+                role: "user",
+                content: `这张图片在群聊中反复出现，可能是一个表情包/贴纸。
+请判断这是否是表情包（而非普通照片、截图、文档等），并描述其含义。
+
+判定标准：
+- 表情包：有明显情绪表达、梗图、配文表情、简笔画风格、可爱动物等
+- 不是：风景照、真人照片（非表情化的）、截图、文档、商品图等
+
+请用以下 JSON 格式回复（仅返回 JSON，不要包含其他内容）：
+{"is_sticker": true/false, "description": "几个词的简短描述", "emoji": "单个代表emoji"}`,
+                imageParts: [{ url: dataUri }],
+            },
+        ];
+
+        const response = await callLLMWithFallback(messages, this.deps.visionConfigs, {
+            caller: "sticker-detector",
+        });
+
+        const raw = response.content.trim();
+        let isSticker = false;
+        let description = "";
+        let emoji: string | undefined;
+
+        try {
+            const jsonStr = raw.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+            const parsed = JSON.parse(jsonStr);
+            isSticker = !!parsed.is_sticker;
+            description = String(parsed.description ?? "").trim();
+            emoji = typeof parsed.emoji === "string" ? parsed.emoji : undefined;
+        } catch {
+            log.debug("classifyImage: JSON 解析失败，视为非表情包", { contentHash: entry.contentHash, raw: raw.slice(0, 100) });
+            isSticker = false;
+        }
+
+        this.deps.imageCatalog.setStickerVerdict({
+            contentHash: entry.contentHash,
+            isSticker,
+            description: description || undefined,
+            emoji,
+        });
+
+        if (isSticker && description) {
+            await this.promoteToSticker(entry, description, emoji);
+        }
+    }
+
+    private async promoteToSticker(entry: ImageCatalogEntry, description: string, emoji?: string): Promise<void> {
+        if (!entry.filePath || !existsSync(entry.filePath)) return;
+
+        const rawBuffer = readFileSync(entry.filePath);
+        const mimeType = entry.mimeType ?? inferMimeType(entry.filePath);
+
+        const saved = this.deps.mediaDownloader.saveMedia(Buffer.from(rawBuffer), {
+            chatId: entry.sourceChatId ?? undefined,
+            uniqueFileId: entry.uniqueFileId ?? entry.contentHash,
+            mediaType: "sticker",
+            mimeType,
+        });
+
+        if (!saved) {
+            log.warn("promoteToSticker: 保存到 stickers/ 失败", { contentHash: entry.contentHash });
+            return;
+        }
+
+        this.deps.memory.setStickerDescription(
+            entry.uniqueFileId ?? entry.contentHash,
+            description,
+            emoji,
+            true,
+        );
+
+        this.deps.imageCatalog.markPromoted(
+            entry.contentHash,
+            entry.uniqueFileId ?? entry.contentHash,
+            saved.path,
+        );
+
+        log.info("promoteToSticker: 表情包已提升到正式贴纸库", {
+            contentHash: entry.contentHash,
+            uniqueFileId: entry.uniqueFileId ?? entry.contentHash,
+            description: description.slice(0, 50),
+            emoji,
+            stickerPath: saved.path,
+        });
+    }
+}
+
+function inferMimeType(filePath: string): string {
+    const ext = filePath.toLowerCase();
+    if (ext.endsWith(".png")) return "image/png";
+    if (ext.endsWith(".jpg") || ext.endsWith(".jpeg")) return "image/jpeg";
+    if (ext.endsWith(".webp")) return "image/webp";
+    if (ext.endsWith(".gif")) return "image/gif";
+    return "image/jpeg";
+}

--- a/src/core/vision-processor.ts
+++ b/src/core/vision-processor.ts
@@ -14,6 +14,10 @@ import { callLLMWithFallback, type ChatMessage } from "./llm.js";
 import { resolveComponentTimeout, type LLMConfig, type VisionConfig } from "./config.js";
 import { createLogger } from "./logger.js";
 import type { MediaDownloader } from "./media-downloader.js";
+import type { ImageCatalog } from "./image-catalog.js";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { computePerceptualHashes } from "./perceptual-hash.js";
 
 const log = createLogger("vision-processor");
 
@@ -131,6 +135,7 @@ export async function processMediaBatch(
     downloadFn?: DownloadFn,
     stickerCache?: StickerCache,
     mediaDownloader?: MediaDownloader,
+    imageCatalog?: ImageCatalog,
     options?: ProcessMediaBatchOptions,
 ): Promise<ProcessedMedia[]> {
     const maxImages = config?.maxImagesPerContext ?? DEFAULT_MAX_IMAGES;
@@ -182,6 +187,7 @@ export async function processMediaBatch(
             downloadFn,
             stickerCache,
             mediaDownloader,
+            imageCatalog,
         );
         // 复用结果到同 uniqueFileId 的所有条目（修正 messageIndex）
         return group.map(s => s === representative
@@ -302,6 +308,69 @@ export async function processMediaBatch(
         }
     }
 
+    // ─── 图片目录追踪（记录 photo 的 SHA256 + 出现频率 + pHash/dHash） ───
+    if (imageCatalog) {
+        const hashPromises: Array<Promise<void>> = [];
+        for (const pm of results) {
+            const att = attachments.find(a => a.messageIndex === pm.index);
+            if (!att || att.type !== "photo") continue;
+            let rawBuffer: Buffer | undefined;
+            if (pm.base64Data) {
+                rawBuffer = Buffer.from(pm.base64Data, "base64");
+            } else if (pathBBuffers.has(att.uniqueFileId)) {
+                rawBuffer = pathBBuffers.get(att.uniqueFileId)!.buffer;
+            } else if (pm.filePath) {
+                try {
+                    rawBuffer = readFileSync(pm.filePath);
+                } catch { /* ignore */ }
+            }
+            if (!rawBuffer) continue;
+            const contentHash = createHash("sha256").update(rawBuffer).digest("hex");
+            const platform = att.chatId?.split(":")[0] ?? "unknown";
+            try {
+                imageCatalog.recordSighting({
+                    contentHash,
+                    sourcePlatform: platform,
+                    sourceChatId: att.chatId,
+                    uniqueFileId: att.uniqueFileId,
+                    filePath: pm.filePath ?? undefined,
+                    mimeType: pm.mimeType ?? att.mimeType,
+                    width: att.width,
+                    height: att.height,
+                    fileSize: att.fileSize ?? rawBuffer.length,
+                    messageId: att.messageId,
+                });
+            } catch (err) {
+                log.debug("imageCatalog.recordSighting 失败", { contentHash, error: String(err) });
+            }
+            // 异步计算 pHash + dHash（不阻塞主流程）
+            hashPromises.push(
+                computePerceptualHashes(rawBuffer).then(({ phash, dhash }) => {
+                    if (phash || dhash) {
+                        try {
+                            imageCatalog.updateHashes(contentHash, phash, dhash);
+                            const similar = imageCatalog.findSimilar(phash, dhash);
+                            for (const s of similar) {
+                                if (s.entry.contentHash !== contentHash && s.entry.isSticker !== null) {
+                                    imageCatalog.setStickerVerdict({
+                                        contentHash,
+                                        isSticker: s.entry.isSticker === 1,
+                                        description: s.entry.description ?? undefined,
+                                        emoji: s.entry.emoji ?? undefined,
+                                    });
+                                    break;
+                                }
+                            }
+                        } catch { /* ignore */ }
+                    }
+                }).catch(() => { /* ignore */ }),
+            );
+        }
+        if (hashPromises.length > 0) {
+            await Promise.allSettled(hashPromises);
+        }
+    }
+
     // ─── 处理 download-only 媒体 (video / document / animation) ───
     if (downloadFn && mediaDownloader) {
         for (const att of downloadOnly) {
@@ -386,6 +455,7 @@ async function processSingleSticker(
     downloadFn?: DownloadFn,
     stickerCache?: StickerCache,
     mediaDownloader?: MediaDownloader,
+    imageCatalog?: ImageCatalog,
 ): Promise<ProcessedMedia> {
     const mode = config?.stickerMode ?? "emoji_only";
 

--- a/src/dashboard/api-routes.ts
+++ b/src/dashboard/api-routes.ts
@@ -623,6 +623,11 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
 
     // ─── Image Catalog (表情包频率追踪) ───
 
+    router.get("/image-catalog/stats", (_req, res) => {
+        if (!deps.imageCatalog) { res.status(404).json({ error: "imageCatalog not available" }); return; }
+        res.json(deps.imageCatalog.getStats());
+    });
+
     router.get("/image-catalog", (req, res) => {
         if (!deps.imageCatalog) { res.status(404).json({ error: "imageCatalog not available" }); return; }
         const limit = Math.min(parseInt(qs(req.query.limit)) || 50, 200);

--- a/src/dashboard/api-routes.ts
+++ b/src/dashboard/api-routes.ts
@@ -568,7 +568,12 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
         const filePath = deps.mediaDownloader.getExistingPath(req.params.uniqueFileId);
         if (!filePath || !fs.existsSync(filePath)) { res.status(404).json({ error: "sticker image not found" }); return; }
         try {
-            res.setHeader("Content-Type", "image/webp");
+            const ext = filePath.toLowerCase();
+            const contentType = ext.endsWith(".png") ? "image/png"
+                : ext.endsWith(".jpg") || ext.endsWith(".jpeg") ? "image/jpeg"
+                : ext.endsWith(".gif") ? "image/gif"
+                : "image/webp";
+            res.setHeader("Content-Type", contentType);
             res.setHeader("Cache-Control", "public, max-age=86400");
             fs.createReadStream(filePath).pipe(res);
         } catch (err) {
@@ -614,6 +619,89 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
         if (enabled === undefined) { res.status(400).json({ error: "enabled required" }); return; }
         const ok = deps.memory.setStickerEnabled(req.params.uniqueFileId, !!enabled);
         res.json({ ok });
+    });
+
+    // ─── Image Catalog (表情包频率追踪) ───
+
+    router.get("/image-catalog", (req, res) => {
+        if (!deps.imageCatalog) { res.status(404).json({ error: "imageCatalog not available" }); return; }
+        const limit = Math.min(parseInt(qs(req.query.limit)) || 50, 200);
+        const offset = parseInt(qs(req.query.offset)) || 0;
+        const filter = qs(req.query.filter);
+        let result;
+        if (filter === "pending") {
+            const items = deps.imageCatalog.getPendingStickerCandidates(1);
+            result = { items, total: items.length };
+        } else if (filter === "stickers") {
+            const items = deps.imageCatalog.getStickerEntries();
+            result = { items, total: items.length };
+        } else {
+            result = deps.imageCatalog.getAllEntries(limit, offset);
+        }
+        res.json(result);
+    });
+
+    router.get("/image-catalog/:contentHash/image", (req, res) => {
+        if (!deps.imageCatalog) { res.status(404).json({ error: "imageCatalog not available" }); return; }
+        const entry = deps.imageCatalog.getByContentHash(req.params.contentHash);
+        if (!entry?.filePath || !fs.existsSync(entry.filePath)) {
+            res.status(404).json({ error: "image not found" });
+            return;
+        }
+        try {
+            const ext = entry.filePath.toLowerCase();
+            const contentType = ext.endsWith(".png") ? "image/png"
+                : ext.endsWith(".jpg") || ext.endsWith(".jpeg") ? "image/jpeg"
+                : ext.endsWith(".gif") ? "image/gif"
+                : "image/webp";
+            res.setHeader("Content-Type", contentType);
+            res.setHeader("Cache-Control", "public, max-age=86400");
+            fs.createReadStream(entry.filePath).pipe(res);
+        } catch (err) {
+            res.status(500).json({ error: String(err) });
+        }
+    });
+
+    router.patch("/image-catalog/:contentHash/verdict", (req, res) => {
+        if (!deps.imageCatalog) { res.status(404).json({ error: "imageCatalog not available" }); return; }
+        const { isSticker, description, emoji } = req.body;
+        if (isSticker === undefined) { res.status(400).json({ error: "isSticker required" }); return; }
+        deps.imageCatalog.setStickerVerdict({
+            contentHash: req.params.contentHash,
+            isSticker: !!isSticker,
+            description,
+            emoji,
+        });
+        if (isSticker && deps.mediaDownloader && deps.memory) {
+            const entry = deps.imageCatalog.getByContentHash(req.params.contentHash);
+            if (entry?.filePath && fs.existsSync(entry.filePath)) {
+                try {
+                    const rawBuffer = fs.readFileSync(entry.filePath);
+                    const saved = deps.mediaDownloader.saveMedia(rawBuffer, {
+                        chatId: entry.sourceChatId ?? undefined,
+                        uniqueFileId: entry.uniqueFileId ?? entry.contentHash,
+                        mediaType: "sticker",
+                        mimeType: entry.mimeType ?? "image/jpeg",
+                    });
+                    if (saved) {
+                        deps.memory.setStickerDescription(
+                            entry.uniqueFileId ?? entry.contentHash,
+                            description ?? "",
+                            emoji,
+                            true,
+                        );
+                        deps.imageCatalog.markPromoted(
+                            entry.contentHash,
+                            entry.uniqueFileId ?? entry.contentHash,
+                            saved.path,
+                        );
+                    }
+                } catch (err) {
+                    log.warn("手动提升贴纸失败", { contentHash: req.params.contentHash, error: String(err) });
+                }
+            }
+        }
+        res.json({ ok: true });
     });
 
 

--- a/src/dashboard/types.ts
+++ b/src/dashboard/types.ts
@@ -13,6 +13,7 @@ import type { NotificationCenter } from "../event/notification-center.js";
 import type { FeedbackLoop } from "../pipeline/feedback-loop.js";
 import type { TokenStatsCollector } from "./token-stats.js";
 import type { MediaDownloader } from "../core/media-downloader.js";
+import type { ImageCatalog } from "../core/image-catalog.js";
 import type { PlatformAdapter } from "../adapter/platform-adapter.js";
 import type { AppConfig } from "../core/config.js";
 
@@ -30,6 +31,8 @@ export interface DashboardDeps {
     tokenStats: TokenStatsCollector;
     /** 媒体下载管理器（用于贴纸预览等） */
     mediaDownloader?: MediaDownloader;
+    /** 图片目录（用于表情包频率追踪和预览） */
+    imageCatalog?: ImageCatalog;
     /** 平台 adapter 引用（用于 mute 等控制操作） */
     adapters?: PlatformAdapter[];
     /** Dashboard 保存配置后的回调（用于热应用） */

--- a/src/dashboard/ui/src/panels/ConfigPanel.svelte
+++ b/src/dashboard/ui/src/panels/ConfigPanel.svelte
@@ -95,6 +95,7 @@
       config = await api("/config");
       if (!config.contextBudget) config.contextBudget = {};
       if (!config.vision) config.vision = {};
+      if (config.vision.stickerStealingEnabled == null) config.vision.stickerStealingEnabled = true;
       if (!config.dashboard) config.dashboard = {};
       if (config.dashboard.host == null || config.dashboard.host === "") {
         config.dashboard.host = "127.0.0.1";

--- a/src/dashboard/ui/src/panels/config/OneBotTab.svelte
+++ b/src/dashboard/ui/src/panels/config/OneBotTab.svelte
@@ -1,8 +1,21 @@
 <script>
+  import { api } from '../../lib/api.js';
+
   export let config;
   export let onebotEnabled = false;
   export let pwFocus;
   export let pwBlur;
+
+  let catalogStats = null;
+  let statsLoading = false;
+
+  async function loadCatalogStats() {
+    statsLoading = true;
+    try {
+      catalogStats = await api('/image-catalog/stats');
+    } catch { catalogStats = null; }
+    statsLoading = false;
+  }
 </script>
 
 <h3 class="card-title text-sm">
@@ -134,4 +147,122 @@
       ></textarea></label
     >
   </div>
+  <div class="divider text-xs opacity-50 my-3">
+    偷表情包 <span class="restart-hint"><i class="fa-solid fa-rotate-right"></i> 修改需重启</span>
+  </div>
+  <p class="text-xs opacity-50 mb-2">自动追踪群聊中反复出现的图片，用 Vision LLM 判定并收录为表情包。</p>
+  <label class="cfg-check mb-2">
+    <input
+      type="checkbox"
+      class="toggle toggle-xs"
+      bind:checked={config.vision.stickerStealingEnabled}
+    />
+    <span>启用偷表情包</span>
+  </label>
+  {#if config.vision.stickerStealingEnabled}
+    <div class="cfg-grid-3 mb-3">
+      <label class="cfg-field"
+        ><span class="cfg-label">最小出现次数</span>
+        <input
+          type="number"
+          class="input input-xs input-bordered w-full"
+          bind:value={config.vision.stickerStealingMinFrequency}
+          placeholder="3"
+          min="1"
+        /></label
+      >
+      <label class="cfg-field"
+        ><span class="cfg-label">检测间隔 (分钟)</span>
+        <input
+          type="number"
+          class="input input-xs input-bordered w-full"
+          bind:value={config.vision.stickerStealingIntervalMin}
+          placeholder="10"
+          min="1"
+        /></label
+      >
+      <label class="cfg-field"
+        ><span class="cfg-label">目录保留天数</span>
+        <input
+          type="number"
+          class="input input-xs input-bordered w-full"
+          bind:value={config.vision.catalogRetentionDays}
+          placeholder="30"
+          min="1"
+        /></label
+      >
+    </div>
+
+    <!-- 状态面板 -->
+    <div class="p-3 bg-base-200 rounded-lg">
+      <div class="flex items-center justify-between mb-2">
+        <span class="text-xs font-bold opacity-70">
+          <i class="fa-solid fa-chart-bar opacity-50 mr-1"></i>图片目录状态
+        </span>
+        <button class="btn btn-xs btn-ghost" on:click={loadCatalogStats} title="刷新状态">
+          {#if statsLoading}
+            <span class="loading loading-spinner loading-xs"></span>
+          {:else}
+            <i class="fa-solid fa-rotate"></i>
+          {/if}
+        </button>
+      </div>
+      {#if catalogStats}
+        <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-2">
+          <div class="stat-card">
+            <span class="stat-num">{catalogStats.totalImages}</span>
+            <span class="stat-label">总追踪</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-num text-warning">{catalogStats.pendingCandidates}</span>
+            <span class="stat-label">待判定</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-num text-success">{catalogStats.confirmedStickers}</span>
+            <span class="stat-label">已收录</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-num text-error">{catalogStats.rejectedImages}</span>
+            <span class="stat-label">已排除</span>
+          </div>
+        </div>
+        {#if catalogStats.recentPromotions.length > 0}
+          <div class="text-xs opacity-60 mb-1">最近收录</div>
+          <div class="space-y-1">
+            {#each catalogStats.recentPromotions as p}
+              <div class="flex items-center gap-2 text-xs">
+                <span class="text-base">{p.emoji || '🎭'}</span>
+                <span class="truncate flex-1" title={p.description}>{p.description || '-'}</span>
+                <span class="opacity-40 whitespace-nowrap">{p.promotedAt ? new Date(p.promotedAt).toLocaleDateString() : ''}</span>
+              </div>
+            {/each}
+          </div>
+        {:else}
+          <p class="text-xs opacity-40 italic">暂无已收录的表情包。</p>
+        {/if}
+      {:else}
+        <p class="text-xs opacity-40 italic">点击刷新按钮加载状态。</p>
+      {/if}
+    </div>
+  {/if}
 </div>
+
+<style>
+  .stat-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.4rem;
+    border-radius: 0.375rem;
+    background: var(--color-base-100);
+  }
+  .stat-num {
+    font-size: 1.1rem;
+    font-weight: 700;
+    line-height: 1.2;
+  }
+  .stat-label {
+    font-size: 0.65rem;
+    opacity: 0.5;
+  }
+</style>

--- a/src/main-agent/attend-handler.ts
+++ b/src/main-agent/attend-handler.ts
@@ -16,6 +16,7 @@ import type { ChatMessage } from "../core/llm.js";
 import type { GlobalState } from "./global-state.js";
 import type { MainAgentLoop } from "./main-agent-loop.js";
 import type { MediaDownloader } from "../core/media-downloader.js";
+import type { ImageCatalog } from "../core/image-catalog.js";
 import { calculateDepth } from "./cosine-decay.js";
 import { buildGroupContext } from "./context-builder.js";
 import { renderPrompt, buildAttentionVariables, buildMainSystemVariables } from "./prompt-renderer.js";
@@ -110,6 +111,8 @@ export interface AttendHandlerDeps {
     adapters?: PlatformAdapter[];
     /** 共享的媒体下载管理器 */
     mediaDownloader?: MediaDownloader;
+    /** 图片目录（用于表情包频率追踪） */
+    imageCatalog?: ImageCatalog;
 
 }
 
@@ -121,7 +124,7 @@ export interface AttendHandlerDeps {
 export function createAttendHandler(
     deps: AttendHandlerDeps,
 ): (entry: AttentionQueueEntry) => Promise<AttendResult | null> {
-    const { memory, globalState, subagentManager, mainLoop, adapters: adapterList, mediaDownloader } = deps;
+    const { memory, globalState, subagentManager, mainLoop, adapters: adapterList, mediaDownloader, imageCatalog } = deps;
 
     // 构建下载函数（用于 vision 处理 sticker/photo）
     // 从 adapters 数组中按 chatId 平台路由到对应 adapter 的 downloadMedia
@@ -344,6 +347,7 @@ export function createAttendHandler(
                             stickerCache: memory,
                             chatId: entry.chatId,
                             mediaDownloader,
+                            imageCatalog,
                             forceTextDescriptions: effectiveAttendVisionMode === "describe",
                         });
                         messagesText = formattedText;

--- a/src/main-agent/dispatch-handler.ts
+++ b/src/main-agent/dispatch-handler.ts
@@ -27,6 +27,7 @@ import { formatTsForDisplay } from "../core/timezone.js";
 import { loadConfig, resolveComponentProfiles } from "../core/config.js";
 import { resolveReplyText } from "../core/message-enricher.js";
 import { MediaDownloader } from "../core/media-downloader.js";
+import type { ImageCatalog } from "../core/image-catalog.js";
 import type { AppConfig } from "../core/config.js";
 import type { PlatformAdapter } from "../adapter/platform-adapter.js";
 import { getGroupModelKey } from "../core/chat-id.js";
@@ -53,6 +54,8 @@ export interface DispatchHandlerDeps {
     sendTyping?: (chatId: string) => Promise<void>;
     /** 共享的媒体下载管理器 */
     mediaDownloader: MediaDownloader;
+    /** 图片目录（用于表情包频率追踪） */
+    imageCatalog?: ImageCatalog;
 }
 
 /**
@@ -63,7 +66,7 @@ export interface DispatchHandlerDeps {
 export function createDispatchHandler(
     deps: DispatchHandlerDeps,
 ): (result: AttendResult) => Promise<void> {
-    const { memory, globalState, subagentManager, sandboxPool, nc, q3, q5, appConfig: _appConfig, adapters: adapterList, sendTyping, mediaDownloader } = deps;
+    const { memory, globalState, subagentManager, sandboxPool, nc, q3, q5, appConfig: _appConfig, adapters: adapterList, sendTyping, mediaDownloader, imageCatalog } = deps;
     // 构建下载函数（根据 chatId 平台路由到对应 adapter）
     const buildDownloadFn = (chatId: string) => {
         if (!adapterList?.length) return undefined;
@@ -222,7 +225,7 @@ export function createDispatchHandler(
                             // allow_listed 模式下仅包含已启用的贴纸
                             if (stickerSendingMode === "allow_listed" && !s.enabled) continue;
                             const filePath = mediaDownloader.getExistingPath(s.uniqueFileId);
-                            if (filePath && existsSync(filePath) && !filePath.toLowerCase().endsWith(".webm")) {
+                            if (filePath && existsSync(filePath) && !filePath.toLowerCase().endsWith(".webm") && !filePath.toLowerCase().endsWith(".tgs")) {
                                 availableStickers.push({
                                     emoji: s.emoji,
                                     description: s.description,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1052,19 +1052,23 @@ async function main(): Promise<void> {
 
     log.info("MainAgentLoop 配置完成");
 
-    // ─── 贴纸检测定时器（每 10 分钟扫描一次待判定的图片） ───
+    // ─── 贴纸检测定时器（定期扫描待判定的图片） ───
+    const stickerStealingEnabled = appConfig.vision?.stickerStealingEnabled !== false;
     const visionLlmConfigsForDetector = appConfig.llmRouting.vision
         ? resolveComponentProfiles("vision", appConfig)
         : resolveComponentProfiles("session", appConfig);
-    if (visionLlmConfigsForDetector.length > 0) {
+    if (stickerStealingEnabled && visionLlmConfigsForDetector.length > 0) {
         const { StickerDetector } = await import("./core/sticker-detector.js");
+        const minFreq = appConfig.vision?.stickerStealingMinFrequency ?? 3;
+        const intervalMin = appConfig.vision?.stickerStealingIntervalMin ?? 10;
         const stickerDetector = new StickerDetector({
             imageCatalog,
             mediaDownloader: sharedMediaDownloader,
             memory,
             visionConfigs: visionLlmConfigsForDetector,
+            minFrequency: minFreq,
         });
-        const STICKER_DETECT_INTERVAL = 10 * 60 * 1000;
+        const STICKER_DETECT_INTERVAL = intervalMin * 60 * 1000;
         const stickerDetectTimer = setInterval(() => {
             stickerDetector.processCandidates().catch(err => {
                 log.warn("贴纸检测定时任务失败", { error: String(err) });
@@ -1077,7 +1081,9 @@ async function main(): Promise<void> {
                 log.warn("贴纸检测首次运行失败", { error: String(err) });
             });
         }, 60_000);
-        log.info("贴纸检测定时器已启动", { intervalMin: 10 });
+        log.info("贴纸检测定时器已启动", { intervalMin, minFreq });
+    } else if (!stickerStealingEnabled) {
+        log.info("偷表情包功能已禁用");
     }
 
     // ─── Dashboard 监控仪表盘 ───

--- a/src/main.ts
+++ b/src/main.ts
@@ -270,6 +270,10 @@ async function main(): Promise<void> {
         maxFileSize: (appConfig.vision?.maxMediaDownloadSize ?? 20) * 1024 * 1024,
     });
 
+    // 图片目录数据库（独立于 memory.db，用于表情包频率追踪）
+    const { ImageCatalog } = await import("./core/image-catalog.js");
+    const imageCatalog = new ImageCatalog(join(DATA_DIR, "image-catalog.db"));
+
     const nc = new NotificationCenter(EVENTS_PATH);
     let shuttingDown = false;
 
@@ -1018,6 +1022,7 @@ async function main(): Promise<void> {
         persona: appConfig.persona,
         adapters,
         mediaDownloader: sharedMediaDownloader,
+        imageCatalog,
 
     }));
 
@@ -1042,9 +1047,38 @@ async function main(): Promise<void> {
             }
         },
         mediaDownloader: sharedMediaDownloader,
+        imageCatalog,
     }));
 
     log.info("MainAgentLoop 配置完成");
+
+    // ─── 贴纸检测定时器（每 10 分钟扫描一次待判定的图片） ───
+    const visionLlmConfigsForDetector = appConfig.llmRouting.vision
+        ? resolveComponentProfiles("vision", appConfig)
+        : resolveComponentProfiles("session", appConfig);
+    if (visionLlmConfigsForDetector.length > 0) {
+        const { StickerDetector } = await import("./core/sticker-detector.js");
+        const stickerDetector = new StickerDetector({
+            imageCatalog,
+            mediaDownloader: sharedMediaDownloader,
+            memory,
+            visionConfigs: visionLlmConfigsForDetector,
+        });
+        const STICKER_DETECT_INTERVAL = 10 * 60 * 1000;
+        const stickerDetectTimer = setInterval(() => {
+            stickerDetector.processCandidates().catch(err => {
+                log.warn("贴纸检测定时任务失败", { error: String(err) });
+            });
+        }, STICKER_DETECT_INTERVAL);
+        if (stickerDetectTimer.unref) stickerDetectTimer.unref();
+        // 启动后延迟 1 分钟首次运行
+        setTimeout(() => {
+            stickerDetector.processCandidates().catch(err => {
+                log.warn("贴纸检测首次运行失败", { error: String(err) });
+            });
+        }, 60_000);
+        log.info("贴纸检测定时器已启动", { intervalMin: 10 });
+    }
 
     // ─── Dashboard 监控仪表盘 ───
     const dashboardEnabled = appConfig.dashboard?.enabled !== false;
@@ -1080,6 +1114,7 @@ async function main(): Promise<void> {
                 feedbackLoop,
                 tokenStats,
                 mediaDownloader: sharedMediaDownloader,
+                imageCatalog,
                 adapters,
                 onConfigSaved: async (config) => {
                     tokenStats.setProfiles(config.llmProfiles ?? {});


### PR DESCRIPTION
在已有表情包收集功能基础上的增强：

• 感知哈希去重（pHash + dHash） — 即使表情包经过重编码、缩放或跨平台格式转换，也能识别为重复图片并跳过
• 跨平台格式转换 — 处理 Telegram（webp）和 QQ/OneBot 之间的格式差异
• 图片目录 + manifest 持久化 — 重启后无需重新扫描文件系统
• Dashboard 面板 — OneBot/QQ 标签页，可配置收集开关和查看收集状态

新增文件：perceptual-hash.ts、sticker-detector.ts、image-catalog.ts，以及 Dashboard UI（OneBotTab.svelte）。