### PR TITLE
Add OpenAI Responses request mode (stream/non_stream) with UI and streaming support

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -76,6 +76,8 @@ export interface LLMConfig {
      * 适用于某些 API 在出错时返回 200 但 content 包含错误信息的情况。
      */
     errorContentPatterns?: string[];
+    /** OpenAI Responses API 请求模式：stream / non_stream。仅 provider=openai_responses 时生效，默认 non_stream。 */
+    responsesRequestMode?: "stream" | "non_stream";
 }
 
 /** 相似度度量方法 */
@@ -1033,6 +1035,7 @@ function parseLLMProfile(raw: Record<string, unknown>): LLMConfig {
         errorContentPatterns: (Array.isArray(raw.error_content_patterns) && raw.error_content_patterns.length > 0)
             ? raw.error_content_patterns.map(String)
             : undefined,
+        responsesRequestMode: (str(raw.responses_request_mode) as "stream" | "non_stream" | undefined),
     };
 }
 
@@ -1131,6 +1134,7 @@ export function serializeConfigToObject(config: AppConfig): Record<string, unkno
         if (p.extraBody && Object.keys(p.extraBody).length > 0) entry.extra_body = p.extraBody;
         if (p.customHeaders && Object.keys(p.customHeaders).length > 0) entry.custom_headers = p.customHeaders;
         if (p.errorContentPatterns && p.errorContentPatterns.length > 0) entry.error_content_patterns = p.errorContentPatterns;
