### PR TITLE
fix: 修复 QQ 发送动图表情包显示为静态图片的问题

### DIFF
--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -663,7 +663,7 @@ export class OneBotAdapter implements PlatformAdapter {
                 }
             }
             file = await this.normalizeOutgoingImageFile(file, {
-                rejectAnimatedSticker: true,
+                preserveAnimation: true,
                 resizeForQqSticker: true,
             });
         } else if (sticker && typeof sticker === "object") {
@@ -678,7 +678,7 @@ export class OneBotAdapter implements PlatformAdapter {
                 resolvedFile = this.mediaDownloader?.getExistingPath(resolvedFile) ?? resolvedFile;
             }
             resolvedFile = await this.normalizeOutgoingImageFile(resolvedFile, {
-                rejectAnimatedSticker: true,
+                preserveAnimation: true,
                 resizeForQqSticker: true,
             });
             file = { ...rec, file: resolvedFile };
@@ -688,26 +688,57 @@ export class OneBotAdapter implements PlatformAdapter {
             ? {
                 type: "photo",
                 file,
+                isSticker: true,
                 caption: typeof opts.caption === "string" ? opts.caption : undefined,
             }
             : {
                 ...(file as Record<string, unknown>),
                 type: "photo",
+                isSticker: true,
             };
         return this.sendMedia(chatId, payload, opts);
     }
 
-    private async normalizeOutgoingImageFile(file: unknown, options?: { rejectAnimatedSticker?: boolean; resizeForQqSticker?: boolean }): Promise<unknown> {
+    private async normalizeOutgoingImageFile(file: unknown, options?: { preserveAnimation?: boolean; resizeForQqSticker?: boolean }): Promise<unknown> {
         if (typeof file !== "string") return file;
 
         const resolvedPath = this.resolveFileReferenceToPath(file);
         if (!resolvedPath) return file;
 
         const lowerPath = resolvedPath.toLowerCase();
-        if (options?.rejectAnimatedSticker && (lowerPath.endsWith(".webm") || lowerPath.endsWith(".tgs"))) {
-            throw new Error(`sendSticker: 暂不支持将动态 TG 贴纸转发到 QQ (${path.basename(resolvedPath)})`);
+        const isAnimated = this.isAnimatedImagePath(resolvedPath);
+
+        if (options?.preserveAnimation && isAnimated) {
+            // 动图路径：webm/tgs → GIF，GIF 直接保留
+            let normalizedPath = resolvedPath;
+            if (lowerPath.endsWith(".webm") || lowerPath.endsWith(".tgs")) {
+                normalizedPath = this.convertToAnimatedGif(resolvedPath);
+            } else if (lowerPath.endsWith(".webp")) {
+                // .webp 后缀但实际是 GIF 的文件，重命名为 .gif 确保 NapCat 正确识别
+                const head = readFileSync(resolvedPath).subarray(0, 4);
+                if (head[0] === 0x47 && head[1] === 0x49 && head[2] === 0x46) {
+                    // 实际是 GIF，复制为 .gif 扩展名
+                    const stat = statSync(resolvedPath);
+                    const hash = createHash("sha1").update(`${resolvedPath}:${stat.size}:${stat.mtimeMs}:rename-gif`).digest("hex").slice(0, 16);
+                    const outDir = path.resolve(process.cwd(), "workspace", "Downloads", "other", "qq-converted");
+                    mkdirSync(outDir, { recursive: true });
+                    const outPath = path.join(outDir, `${path.basename(resolvedPath, path.extname(resolvedPath))}_${hash}.gif`);
+                    if (!existsSync(outPath)) {
+                        writeFileSync(outPath, readFileSync(resolvedPath));
+                    }
+                    normalizedPath = outPath;
+                } else {
+                    // 真正的 animated webp，转 GIF
+                    normalizedPath = this.convertToAnimatedGif(resolvedPath);
+                }
+            }
+            if (options?.resizeForQqSticker) {
+                normalizedPath = this.resizeStickerImageForQq(normalizedPath);
+            }
+            return normalizedPath;
         }
 
+        // 非动图路径（或未请求保留动画）：原逻辑
         const mimeType = this.inferImageMimeType(resolvedPath);
         let normalizedPath = resolvedPath;
         if (mimeType && mimeType !== "image/jpeg" && mimeType !== "image/png") {
@@ -721,6 +752,59 @@ export class OneBotAdapter implements PlatformAdapter {
             normalizedPath = this.resizeStickerImageForQq(normalizedPath);
         }
         return normalizedPath;
+    }
+
+    /** 判断文件是否为动图格式（GIF / webm / tgs / 扩展名不匹配但实际为 GIF 的 webp） */
+    private isAnimatedImagePath(filePath: string): boolean {
+        const ext = path.extname(filePath).toLowerCase();
+        if (ext === ".gif" || ext === ".webm" || ext === ".tgs") return true;
+        // .webp 文件可能实际是 GIF（QQ/NapCat 有时用 .webp 扩展名存 GIF）
+        // 或者是 animated webp（含 ANMF chunk）
+        if (ext === ".webp" && existsSync(filePath)) {
+            try {
+                const buf = readFileSync(filePath);
+                // 实际内容是 GIF？
+                if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46) return true; // "GIF"
+                // Animated WebP: RIFF header + WEBP + 检查 ANMF chunk
+                if (buf.length >= 12 && buf.toString("ascii", 0, 4) === "RIFF" && buf.toString("ascii", 8, 12) === "WEBP") {
+                    return buf.includes(Buffer.from("ANMF"));
+                }
+            } catch { /* ignore */ }
+        }
+        return false;
+    }
+
+    /** 将 webm/tgs/animated-webp 动图转为 GIF（带调色板优化） */
+    private convertToAnimatedGif(sourcePath: string): string {
+        const stat = statSync(sourcePath);
+        const hash = createHash("sha1")
+            .update(`${sourcePath}:${stat.size}:${stat.mtimeMs}:anim-gif`)
+            .digest("hex")
+            .slice(0, 16);
+        const outDir = path.resolve(process.cwd(), "workspace", "Downloads", "other", "qq-converted");
+        mkdirSync(outDir, { recursive: true });
+        const outPath = path.join(outDir, `${path.basename(sourcePath, path.extname(sourcePath))}_${hash}.gif`);
+        if (existsSync(outPath)) {
+            return outPath;
+        }
+        try {
+            execFileSync("ffmpeg", [
+                "-hide_banner", "-loglevel", "error",
+                "-i", sourcePath,
+                "-vf", "scale=200:-2:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse",
+                outPath,
+            ], {
+                timeout: 15000,
+                maxBuffer: 30 * 1024 * 1024,
+            });
+            return outPath;
+        } catch (err) {
+            log.warn("动图转 GIF 失败，回退原图", {
+                sourcePath,
+                error: String(err).slice(0, 200),
+            });
+            return sourcePath;
+        }
     }
 
     private resolveFileReferenceToPath(file: string): string | null {
@@ -800,27 +884,44 @@ export class OneBotAdapter implements PlatformAdapter {
 
     private resizeStickerImageForQq(sourcePath: string): string {
         const stat = statSync(sourcePath);
+        const isGif = sourcePath.toLowerCase().endsWith(".gif");
+        const suffix = isGif ? "sticker-anim-w200" : "sticker-w200";
         const hash = createHash("sha1")
-            .update(`${sourcePath}:${stat.size}:${stat.mtimeMs}:sticker-w200`)
+            .update(`${sourcePath}:${stat.size}:${stat.mtimeMs}:${suffix}`)
             .digest("hex")
             .slice(0, 16);
         const outDir = path.resolve(process.cwd(), "workspace", "Downloads", "other", "qq-converted");
         mkdirSync(outDir, { recursive: true });
-        const outPath = path.join(outDir, `${path.basename(sourcePath, path.extname(sourcePath))}_${hash}_w200.png`);
+        const outExt = isGif ? ".gif" : ".png";
+        const outPath = path.join(outDir, `${path.basename(sourcePath, path.extname(sourcePath))}_${hash}_w200${outExt}`);
         if (existsSync(outPath)) {
             return outPath;
         }
         try {
-            execFileSync("ffmpeg", [
-                "-hide_banner", "-loglevel", "error",
-                "-i", sourcePath,
-                "-vf", "scale=200:-2",
-                "-frames:v", "1",
-                outPath,
-            ], {
-                timeout: 10000,
-                maxBuffer: 20 * 1024 * 1024,
-            });
+            if (isGif) {
+                // 动画 GIF 缩放：保持帧，使用调色板优化
+                execFileSync("ffmpeg", [
+                    "-hide_banner", "-loglevel", "error",
+                    "-i", sourcePath,
+                    "-vf", "scale=200:-2:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse",
+                    outPath,
+                ], {
+                    timeout: 15000,
+                    maxBuffer: 30 * 1024 * 1024,
+                });
+            } else {
+                // 静态图片缩放
+                execFileSync("ffmpeg", [
+                    "-hide_banner", "-loglevel", "error",
+                    "-i", sourcePath,
+                    "-vf", "scale=200:-2",
+                    "-frames:v", "1",
+                    outPath,
+                ], {
+                    timeout: 10000,
+                    maxBuffer: 20 * 1024 * 1024,
+                });
+            }
             return outPath;
         } catch (err) {
             log.warn("贴纸缩放失败，回退原图", {
@@ -878,7 +979,11 @@ export class OneBotAdapter implements PlatformAdapter {
         const type = String(media.type ?? "");
         let file = media.file;
         if ((type === "photo" || type === "image") && typeof file === "string") {
-            file = await this.normalizeOutgoingImageFile(file);
+            // isSticker 时 sendSticker 已做过 normalize（含 preserveAnimation），跳过二次处理
+            // 非 sticker 发送也保留动图（QQ 原生支持 GIF）
+            if (!media.isSticker) {
+                file = await this.normalizeOutgoingImageFile(file, { preserveAnimation: true });
+            }
         }
         if (this.config.sendFileAsDataUrl === true && typeof file === "string") {
             const dataUrl = this.toDataUrlIfLocalFile(file);


### PR DESCRIPTION
## 问题

通过 OneBot/NapCat 发送动图表情包时，QQ 端只显示静态图片，动画丢失。

## 原因

QQ/NapCat 下载存储动图表情包时使用 `.webp` 扩展名，但文件实际内容是 GIF 格式（magic bytes 为 `GIF89a`）。原有代码的处理链路：

1. `isAnimatedImagePath()` 仅按扩展名判断（`.gif`/`.webm`/`.tgs`），无法识别 `.webp` 后缀的 GIF 文件
2. `normalizeOutgoingImageFile()` 将其当作静态 WebP 处理 → `ensureSupportedFormat()` 转为单帧 PNG
3. `buildOutgoingSegments()` 对 `sendSticker()` 已处理过的文件进行二次 normalize，再次触发格式转换
4. `resizeStickerImageForQq()` 固定输出 `.png` 并使用 `-frames:v 1`，丢弃所有动画帧

## 修复

- **文件头检测**：读取 magic bytes 判断真实格式，不再依赖扩展名；同时支持检测 animated WebP（ANMF chunk）
- **GIF 保留**：`.webp` 后缀但实际为 GIF 的文件复制为 `.gif`；`webm`/`tgs`/animated WebP 通过 ffmpeg 调色板优化转 GIF
- **避免二次处理**：`sendSticker` 的 payload 标记 `isSticker`，`buildOutgoingSegments` 跳过已处理的文件
- **动画感知缩放**：`resizeStickerImageForQq` 对 GIF 使用 palettegen/paletteuse 滤镜，保留全部帧
- **统一行为**：所有出站图片发送传入 `preserveAnimation: true`（QQ 原生支持 GIF）

## 验证

通过 NapCat WebSocket API 以三种格式（`data:image/gif;base64,…`、`base64://…`、`file://…`）发送 GIF 表情包，QQ 客户端均正常显示动画。
