### PR TITLE
 feat(onebot): 群名/昵称显示、chatId 三段式修复、类型标注与编辑

### DIFF
--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -362,10 +362,9 @@ export class OneBotAdapter implements PlatformAdapter {
     private async sendMessage(chatId: string, text: string, opts: Record<string, unknown>): Promise<unknown> {
         const parsed = parseChatId(chatId);
         const message = this.applyReplyTo(text, opts.replyTo);
-        if (parsed.rawId.startsWith("group:")) {
-            const groupId = parsed.rawId.slice("group:".length);
+        if (parsed.groupId != null) {
             return this.callAction("send_group_msg", {
-                group_id: Number(groupId),
+                group_id: Number(parsed.groupId),
                 message,
             });
         }
@@ -382,10 +381,9 @@ export class OneBotAdapter implements PlatformAdapter {
     private async sendMedia(chatId: string, media: Record<string, unknown>, opts: Record<string, unknown>): Promise<unknown> {
         const parsed = parseChatId(chatId);
         const segments = await this.buildOutgoingSegments(media, opts);
-        if (parsed.rawId.startsWith("group:")) {
-            const groupId = parsed.rawId.slice("group:".length);
+        if (parsed.groupId != null) {
             return this.callAction("send_group_msg", {
-                group_id: Number(groupId),
+                group_id: Number(parsed.groupId),
                 message: segments,
             });
         }
@@ -611,10 +609,9 @@ export class OneBotAdapter implements PlatformAdapter {
         if (typeof opts.text === "string" && opts.text.trim()) {
             segments.push({ type: "text", data: { text: opts.text } });
         }
-        if (parsed.rawId.startsWith("group:")) {
-            const groupId = parsed.rawId.slice("group:".length);
+        if (parsed.groupId != null) {
             return this.callAction("send_group_msg", {
-                group_id: Number(groupId),
+                group_id: Number(parsed.groupId),
                 message: segments,
             });
         }
@@ -631,7 +628,7 @@ export class OneBotAdapter implements PlatformAdapter {
     private async deleteMessages(chatId: string, messageIds: string[]): Promise<void> {
         if (messageIds.length === 0) return;
         const parsed = parseChatId(chatId);
-        if (!parsed.rawId.startsWith("group:")) {
+        if (parsed.groupId == null) {
             throw new Error("deleteMessages: OneBot 目前仅支持群消息撤回");
         }
         for (const id of messageIds) {

--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -79,6 +79,15 @@ export class OneBotAdapter implements PlatformAdapter {
     private static readonly RECONNECT_MAX_MS = 30_000;
     private readonly pending = new Map<string, { resolve: (v: unknown) => void; reject: (err: Error) => void; timer: NodeJS.Timeout }>();
     private readonly mutedChats = new Map<string, number>();
+    /** 缓存群名：groupId → group_name
+    * OneBot get_group_info 返回 group_name 字段
+    * 群管理员改名后通过 notice 事件更新
+    */
+    private readonly groupNameCache = new Map<string, string>();
+    /** 缓存用户昵称：userId → nickname
+    * OneBot get_stranger_info / get_friend_list 返回 nickname 字段
+    */
+    private readonly userNickCache = new Map<string, string>();
 
     constructor(
         private config: OneBotConfig,
@@ -94,6 +103,9 @@ export class OneBotAdapter implements PlatformAdapter {
         this.stopRequested = false;
         this.reconnectAttempts = 0;
         await this.connect();
+
+        // 连接成功后预加载白名单群组的名称
+        this.prefetchWhitelistedGroups();
     }
 
     private connect(): Promise<void> {
@@ -184,6 +196,59 @@ export class OneBotAdapter implements PlatformAdapter {
         this.ws.close();
         this.ws = null;
         this.started = false;
+    }
+
+    /**
+     * 连接成功后预加载白名单群组名称和私聊用户昵称。
+     * 调用 get_group_list 和 get_friend_list 批量获取，
+     * 填充缓存使快照立即显示群名而非群号。
+     */
+    private prefetchWhitelistedGroups(): void {
+        // 异步执行，不阻塞 start()
+        (async () => {
+            try {
+                // 1. 获取群列表
+                const groupListResult = await this.callAction("get_group_list", {}) as Record<string, unknown>;
+                const groupListData = groupListResult?.data ?? groupListResult;
+                if (Array.isArray(groupListData)) {
+                    for (const g of groupListData) {
+                        const gid = String(g.group_id ?? "");
+                        const gname = String(g.group_name ?? "");
+                        if (gid && gname) {
+                            this.groupNameCache.set(gid, gname);
+                        }
+                    }
+                    log.info("预加载群列表成功", { count: groupListData.length, cached: this.groupNameCache.size });
+                }
+            } catch (err) {
+                log.warn("预加载群列表失败", { error: String(err) });
+            }
+
+            try {
+                // 2. 获取好友列表（私聊用户昵称）
+                const friendListResult = await this.callAction("get_friend_list", {}) as Record<string, unknown>;
+                const friendListData = friendListResult?.data ?? friendListResult;
+                if (Array.isArray(friendListData)) {
+                    for (const f of friendListData) {
+                        const uid = String(f.user_id ?? "");
+                        const nick = String(f.nickname ?? "");
+                        if (uid && nick) {
+                            this.userNickCache.set(uid, nick);
+                        }
+                    }
+                    log.info("预加载好友列表成功", { count: friendListData.length, cached: this.userNickCache.size });
+                }
+            } catch (err) {
+                log.warn("预加载好友列表失败", { error: String(err) });
+            }
+        })();
+    }
+
+    /**
+     * 获取所有已缓存的群名和用户昵称，供外部批量更新 GroupModel。
+     */
+    getCachedNames(): { groupNames: ReadonlyMap<string, string>; userNicks: ReadonlyMap<string, string> } {
+        return { groupNames: this.groupNameCache, userNicks: this.userNickCache };
     }
 
     canHandle(method: string): boolean {
@@ -711,39 +776,32 @@ export class OneBotAdapter implements PlatformAdapter {
         }
 
         const event = payload as OneBotIncomingEvent;
+
+        // 处理 notice 事件（群名变更等）
+        if (event.post_type === "notice") {
+            this.handleNoticeEvent(event);
+            return;
+        }
+
         if (event.post_type !== "message") return;
         if (String(event.self_id ?? "") !== String(this.config.selfId)) return;
 
-        const normalized = this.normalizeIncomingMessage(event);
-        if (!normalized) return;
+        // normalizeIncomingMessage 是异步的（需要调用 OneBot API 获取群名/昵称）
+        this.normalizeIncomingMessage(event).then(normalized => {
+            if (!normalized) return;
 
-        this.nc.push({
-            type: "nc.message",
-            scene: "onebot",
-            source: {
+            this.nc.push({
+                type: "nc.message",
                 scene: "onebot",
-                platform: "onebot",
-                chatId: normalized.chatId,
-                userId: normalized.userId,
-                chatType: normalized.chatType,
-                messageId: normalized.messageId,
-                replyToMessageId: normalized.replyToMessageId,
-            },
-            chatId: normalized.chatId,
-            userId: normalized.userId,
-            displayName: normalized.displayName,
-            username: normalized.username,
-            text: normalized.text,
-            timestamp: normalized.timestamp,
-            messageId: normalized.messageId,
-            replyToMessageId: normalized.replyToMessageId,
-            chatTitle: normalized.chatTitle,
-            chatType: normalized.chatType,
-            isDirectMessage: normalized.isDirectMessage,
-            mentionsAgent: normalized.mentionsAgent,
-            mediaInfo: normalized.mediaInfo,
-            payload: {
-                scene: "onebot",
+                source: {
+                    scene: "onebot",
+                    platform: "onebot",
+                    chatId: normalized.chatId,
+                    userId: normalized.userId,
+                    chatType: normalized.chatType,
+                    messageId: normalized.messageId,
+                    replyToMessageId: normalized.replyToMessageId,
+                },
                 chatId: normalized.chatId,
                 userId: normalized.userId,
                 displayName: normalized.displayName,
@@ -757,24 +815,120 @@ export class OneBotAdapter implements PlatformAdapter {
                 isDirectMessage: normalized.isDirectMessage,
                 mentionsAgent: normalized.mentionsAgent,
                 mediaInfo: normalized.mediaInfo,
-                source: {
+                payload: {
                     scene: "onebot",
-                    platform: "onebot",
                     chatId: normalized.chatId,
                     userId: normalized.userId,
-                    chatType: normalized.chatType,
+                    displayName: normalized.displayName,
+                    username: normalized.username,
+                    text: normalized.text,
+                    timestamp: normalized.timestamp,
                     messageId: normalized.messageId,
                     replyToMessageId: normalized.replyToMessageId,
+                    chatTitle: normalized.chatTitle,
+                    chatType: normalized.chatType,
+                    isDirectMessage: normalized.isDirectMessage,
+                    mentionsAgent: normalized.mentionsAgent,
+                    mediaInfo: normalized.mediaInfo,
+                    source: {
+                        scene: "onebot",
+                        platform: "onebot",
+                        chatId: normalized.chatId,
+                        userId: normalized.userId,
+                        chatType: normalized.chatType,
+                        messageId: normalized.messageId,
+                        replyToMessageId: normalized.replyToMessageId,
+                    },
+                    platformData: {
+                        originalType: "onebot.message",
+                    },
                 },
-                platformData: {
-                    originalType: "onebot.message",
-                },
-            },
-            _urgent: normalized.isDirectMessage || normalized.mentionsAgent || normalized.replyToMessageId ? true : false,
+                _urgent: normalized.isDirectMessage || normalized.mentionsAgent || normalized.replyToMessageId ? true : false,
+            });
+        }).catch(err => {
+            log.warn("异步处理 OneBot 消息失败", { error: String(err) });
         });
     }
 
-    private normalizeIncomingMessage(event: OneBotIncomingEvent) {
+
+    /**
+     * 处理 OneBot notice 事件：群名变更、群成员昵称变更等。
+     * 这些事件用于实时更新缓存，确保 chatTitle 始终反映最新状态。
+     */
+    private handleNoticeEvent(event: OneBotIncomingEvent): void {
+        const noticeType = (event as Record<string, unknown>).notice_type;
+
+        if (noticeType === "group_name_change") {
+            // 群名变更事件（NapCat 扩展）
+            const groupId = String(event.group_id ?? "");
+            const newName = String((event as Record<string, unknown>).group_name ?? "");
+            if (groupId && newName) {
+                const oldName = this.groupNameCache.get(groupId);
+                this.groupNameCache.set(groupId, newName);
+                log.info("群名变更", { groupId, oldName, newName });
+            }
+            return;
+        }
+
+        if (noticeType === "group_card" || noticeType === "group_card_change") {
+            // 群成员昵称变更（部分实现支持的扩展事件）
+            const userId = String(event.user_id ?? "");
+            const card = String(event.sender?.card ?? (event as Record<string, unknown>).card ?? "");
+            if (userId && card) {
+                this.userNickCache.set(userId, card);
+                log.debug("群名片变更", { userId, card });
+            }
+            return;
+        }
+    }
+
+    /**
+     * 异步获取群名称，带缓存。
+     * 调用 OneBot get_group_info API，成功后缓存结果。
+     */
+    private async fetchGroupName(groupId: string): Promise<string | undefined> {
+        if (this.groupNameCache.has(groupId)) {
+            return this.groupNameCache.get(groupId)!;
+        }
+        try {
+            const result = await this.callAction("get_group_info", { group_id: Number(groupId) }) as Record<string, unknown>;
+            const data = (result?.data ?? result) as Record<string, unknown> | undefined;
+            const name = typeof data?.group_name === "string" ? data.group_name : undefined;
+            if (name) {
+                this.groupNameCache.set(groupId, name);
+                log.debug("获取群名成功", { groupId, groupName: name });
+            }
+            return name;
+        } catch (err) {
+            log.warn("获取群名失败", { groupId, error: String(err) });
+            return undefined;
+        }
+    }
+
+    /**
+     * 异步获取用户昵称，带缓存。
+     * 调用 OneBot get_stranger_info API，成功后缓存结果。
+     */
+    private async fetchUserNickname(userId: string): Promise<string | undefined> {
+        if (this.userNickCache.has(userId)) {
+            return this.userNickCache.get(userId)!;
+        }
+        try {
+            const result = await this.callAction("get_stranger_info", { user_id: Number(userId) }) as Record<string, unknown>;
+            const data = (result?.data ?? result) as Record<string, unknown> | undefined;
+            const nickname = typeof data?.nickname === "string" ? data.nickname : undefined;
+            if (nickname) {
+                this.userNickCache.set(userId, nickname);
+                log.debug("获取用户昵称成功", { userId, nickname });
+            }
+            return nickname;
+        } catch (err) {
+            log.warn("获取用户昵称失败", { userId, error: String(err) });
+            return undefined;
+        }
+    }
+
+    private async normalizeIncomingMessage(event: OneBotIncomingEvent) {
         const messageType = event.message_type;
         const userId = String(event.user_id ?? event.sender?.user_id ?? "");
         if (!userId) return null;
@@ -796,6 +950,24 @@ export class OneBotAdapter implements PlatformAdapter {
         const replyToMessageId = this.extractReplyTo(normalizedMessage) ?? (event.reply?.message_id != null ? String(event.reply.message_id) : undefined);
         const normalizedText = text || (mediaInfo ? this.mediaPlaceholder(mediaInfo.type) : "");
 
+        // 异步获取群名或用户昵称作为 chatTitle
+        let chatTitle: string | undefined;
+        if (messageType === "group") {
+            const groupId = String(event.group_id ?? "");
+            chatTitle = await this.fetchGroupName(groupId);
+            // 回退：缓存未命中时先用群号，后台获取成功后会在下条消息更新
+            if (!chatTitle) chatTitle = groupId;
+        } else {
+            // 私聊：用对方昵称作为 chatTitle
+            const nickname = await this.fetchUserNickname(userId);
+            chatTitle = nickname || displayName;
+        }
+
+        // 缓存发送者昵称（群聊时也缓存群成员昵称）
+        if (event.sender?.nickname && userId) {
+            this.userNickCache.set(userId, event.sender.nickname);
+        }
+
         return {
             chatId,
             userId,
@@ -805,7 +977,7 @@ export class OneBotAdapter implements PlatformAdapter {
             timestamp: new Date((event.time ?? Math.floor(Date.now() / 1000)) * 1000).toISOString(),
             messageId,
             replyToMessageId,
-            chatTitle: messageType === "group" ? String(event.group_id ?? "") : undefined,
+            chatTitle,
             chatType: messageType === "group" ? "group" : "private",
             isDirectMessage: messageType === "private",
             mentionsAgent,

--- a/src/core/chat-id.ts
+++ b/src/core/chat-id.ts
@@ -24,13 +24,16 @@ export interface ParsedChatId {
     /** 原始 ID（完整，不含平台前缀） */
     rawId: string;
     /**
-     * Discord Guild ID（仅 Discord 三段式有值）。
-     * Telegram 群组本身即为 group，此字段为 undefined。
+     * 群组 ID。各平台含义：
+     * - Discord: Guild ID（三段式时有值，DM 时 undefined）
+     * - OneBot: 群聊 ID（onebot:group:xxx → xxx，私聊时 undefined）
+     * - Telegram: 群组即 chatId 本身，此字段为 undefined
      */
     groupId?: string;
     /**
-     * Discord Channel/Thread ID（仅 Discord 三段式有值）。
-     * Telegram 无 channel 层，此字段为 undefined。
+     * 频道/子级 ID。各平台含义：
+     * - Discord: Channel/Thread ID（三段式时有值）
+     * - OneBot/Telegram: 无此层级，此字段为 undefined
      */
     channelId?: string;
 }
@@ -67,6 +70,12 @@ export function composeChatId(platform: PlatformName, ...parts: string[]): strin
  *
  * parseChatId("discord:user789")
  *   → { platform: "discord", rawId: "user789" }  (DM, 无 groupId/channelId)
+ *
+ * parseChatId("onebot:group:679691983")
+ *   → { platform: "onebot", rawId: "group:679691983", groupId: "679691983" }
+ *
+ * parseChatId("onebot:private:1694442676")
+ *   → { platform: "onebot", rawId: "private:1694442676" }  (私聊, 无 groupId)
  */
 export function parseChatId(compositeId: string): ParsedChatId {
     if (!compositeId) {
@@ -107,6 +116,15 @@ export function parseChatId(compositeId: string): ParsedChatId {
             result.channelId = rest.slice(secondColon + 1);
         }
         // 二段式 DM: discord:userId — 无 groupId/channelId
+    }
+
+    // OneBot 三段式: onebot:group:groupId / onebot:private:userId
+    if (platform === "onebot") {
+        const secondColon = rest.indexOf(":");
+        if (secondColon !== -1 && rest.slice(0, secondColon) === "group") {
+            result.groupId = rest.slice(secondColon + 1);
+        }
+        // onebot:private:xxx → 无 groupId（私聊不是群组）
     }
 
     return result;

--- a/src/core/chat-id.ts
+++ b/src/core/chat-id.ts
@@ -215,10 +215,16 @@ export function fileNameToChatId(fileName: string): string {
 
     const rest = base.slice(underscoreIdx + 1);
 
-    // Telegram / OneBot: 直接还原 — telegram_-1001234567 → telegram:-1001234567
+    // Telegram: 二段式，直接还原 — telegram_-1001234567 → telegram:-1001234567
     // 注意 Telegram chatId 可能包含负号，不会与 _ 冲突
-    if (platform === "telegram" || platform === "onebot") {
+    if (platform === "telegram") {
         return `${platform}:${rest}`;
+    }
+
+    // OneBot: 三段式（onebot:group:xxx / onebot:private:xxx），需将 _ 还原为 :
+    // onebot_group_679691983 → onebot:group:679691983
+    if (platform === "onebot") {
+        return `onebot:${rest.replaceAll("_", ":")}`;
     }
 
     // Discord: 需要将 _ 还原为 : — discord_guild_chan → discord:guild:chan

--- a/src/dashboard/event-bridge.ts
+++ b/src/dashboard/event-bridge.ts
@@ -214,6 +214,7 @@ export class EventBridge {
                     text: String(event.text ?? event.message ?? ""),
                     isDirectMessage: !!event.isDirectMessage,
                     mentionsAgent: !!event.mentionsAgent,
+                    chatTitle: String(event.chatTitle ?? ""),
                 },
             });
         });
@@ -399,6 +400,7 @@ export class EventBridge {
             groups.push({
                 chatId: sub.chatId,
                 chatTitle: gm?.chatTitle || "",
+                isDirectMessage: !!gm?.isDirectMessage,
                 engagement: sub.observer.getEngagementScore(),
                 bufferSize: sub.observer.getBufferSize(),
                 topicCount: sub.topicRegistry.getAll().length,

--- a/src/dashboard/ui/src/lib/stores.js
+++ b/src/dashboard/ui/src/lib/stores.js
@@ -30,13 +30,24 @@ export function addMessage(data, timestamp) {
     return msgs;
   });
 
-  // Update group list if new chat
+  // Update group list if new chat, and sync chatTitle/isDirectMessage
   appState.update(s => {
-    if (!s.groups.find(g => g.chatId === data.chatId)) {
+    const existing = s.groups.find(g => g.chatId === data.chatId);
+    if (!existing) {
       s.groups.push({
         chatId: data.chatId, engagement: 0, bufferSize: 0,
         topicCount: 0, stickiness: 'STRANGER', attendCount: 0,
+        chatTitle: data.chatTitle || '',
+        isDirectMessage: !!data.isDirectMessage,
       });
+    } else {
+      // 如果收到的 chatTitle 比现有更完整，更新它
+      if (data.chatTitle && (!existing.chatTitle || existing.chatTitle === data.chatId)) {
+        existing.chatTitle = data.chatTitle;
+      }
+      if (typeof data.isDirectMessage === 'boolean') {
+        existing.isDirectMessage = data.isDirectMessage;
+      }
     }
     return s;
   });

--- a/src/dashboard/ui/src/lib/utils.js
+++ b/src/dashboard/ui/src/lib/utils.js
@@ -88,6 +88,22 @@ export function getGroupLabel(chatId) {
   return shortId(chatId);
 }
 
+/**
+ * 获取聊天类型标签（群聊/私聊）
+ */
+export function getChatTypeLabel(chatId) {
+  const state = get(appState);
+  const g = state.groups.find(g => g.chatId === chatId);
+  if (g?.isDirectMessage) return '私聊';
+  // onebot:group:xxx 是群聊
+  const s = String(chatId ?? '');
+  if (s.includes(':group:')) return '群聊';
+  if (s.includes(':private:')) return '私聊';
+  // Telegram/Discord: 非私聊则默认群聊
+  if (g && !g.isDirectMessage) return '群聊';
+  return '';
+}
+
 export function isAtBottom(el) {
   if (!el) return true;
   return el.scrollTop + el.clientHeight >= el.scrollHeight - 50;

--- a/src/dashboard/ui/src/panels/MemoryEditModal.svelte
+++ b/src/dashboard/ui/src/panels/MemoryEditModal.svelte
@@ -2,6 +2,7 @@
   import { onMount } from 'svelte';
   import { api } from '../lib/api.js';
   import { shortId } from '../lib/utils.js';
+  import { appState } from '../lib/stores.js';
 
   let modal;
   let editCtx = null; // { type, key, data }
@@ -107,6 +108,12 @@
           hotTopics: splitCSV(v.hotTopics), tabooTopics: splitCSV(v.tabooTopics),
           communicationNorms: splitCSV(v.communicationNorms),
         }});
+        // 乐观更新 appState 中的 chatTitle，使侧边栏立即反映修改
+        appState.update(s => {
+          const g = s.groups.find(g => g.chatId === key.chatId);
+          if (g && v.chatTitle) g.chatTitle = v.chatTitle;
+          return s;
+        });
       } else if (type === 'fact') {
         await api(`/memory/fact/${key.id}`, { method: 'PUT', body: {
           content: v.content, category: v.category,

--- a/src/dashboard/ui/src/panels/MessagesPanel.svelte
+++ b/src/dashboard/ui/src/panels/MessagesPanel.svelte
@@ -11,6 +11,7 @@
     escapeHtml,
     shortId,
     getGroupLabel,
+    getChatTypeLabel,
     isAtBottom,
     scrollToBottom,
     getPlatform,
@@ -176,6 +177,10 @@
     );
   }
 
+  function editChatTitle(chatId) {
+    window.dispatchEvent(new CustomEvent('memoryEdit', { detail: { type: 'group', chatId } }));
+  }
+
   // Auto-scroll on new messages
   let wasBottom = true;
   $: if (displayMessages && streamEl) {
@@ -218,6 +223,7 @@
           {#each allChatIds as chatId}
             {@const count = $messages.filter((m) => m.chatId === chatId).length}
             {@const plat = getPlatform(chatId)}
+            {@const chatType = getChatTypeLabel(chatId)}
             <button
               class="chat-item"
               class:active={$selectedChatId === chatId}
@@ -228,9 +234,13 @@
                 {#if plat}<span class="platform-badge platform-{plat}"
                     >{platformLabel(plat)}</span
                   >{/if}
+                {#if chatType}<span class="chat-type-badge">{chatType}</span>{/if}
                 {getGroupLabel(chatId)}
               </span>
               <span class="flex items-center gap-1">
+                <span class="chat-edit-btn" title="编辑群名/显示名" onclick={(e) => { e.stopPropagation(); editChatTitle(chatId); }}>
+                  <i class="fa-solid fa-pen" style="font-size:0.55rem"></i>
+                </span>
                 {#if mutedChatIds.has(chatId)}<span title="禁言中"><i class="fa-solid fa-volume-xmark" style="font-size:0.65rem;color:var(--color-warning)"></i></span>{/if}
                 <span class="badge badge-sm">{count}</span>
               </span>
@@ -447,6 +457,32 @@
     flex-shrink: 0;
     text-align: center;
     display: inline-block;
+  }
+
+
+  .chat-type-badge {
+    font-size: 0.6rem;
+    padding: 0.05rem 0.3rem;
+    border-radius: 0.15rem;
+    background: color-mix(in srgb, var(--color-secondary) 15%, transparent);
+    color: var(--color-secondary);
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+
+  .chat-edit-btn {
+    opacity: 0;
+    cursor: pointer;
+    padding: 0.15rem 0.25rem;
+    border-radius: 0.15rem;
+    transition: opacity 0.15s, background 0.15s;
+  }
+  .chat-item:hover .chat-edit-btn {
+    opacity: 0.5;
+  }
+  .chat-edit-btn:hover {
+    opacity: 1 !important;
+    background: var(--color-base-200);
   }
 
   .chat-item {

--- a/src/dashboard/ui/src/panels/memory/GroupsTab.svelte
+++ b/src/dashboard/ui/src/panels/memory/GroupsTab.svelte
@@ -1,7 +1,7 @@
 <script>
   import { activeTab, activeMemoryTab, pendingMemoryLink } from '../../lib/stores.js';
   import { api } from '../../lib/api.js';
-  import { shortId, escapeHtml, getPlatform, platformLabel } from '../../lib/utils.js';
+  import { shortId, escapeHtml, getPlatform, platformLabel, getChatTypeLabel } from '../../lib/utils.js';
 
   let groups = [];
 
@@ -35,19 +35,27 @@
     <div class="overflow-x-auto">
       <table class="table table-xs">
         <thead><tr>
-          <th>ChatId</th><th>标题</th><th>描述</th><th>角色</th><th>参与度</th><th>活跃人数</th><th>日均消息</th><th>私聊</th><th>热门话题</th><th>操作</th>
+          <th>ChatId</th><th>类型</th><th>标题</th><th>描述</th><th>角色</th><th>参与度</th><th>活跃人数</th><th>日均消息</th><th>热门话题</th><th>操作</th>
         </tr></thead>
         <tbody>
           {#if !groups.length}
-            <tr><td colspan="10" class="text-center opacity-60">暂无数据</td></tr>
+            <tr><td colspan="11" class="text-center opacity-60">暂无数据</td></tr>
           {:else}
             {#each groups as g}
+              {@const chatType = getChatTypeLabel(g.chatId) || (g.isDirectMessage ? '私聊' : '群聊')}
               <tr>
                 <td class="font-mono text-xs" title={g.chatId}>
                   {#if getPlatform(g.chatId)}<span class="platform-badge platform-{getPlatform(g.chatId)}">{platformLabel(getPlatform(g.chatId))}</span>{/if}
                   {shortId(g.chatId)}
                 </td>
-                <td>{g.chatTitle || '-'}</td>
+                <td>
+                  <span class="badge badge-xs {g.isDirectMessage ? 'badge-ghost' : 'badge-primary'}">{chatType}</span>
+                </td>
+                <td>
+                  <span class="cursor-pointer hover:underline" title="点击编辑" onclick={() => editGroup(g.chatId)}>
+                    {g.chatTitle || '-'}
+                  </span>
+                </td>
                 <td class="max-w-40 truncate" title={g.description || ''}>{g.description || '-'}</td>
                 <td class="max-w-24 truncate" title={g.agentRole || ''}>{g.agentRole || '-'}</td>
                 <td>
@@ -61,13 +69,12 @@
                 </td>
                 <td>{g.activeMembers ?? '-'}</td>
                 <td>{g.avgMessagesPerDay != null ? g.avgMessagesPerDay.toFixed(1) : '-'}</td>
-                <td>{g.isDirectMessage ? '✓' : '-'}</td>
                 <td class="max-w-32 truncate" title={(g.hotTopics || []).join(', ')}>{(g.hotTopics || []).join(', ') || '-'}</td>
                 <td>
                   <div class="flex gap-1">
                     <button class="btn btn-xs btn-ghost" title="群内画像列表" onclick={() => jumpToProfiles(g.chatId)}><i class="fa-solid fa-id-badge"></i></button>
                     <button class="btn btn-xs btn-ghost" title="聊天记录" onclick={() => jumpToChatLog(g.chatId)}><i class="fa-solid fa-comments"></i></button>
-                    <button class="btn btn-xs btn-ghost" onclick={() => editGroup(g.chatId)}><i class="fa-solid fa-pen-to-square"></i></button>
+                    <button class="btn btn-xs btn-ghost" title="编辑群组" onclick={() => editGroup(g.chatId)}><i class="fa-solid fa-pen-to-square"></i></button>
                   </div>
                 </td>
               </tr>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1303,6 +1303,39 @@ async function main(): Promise<void> {
 
     // 广播 adapter 状态到 dashboard
     nc.push({ type: "system.adapter_status", adapters: adapterStatuses });
+
+    // ─── 延迟刷新 OneBot 预加载的群名/昵称到 GroupModel ───
+    // prefetchWhitelistedGroups 是异步的，等 5 秒后从缓存读取并更新 GroupModel
+    const onebotAdapterInstance = adapters.find(a => a.platform === "onebot") as OneBotAdapter | undefined;
+    if (onebotAdapterInstance) {
+        setTimeout(() => {
+            try {
+                const { groupNames, userNicks } = onebotAdapterInstance.getCachedNames();
+                let updatedCount = 0;
+                for (const [groupId, groupName] of groupNames.entries()) {
+                    const chatId = `onebot:group:${groupId}`;
+                    const existing = memory.getGroupModel(getGroupModelKey(chatId));
+                    if (!existing || existing.chatTitle !== groupName) {
+                        memory.upsertGroupModel(getGroupModelKey(chatId), { chatTitle: groupName, isDirectMessage: false });
+                        updatedCount++;
+                    }
+                }
+                for (const [userId, nickname] of userNicks.entries()) {
+                    const chatId = `onebot:private:${userId}`;
+                    const existing = memory.getGroupModel(getGroupModelKey(chatId));
+                    if (!existing || existing.chatTitle !== nickname) {
+                        memory.upsertGroupModel(getGroupModelKey(chatId), { chatTitle: nickname, isDirectMessage: true });
+                        updatedCount++;
+                    }
+                }
+                if (updatedCount > 0) {
+                    log.info("OneBot 预加载 chatTitle 已同步到 GroupModel", { updatedCount });
+                }
+            } catch (err) {
+                log.warn("OneBot 预加载 chatTitle 同步失败", { error: String(err) });
+            }
+        }, 5000);
+    }
     const failedAdapters = adapterStatuses.filter(a => a.status !== "ok");
     if (failedAdapters.length > 0) {
         log.warn("部分 adapter 未就绪", { failed: failedAdapters.map(a => `${a.platform}: ${a.error}`) });


### PR DESCRIPTION
变更概要

1. fix: fileNameToChatId 还原 OneBot 三段式 chatId

fileNameToChatId 对 onebot 仍沿用二段式还原逻辑（_ → : 只替换第一个），导致 onebot_group_679691983 还原为 onebot:group_679691983 而非 onebot:group:679691983，session restore 时 chatId 不匹配。现改为 replaceAll("_", ":")。

2. refactor: parseChatId 为 OneBot 填充 groupId

• onebot:group:xxx → groupId: xxx（与 Discord 模式一致）
• onebot:private:xxx → groupId: undefined
• adatper 中所有 parsed.rawId.startsWith("group:") + slice 模式统一改用 parsed.groupId，私聊/群聊分发逻辑跨平台一致

3. feat: OneBot 群名/昵称显示、类型标注、编辑

• onebot-adapter: 启动时调用 get_group_list / get_friend_list 预加载群名和昵称缓存；消息处理时通过 get_group_info / get_stranger_info 按需获取；处理 notice 事件（群名变更、群名片变更）实时更新缓存
• event-bridge: snapshot 和 nc:message 广播新增 chatTitle / isDirectMessage
• main.ts: 启动后延迟 5 秒将预加载的 chatTitle 同步到 GroupModel
• 前端: 侧栏显示 [群聊] / [私聊] 类型标签和编辑按钮；GroupsTab 新增类型列替代原私聊列，标题可点击编辑；MemoryEditModal 保存 chatTitle 后乐观更新 appState