+        if (p.responsesRequestMode) entry.responses_request_mode = p.responsesRequestMode;
         if (p.supportsPrefill === false) entry.supports_prefill = false;
         if (p.pricing) {
             const pricing: Record<string, unknown> = {

--- a/src/core/llm/openai-responses.ts
+++ b/src/core/llm/openai-responses.ts
@@ -6,6 +6,20 @@ import OpenAI from "openai";
 import type { LLMConfig } from "../config.js";
 import type { ChatMessage, LLMResponse } from "./types.js";
 
+type ResponsesUsage = {
+    input_tokens?: number;
+    output_tokens?: number;
+    total_tokens?: number;
+    input_tokens_details?: {
+        cached_tokens?: number;
+    };
+};
+
+type ResponsesResult = {
+    output_text?: string;
+    usage?: ResponsesUsage;
+};
+
 export async function callOpenAIResponses(
     messages: ChatMessage[],
     config: LLMConfig,
@@ -42,6 +56,12 @@ export async function callOpenAIResponses(
             }
             return { role: m.role, content };
         }
+        if (m.role === "assistant") {
+            return {
+                role: m.role,
+                content: [{ type: "output_text", text: m.content }],
+            };
+        }
         return {
             role: m.role,
             content: [{ type: "input_text", text: m.content }],
@@ -51,26 +71,28 @@ export async function callOpenAIResponses(
     if (prefill) {
         input.push({
             role: "assistant",
-            content: [{ type: "input_text", text: prefill }],
+            content: [{ type: "output_text", text: prefill }],
         });
     }
 
-    const response = await client.responses.create(
-        {
-            model,
-            store: false,
-            ...(systemMessages.length > 0 ? { instructions: systemMessages.join("\n\n") } : {}),
-            input,
-            temperature,
-            max_output_tokens: maxTokens,
-            ...(thinkingLevel && thinkingLevel !== "none" ? { reasoning: { effort: thinkingLevel } } : {}),
-            ...(stop && stop.length > 0 ? { stop } : {}),
-            ...(config.extraBody ?? {}),
-        },
-        {
-            signal,
-        },
-    );
+    const requestBody = {
+        model,
+        store: false,
+        ...(systemMessages.length > 0 ? { instructions: systemMessages.join("\n\n") } : {}),
+        input,
+        temperature,
+        max_output_tokens: maxTokens,
+        ...(thinkingLevel && thinkingLevel !== "none" ? { reasoning: { effort: thinkingLevel } } : {}),
+        ...(stop && stop.length > 0 ? { stop } : {}),
+        ...(config.extraBody ?? {}),
+    };
+
+    const requestMode = config.responsesRequestMode ?? "non_stream";
+    const response = requestMode === "stream"
+        ? await collectResponseFromStream(
+            await client.responses.create({ ...requestBody, stream: true }, { signal }),
+        )
+        : await client.responses.create(requestBody, { signal }) as ResponsesResult;
 
     const content = response.output_text ?? "";
     if (!content) {
@@ -88,4 +110,28 @@ export async function callOpenAIResponses(
             }
             : undefined,
     };
+}
+
+async function collectResponseFromStream(stream: unknown): Promise<ResponsesResult> {
+    const asyncIterator = (stream as AsyncIterable<unknown>)?.[Symbol.asyncIterator];
+    if (!asyncIterator) {
+        throw new Error("OpenAI Responses stream mode did not return an async iterable");
+    }
+
+    let outputText = "";
+    let usage: ResponsesUsage | undefined;
+    for await (const event of stream as AsyncIterable<Record<string, unknown>>) {
+        if (event.type === "response.output_text.delta") {
+            outputText += typeof event.delta === "string" ? event.delta : "";
+        }
+        if (event.type === "response.completed") {
+            const completed = event.response as ResponsesResult | undefined;
+            if (completed?.output_text) {
+                outputText = completed.output_text;
+            }
+            usage = completed?.usage ?? usage;
+        }
+    }
+
+    return { output_text: outputText, usage };
 }

--- a/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
+++ b/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
@@ -117,6 +117,16 @@
               }}
             /><span>Prefill</span></label>
         </div>
+        {#if p.provider === "openai_responses"}
+          <div class="cfg-grid-2 mt-2">
+            <label class="cfg-field"><span class="cfg-label">Responses 请求模式</span>
+              <select class="select select-xs select-bordered w-full" bind:value={p.responsesRequestMode}>
+                <option value="non_stream">non_stream（默认）</option>
+                <option value="stream">stream（后台聚合完整输出）</option>
+              </select>
+            </label>
+          </div>
+        {/if}
         {#if p.provider === "google"}
           <div class="divider text-xs opacity-50 my-2"><i class="fa-brands fa-google mr-1"></i>Vertex AI 设置（可选）</div>
           <p class="text-xs opacity-40 mb-2">粘贴服务账号 JSON 密钥后自动启用 Vertex AI 模式。留空则使用 AI Studio（需填 API Key）。</p>


### PR DESCRIPTION
### Motivation
- Allow callers to choose how to call the OpenAI Responses API (stream vs non_stream) per LLM profile for better control over latency and aggregation.
- Ensure assistant messages and prefill content are encoded correctly for the Responses API by using `output_text` entries.
- Expose the request mode in the dashboard so operators can switch modes per `openai_responses` profile.

### Description
- Add `responsesRequestMode?: "stream" | "non_stream"` to `LLMConfig`, parse it in `parseLLMProfile`, and serialize it in `serializeConfigToObject` as `responses_request_mode`.
- Update `openai-responses.ts` to construct a single request body, respect `config.responsesRequestMode`, and call the Responses API either in non-streaming mode or with `stream: true` and aggregate events via a new `collectResponseFromStream` helper.
- Introduce `ResponsesUsage`/`ResponsesResult` types and map Responses API `usage` fields into the existing `LLMResponse.usage` shape, and throw on empty outputs.
- Encode existing assistant messages and the `prefill` value as `output_text` content entries when building the Responses `input`, and preserve `extraBody` and `customHeaders` behavior.
- Add a UI control in `LlmProfilesTab.svelte` that conditionally shows a `Responses 请求模式` select when `p.provider === "openai_responses"` to choose between `non_stream` and `stream`.

### Testing
- Ran TypeScript type check and project build (`tsc` / `pnpm build`) with no errors.
- Executed the repository unit test suite (`pnpm test`) and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d968d9c4832081ab10240d411891)