### PR TITLE
feat(dashboard): show LLM profile key in log row

### DIFF
--- a/src/core/llm.ts
+++ b/src/core/llm.ts
@@ -51,6 +51,8 @@ export interface LLMCallEvent {
     maxTokens: number;
     /** provider */
     provider: string;
+    /** llm_profiles 中的 key（如 gemini-flash） */
+    profileName?: string;
     /** 消息摘要：每条消息的 role + content 前 200 字 + imageParts 信息 */
     messageSummaries: Array<{
         role: string;
@@ -342,7 +344,7 @@ async function callLLMSingleKey(
     }
     const releaseSlot = await rateLimiter.acquire(profileName);
     try {
-        return await _callLLMSingleKeyInner(messages, config, options);
+        return await _callLLMSingleKeyInner(messages, config, { ...options, profileName });
     } finally {
         releaseSlot();
     }
@@ -380,6 +382,7 @@ async function _callLLMSingleKeyInner(
             temperature,
             maxTokens,
             provider: config.provider ?? "openai",
+            profileName: options?.profileName,
             messageSummaries: summarizeMessages(messages),
             timestamp: new Date().toISOString(),
             extraBody: config.extraBody,

--- a/src/dashboard/event-bridge.ts
+++ b/src/dashboard/event-bridge.ts
@@ -27,6 +27,7 @@ export interface LLMLogEntry {
     temperature: number;
     maxTokens: number;
     provider: string;
+    profileName?: string;
     timestamp: string;
     messageSummaries: LLMCallEvent["messageSummaries"];
     contextManifest?: ContextManifest;
@@ -63,6 +64,7 @@ export class LLMLogBuffer {
             temperature: data.temperature,
             maxTokens: data.maxTokens,
             provider: data.provider,
+            profileName: data.profileName,
             timestamp: data.timestamp,
             messageSummaries: data.messageSummaries,
             contextManifest: data.contextManifest,

--- a/src/dashboard/ui/src/panels/LLMLogPanel.svelte
+++ b/src/dashboard/ui/src/panels/LLMLogPanel.svelte
@@ -475,7 +475,7 @@
             </span>
             <span class="llm-row-time">{time}</span>
             <span class="badge badge-xs {callerBadge}">{entry.caller}</span>
-            <span class="llm-row-model">{entry.model}</span>
+            <span class="llm-row-model" title="{entry.model}">{entry.profileName ?? entry.model}</span>
             <span class="llm-row-meta"
               ><i class="fa-solid fa-envelope fa-xs"></i>{msgCount}{hasImages ? " " : ""}{#if hasImages}<i class="fa-solid fa-image fa-xs"></i>{/if}</span
             >


### PR DESCRIPTION
In LLM Log panel rows, the column previously showed only the raw model name (e.g. 'gpt-5'), which is ambiguous when the same model is reached through different llm_profiles entries (different provider/base_url/key).

Expose the auto-detected llm_profiles key (profileName) end-to-end:

- LLMCallEvent / LLMLogEntry: add optional profileName field
- callLLM: pass detected profileName into _callLLMSingleKeyInner via options
- event-bridge: copy profileName into log entry
- LLMLogPanel.svelte: display profileName if present, fall back to model; title shows the underlying model name on hover

Requested in LLM Meta chat by @clover-yan.