### PR TITLE
feat(llm): add OpenAI Responses provider using official SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "typescript": "^5.9.3",
     "ulid": "^2.3.0",
     "ws": "^8.19.0",
-    "yaml": "^2.8.2"
+    "yaml": "^2.8.2",
+    "openai": "^4.104.0"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.0.0",

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -33,7 +33,7 @@ export interface PoolConfig {
 }
 
 export interface LLMConfig {
-    provider: "anthropic" | "openai" | "google";
+    provider: "anthropic" | "openai" | "openai_responses" | "google";
     baseUrl: string;
     apiKey: string;
     model: string;
@@ -1009,7 +1009,7 @@ function parseLLMProfile(raw: Record<string, unknown>): LLMConfig {
     }
 
     return {
-        provider: (str(raw.provider) as "anthropic" | "openai" | "google") ?? DEFAULT_LLM.provider,
+        provider: (str(raw.provider) as "anthropic" | "openai" | "openai_responses" | "google") ?? DEFAULT_LLM.provider,
         baseUrl: str(raw.base_url) ?? DEFAULT_LLM.baseUrl,
         apiKey: str(raw.api_key) ?? DEFAULT_LLM.apiKey,
         model: str(raw.model) ?? DEFAULT_LLM.model,

--- a/src/core/llm.ts
+++ b/src/core/llm.ts
@@ -26,6 +26,7 @@ import { EventEmitter } from "node:events";
 
 // Provider 实现
 import { callOpenAI } from "./llm/openai.js";
+import { callOpenAIResponses } from "./llm/openai-responses.js";
 import { callAnthropic } from "./llm/anthropic.js";
 import { callGoogle } from "./llm/google.js";
 
@@ -417,6 +418,8 @@ async function _callLLMSingleKeyInner(
                 result = await callAnthropic(messages, config, model, temperature, maxTokens, thinkingLevel, prefill, stop, combinedSignal);
             } else if (config.provider === "google") {
                 result = await callGoogle(messages, config, model, temperature, maxTokens, thinkingLevel, prefill, stop, combinedSignal);
+            } else if (config.provider === "openai_responses") {
+                result = await callOpenAIResponses(messages, config, model, temperature, maxTokens, thinkingLevel, prefill, stop, combinedSignal);
             } else {
                 result = await callOpenAI(messages, config, model, temperature, maxTokens, thinkingLevel, prefill, stop, combinedSignal);
             }

--- a/src/core/llm/openai-responses.ts
+++ b/src/core/llm/openai-responses.ts
@@ -1,0 +1,82 @@
+/**
+ * llm/openai-responses.ts — OpenAI Responses API（官方 SDK）调用
+ */
+
+import OpenAI from "openai";
+import type { LLMConfig } from "../config.js";
+import type { ChatMessage, LLMResponse } from "./types.js";
+
+export async function callOpenAIResponses(
+    messages: ChatMessage[],
+    config: LLMConfig,
+    model: string,
+    temperature: number,
+    maxTokens: number,
+    thinkingLevel?: string,
+    prefill?: string,
+    stop?: string[],
+    signal?: AbortSignal,
+): Promise<LLMResponse> {
+    const client = new OpenAI({
+        apiKey: config.apiKey,
+        baseURL: config.baseUrl,
+        defaultHeaders: config.customHeaders,
+    });
+
+    const input: Array<Record<string, unknown>> = messages.map(m => {
+        if (m.imageParts && m.imageParts.length > 0 && m.role === "user") {
+            const content: Array<Record<string, unknown>> = [{ type: "input_text", text: m.content }];
+            for (const img of m.imageParts) {
+                content.push({
+                    type: "input_image",
+                    image_url: img.url,
+                    ...(img.detail ? { detail: img.detail } : {}),
+                });
+            }
+            return { role: m.role, content };
+        }
+        return {
+            role: m.role,
+            content: [{ type: "input_text", text: m.content }],
+        };
+    });
+
+    if (prefill) {
+        input.push({
+            role: "assistant",
+            content: [{ type: "output_text", text: prefill }],
+        });
+    }
+
+    const response = await client.responses.create(
+        {
+            model,
+            input,
+            temperature,
+            max_output_tokens: maxTokens,
+            ...(thinkingLevel && thinkingLevel !== "none" ? { reasoning: { effort: thinkingLevel } } : {}),
+            ...(stop && stop.length > 0 ? { stop } : {}),
+            ...(config.extraBody ?? {}),
+        },
+        {
+            signal,
+        },
+    );
+
+    const content = response.output_text ?? "";
+    if (!content) {
+        throw new Error(`LLM returned empty response (0 chars) from model ${model}`);
+    }
+
+    return {
+        content,
+        usage: response.usage
+            ? {
+                promptTokens: response.usage.input_tokens,
+                completionTokens: response.usage.output_tokens,
+                totalTokens: response.usage.total_tokens,
+                cachedTokens: response.usage.input_tokens_details?.cached_tokens,
+            }
+            : undefined,
+    };
+}

--- a/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
+++ b/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
@@ -84,7 +84,7 @@
           <label class="cfg-field"
             ><span class="cfg-label">Provider</span>
             <select class="select select-xs select-bordered w-full" bind:value={p.provider}>
-              <option value="openai">openai (兼容)</option><option value="anthropic">anthropic</option><option value="google">google (Gemini)</option>
+              <option value="openai">openai (兼容)</option><option value="openai_responses">openai (responses)</option><option value="anthropic">anthropic</option><option value="google">google (Gemini)</option>
             </select></label
           >
           <label class="cfg-field"
@@ -145,7 +145,7 @@
             <label class="cfg-field"><span class="cfg-label">Region</span><input type="text" class="input input-xs input-bordered w-full" bind:value={p.vertexRegion} placeholder="global" /></label>
           </div>
         {/if}
-        {#if p.provider === "openai" || p.provider === "anthropic"}
+        {#if p.provider === "openai" || p.provider === "openai_responses" || p.provider === "anthropic"}
           <div class="divider text-xs opacity-50 my-2"><i class="fa-solid fa-plus-circle mr-1"></i>Extra Body & Headers（可选）</div>
           <p class="text-xs opacity-40 mb-2">额外请求体字段和自定义请求头，JSON 对象格式。会被展开合并到对应的 API 请求中。</p>
           <div class="cfg-field"><span class="cfg-label">Extra Body (JSON)</span>


### PR DESCRIPTION
### Motivation
- Provide a first-class upstream type for the OpenAI Responses API using the official TypeScript SDK while keeping the existing `openai` (compat/chat-completions) path unchanged.
- Allow projects to opt into the Responses API for multimodal and SDK-based features without breaking existing profiles or behaviour.

### Description
- Add new provider type `openai_responses` to `LLMConfig` parsing and validation in `src/core/config.ts` and accept it from config files via `provider: "openai_responses"`.
- Implement `callOpenAIResponses` in a new file `src/core/llm/openai-responses.ts` that adapts internal `ChatMessage[]` to the Responses API `input` format, supports multimodal `input_image`, `prefill`, `thinkingLevel` → `reasoning.effort`, `stop`, `max_output_tokens`, `extraBody`, `customHeaders`, and maps usage (including cached token details).
- Wire the new provider into runtime dispatch in `src/core/llm.ts` so `config.provider === "openai_responses"` calls the SDK-based function, while existing `openai` (compat) implementation remains unchanged.
- Update dashboard UI in `src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte` to present `openai (responses)` in the provider selector and to allow editing Extra Body / Headers for this provider.
- Add `openai` dependency entry in `package.json` to declare the official SDK requirement.

### Testing
- Ran `npm run test`; tests failed to complete in this environment because the `openai` package could not be installed, causing `ERR_MODULE_NOT_FOUND` for `src/core/llm/openai-responses.ts`, and the test run also surfaced several unrelated existing test failures in the repo.
- Attempted `npm i openai@^4.104.0` but the environment returned `403 Forbidden` preventing dependency installation and lockfile update, so SDK integration could not be validated by the CI tests here.
- Local static checks performed: Type additions, new file, and provider dispatch were compiled/added and committed, but runtime execution of the new SDK path requires successful installation of the `openai` package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c7411a008320907eb6154ecdab28)