### PR TITLE
feat(dashboard): support note on manual enqueue

### DIFF
--- a/src/dashboard/api-routes.ts
+++ b/src/dashboard/api-routes.ts
@@ -488,19 +488,19 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
     });
 
     router.post("/queue/enqueue", (req, res) => {
-        const { chatId, priority } = req.body;
+        const { chatId, priority, note } = req.body;
         if (!chatId) { res.status(400).json({ error: "chatId required" }); return; }
         const sub = deps.subagentManager.get(chatId);
         if (!sub) { res.status(404).json({ error: "chat not found" }); return; }
         deps.accumulator.ingest(0, {
             chatId,
             source: "DIRECT_ADDRESS",
-            payload: { reason: "dashboard-manual" },
+            payload: { reason: typeof note === "string" && note.trim() ? `dashboard-manual: ${note.trim()}` : "dashboard-manual" },
             enqueuedAt: Date.now(),
             pressure: Number(priority) || 0,
         });
         bridge.broadcast({ type: "queue:update", timestamp: new Date().toISOString(), data: deps.accumulator.getSnapshot() });
-        log.info("手动注入 accumulator", { chatId, priority });
+        log.info("手动注入 accumulator", { chatId, priority, note: typeof note === "string" ? note.slice(0, 200) : undefined });
         res.json({ ok: true });
     });
 

--- a/src/dashboard/ui/src/panels/EnqueueModal.svelte
+++ b/src/dashboard/ui/src/panels/EnqueueModal.svelte
@@ -5,10 +5,12 @@
   let modal;
   let chatId = '';
   let priority = 80;
+  let note = '';
 
   onMount(() => {
     function onShow(e) {
       if (e.detail?.chatId) chatId = e.detail.chatId;
+      note = '';
       modal?.showModal();
     }
     window.addEventListener('showEnqueueModal', onShow);
@@ -17,7 +19,7 @@
 
   async function doEnqueue() {
     if (!chatId) return;
-    await api('/queue/enqueue', { method: 'POST', body: { chatId, priority } });
+    await api('/queue/enqueue', { method: 'POST', body: { chatId, priority, note } });
     modal.close();
   }
 </script>
@@ -28,6 +30,7 @@
     <div class="py-4 space-y-3">
       <input type="text" placeholder="ChatId" class="input input-bordered w-full" bind:value={chatId} />
       <input type="number" placeholder="Pressure (0-100)" class="input input-bordered w-full" bind:value={priority} />
+      <input type="text" placeholder="附言（将写入 directAddressReason）" class="input input-bordered w-full" bind:value={note} />
     </div>
     <div class="modal-action">
       <button class="btn btn-primary" onclick={doEnqueue}>注入</button>


### PR DESCRIPTION
### Motivation
- Allow operators to attach a short freeform `note` when manually enqueueing a chat from the dashboard so the reason can surface in attention rendering (e.g. via `directAddressReason`).
- Reuse the existing direct-address rendering path instead of adding new fields, by storing the note inside the enqueue payload `reason` so downstream components already reading `directAddressReason` will see it.

### Description
- Backend: `POST /queue/enqueue` in `src/dashboard/api-routes.ts` now accepts `{ chatId, priority, note }` and sets `payload.reason` to either `dashboard-manual` or `dashboard-manual: <trimmed note>` when `note` is provided.
- Frontend: `src/dashboard/ui/src/panels/EnqueueModal.svelte` adds a `note` input, resets it when the modal opens, and includes `note` in the API request body.
- Logging: the server log now records a truncated preview of the provided `note` for observability.

### Testing
- Ran the test suite with `npm test` to exercise repository tests after the change.
- `npm test` executed but the run encountered pre-existing repository test failures and an environment-native module error (`node-pty` prebuild missing) which are unrelated to this change; no dashboard-specific automated tests failed as a result of this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e561f2288320a01a11d78f9dc2ad)