### PR TITLE
Require separate pure-text session digest turn; ignore in-band <end_turn> after code

### DIFF
--- a/src/meta-sandbox/meta-session-runner.ts
+++ b/src/meta-sandbox/meta-session-runner.ts
@@ -135,13 +135,6 @@ function hasSessionDigest(thinking?: string): boolean {
     return Boolean(match?.[1]?.trim());
 }
 
-function appendSessionDigestBlock(thinking: string | undefined, digest: string): string {
-    return [
-        thinking?.trim() ?? "",
-        `[SESSION_DIGEST]${digest}[/SESSION_DIGEST]`,
-    ].filter(Boolean).join("\n");
-}
-
 export function compactThinking(thinking: string, maxChars: number = 500): string {
     const trimmed = thinking.trim();
     if (trimmed.length <= maxChars) {
@@ -237,12 +230,8 @@ export async function runMetaSession(
             const parsed = parseMetaResponse(assistantMessage);
             const hasCode = Boolean(parsed.code);
             const hasEndTurn = assistantMessage.includes(END_TURN_MARKER);
-            const postCodeEndRequest = hasCode
-                ? getCleanPostCodeEndRequest(assistantMessage, parsed.thinking)
-                : null;
-            const shouldEndAfterCode = Boolean(postCodeEndRequest);
-            if (hasCode && hasEndTurn && !postCodeEndRequest) {
-                log.info("Meta session code block included non-clean end_turn tail; ignoring tail until after observation", {
+            if (hasCode && hasEndTurn) {
+                log.info("Meta session response included code and end_turn; end_turn is ignored until a later pure-text turn", {
                     sessionId,
                     turn,
                 });
@@ -336,23 +325,6 @@ export async function runMetaSession(
                 return finalize("interrupted", "Meta session cancelled by user");
             }
 
-            if (shouldEndAfterCode) {
-                if (!postCodeEndRequest?.digest) {
-                    const observation = buildMissingDigestObservation();
-                    turnRecord.observation = [turnRecord.observation, observation].filter(Boolean).join("\n\n");
-                    messages.push({ role: "user", content: observation });
-                    syncMetaCodeActState(sessionId, messages, turns, true);
-                    emitMetaProgress(sessionId, {
-                        turn,
-                        phase: "observation",
-                        executionOutput: observation,
-                        isProcessing: true,
-                    });
-                    continue;
-                }
-                turnRecord.thinking = appendSessionDigestBlock(turnRecord.thinking, postCodeEndRequest.digest);
-                return finalize("end_turn");
-            }
         } catch (error) {
             const message = error instanceof Error ? error.message : String(error);
             log.warn("Meta session failed", { sessionId, turn, error: message });
@@ -373,30 +345,6 @@ function buildAssistantHistoryContent(content: string): string {
         return content.trim();
     }
     return stripEndTurnMarker(content.slice(0, firstCodeBlock.start)).trim();
-}
-
-function getCleanPostCodeEndRequest(content: string, preCodeThinking: string): { digest?: string } | null {
-    const firstCodeBlock = findFirstCodeBlock(content);
-    if (!firstCodeBlock) {
-        return null;
-    }
-
-    const tail = content.slice(firstCodeBlock.end).trim();
-    if (!tail.includes(END_TURN_MARKER)) {
-        return null;
-    }
-
-    const digest = extractSessionDigest(tail) ?? extractSessionDigest(preCodeThinking);
-    const residue = tail
-        .replace(/\[SESSION_DIGEST\][\s\S]*?(?:\[\/SESSION_DIGEST\]|$)/g, "")
-        .replace(new RegExp(END_TURN_MARKER, "g"), "")
-        .trim();
-
-    if (residue.length > 0) {
-        return null;
-    }
-
-    return { digest };
 }
 
 function findFirstCodeBlock(content: string): FirstCodeBlockMatch | null {

--- a/tests/meta-main-loop.test.ts
+++ b/tests/meta-main-loop.test.ts
@@ -16,6 +16,7 @@ import { MetaSandbox } from "../src/meta-sandbox/meta-sandbox.js";
 import { CallbackQueue } from "../src/subagent/callback-queue.js";
 import { SubagentManager } from "../src/subagent/subagent-manager.js";
 import type { AttentionQueueEntry } from "../src/subagent/types.js";
+import type { LLMResponse } from "../src/core/llm.js";
 
 function createMetaMemoryStub() {
     return {
@@ -181,13 +182,8 @@ describe("MainAgentLoop meta session path", () => {
         });
         const sandbox = new MetaSandbox(metaApiContext);
 
-        loop.setMetaSessionHandler(createMetaSessionHandler({
-            getPersona: () => ({ name: "测试编排者", description: "验证真实 meta session dispatch" }),
-            globalState,
-            memory: createMetaMemoryStub() as any,
-            sandbox,
-            getLlmConfigs: () => [TEST_LLM_CONFIG],
-            llmCaller: async () => ({
+        const responses: LLMResponse[] = [
+            {
                 content: [
                     "准备下发任务。",
                     "```ts",
@@ -201,7 +197,22 @@ describe("MainAgentLoop meta session path", () => {
                     "[SESSION_DIGEST]dispatched task to telegram:g1[/SESSION_DIGEST]",
                     "<end_turn>",
                 ].join("\n"),
-            }),
+            },
+            {
+                content: "Done.\n[SESSION_DIGEST]dispatched task to telegram:g1[/SESSION_DIGEST]\n<end_turn>",
+            },
+        ];
+        loop.setMetaSessionHandler(createMetaSessionHandler({
+            getPersona: () => ({ name: "测试编排者", description: "验证真实 meta session dispatch" }),
+            globalState,
+            memory: createMetaMemoryStub() as any,
+            sandbox,
+            getLlmConfigs: () => [TEST_LLM_CONFIG],
+            llmCaller: async () => {
+                const next = responses.shift();
+                assert.ok(next);
+                return next;
+            },
         }));
 
         accumulator.ingest(2, {

--- a/tests/meta-session-runner.test.ts
+++ b/tests/meta-session-runner.test.ts
@@ -205,7 +205,7 @@ describe("runMetaSession", () => {
         assert.doesNotMatch(llmCalls[1][llmCalls[1].length - 2].content, /<end_turn>/);
     });
 
-    it("ends after successful code execution when code is followed only by digest and end_turn", async () => {
+    it("ignores code+end_turn and waits for a pure-text digest+end_turn turn", async () => {
         const sandbox = new MetaSandbox({
             tools: {
                 dispatch: async () => ({ taskId: "task-1", status: "PENDING" }),
@@ -213,6 +213,23 @@ describe("runMetaSession", () => {
         });
         const llmCalls: ChatMessage[][] = [];
 
+        const responses: LLMResponse[] = [
+            {
+                content: [
+                    "Need to dispatch once.",
+                    "",
+                    "```ts",
+                    "return await tools.dispatch();",
+                    "```",
+                    "",
+                    "[SESSION_DIGEST]dispatched greeting task[/SESSION_DIGEST]",
+                    "<end_turn>",
+                ].join("\n"),
+            },
+            {
+                content: "Done.\n[SESSION_DIGEST]dispatched greeting task[/SESSION_DIGEST]\n<end_turn>",
+            },
+        ];
         const result = await runMetaSession(
             [
                 { role: "system", content: "system" },
@@ -223,37 +240,29 @@ describe("runMetaSession", () => {
             {
                 llmCaller: async (messages) => {
                     llmCalls.push(messages.map((message) => ({ ...message })));
-                    return {
-                        content: [
-                            "Need to dispatch once.",
-                            "",
-                            "```ts",
-                            "return await tools.dispatch();",
-                            "```",
-                            "",
-                            "[SESSION_DIGEST]dispatched greeting task[/SESSION_DIGEST]",
-                            "<end_turn>",
-                        ].join("\n"),
-                    };
+                    const next = responses.shift();
+                    assert.ok(next);
+                    return next;
                 },
             },
         );
 
         assert.equal(result.endReason, "end_turn");
-        assert.equal(result.turns.length, 1);
-        assert.equal(llmCalls.length, 1);
+        assert.equal(result.turns.length, 2);
+        assert.equal(llmCalls.length, 2);
         assert.equal(result.sessionDigest, "dispatched greeting task");
         assert.match(result.turns[0]?.observation ?? "", /task-1/);
         assert.doesNotMatch(result.messages.map((message) => message.content).join("\n\n"), /dispatched greeting task/);
     });
 
-    it("ignores fabricated observations and extra code after the first code block", async () => {
+    it("strips post-code content, runs only first block, then waits next round to end", async () => {
         const sandbox = new MetaSandbox({
             tools: {
                 answer: async () => 42,
             },
         });
         const llmCalls: ChatMessage[][] = [];
+
         const responses: LLMResponse[] = [
             {
                 content: [
@@ -282,7 +291,6 @@ describe("runMetaSession", () => {
                 content: "Done.\n[SESSION_DIGEST]real observation handled[/SESSION_DIGEST]\n<end_turn>",
             },
         ];
-
         const result = await runMetaSession(
             [
                 { role: "system", content: "system" },
@@ -309,6 +317,7 @@ describe("runMetaSession", () => {
         assert.match(result.turns[0]?.observation ?? "", /42/);
         assert.equal(result.sessionDigest, "real observation handled");
 
+        assert.equal(llmCalls.length, 2);
         const secondCallText = llmCalls[1]?.map((message) => message.content).join("\n\n") ?? "";
         assert.match(secondCallText, /Need one real lookup/);
         assert.doesNotMatch(secondCallText, /second block must not run/);


### PR DESCRIPTION
### Motivation
- Prevent models from ending a meta session by tacking an `<end_turn>` (and optional digest) onto the same message that contains executable code, which could mask non-clean tails or fabricated observations.
- Make the meta-runner require an explicit pure-text digest+`<end_turn>` turn to finalize a session, improving safety of code execution and observation handling.

### Description
- Removed the post-code tail parsing and handling logic (`getCleanPostCodeEndRequest` and `appendSessionDigestBlock`) that treated a code block plus trailing digest+`<end_turn>` as a clean end-of-turn.
- When a response contains both executable code and an `END_TURN_MARKER`, the runner now logs that the `end_turn` is ignored and defers ending until a later pure-text turn containing the digest.
- Adjusted meta session flow to always require a subsequent pure-text digest turn to finalize, and updated helper behavior accordingly (no longer merging post-code digest into the same turn).
- Updated tests to simulate two-step LLM behavior (first message with code and in-band `END_TURN_MARKER`, second pure-text digest+`END_TURN_MARKER`) and to assert the runner waits for the second turn.

### Testing
- Updated and ran the unit tests in `tests/meta-session-runner.test.ts` and `tests/meta-main-loop.test.ts` which exercise the new two-step digest flow and related edge cases; the modified tests passed.
- Ran the project's automated test suite (unit tests under `node:test`) after the changes and observed success for the affected tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f711acc4cc8320a91581c3100078b4)