### PR TITLE
feat(mcp): MCP server 配置 ${VAR} 环境变量插值

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -423,7 +423,14 @@ export interface EnvironmentVariable {
     scope: "both" | "host" | "sandbox";
 }
 
-/** MCP Server 预配置（config.yaml 中声明，Sandbox 启动时自动连接） */
+/**
+ * MCP Server 预配置（config.yaml 中声明，Sandbox 启动时自动连接）。
+ *
+ * command / args / env / url / headers 的字符串值支持 `${VAR}` 环境变量插值——
+ * VAR 取自 env_vars 注入器（scope=host/both，写入 host 进程 process.env），
+ * 在连接/请求时解析，密钥不会以明文落盘到 mcp-connections.json。
+ * 例：headers: { Authorization: "Bearer ${ZAI_API_KEY}" }
+ */
 export interface McpServerPreConfig {
     /** 显示名称（也是 tool 命名空间） */
     name: string;

--- a/src/sandbox/modules/mcp-bridge/index.ts
+++ b/src/sandbox/modules/mcp-bridge/index.ts
@@ -159,6 +159,20 @@ function cloneServerList(list: McpServerInfo[]): McpServerInfo[] {
 
 // ─── 配置 / transport 判定 ───
 
+/**
+ * 把字符串里的 `${VAR}` 占位符替换为 `process.env[VAR]`。
+ *
+ * VAR 由 cgm 的环境变量注入器（buildEnvPlan，scope=host/both）写入 host 进程的 process.env，
+ * 而 MCP 预配置连接 / 工具调用都跑在 host 进程，所以这里能取到。
+ * 在请求/连接时（而非解析时）解析：
+ *   - 持久化的 mcp-connections.json 仍只保存字面量 `${VAR}`，密钥不落盘；
+ *   - dashboard 热改 env 后，下一次请求即生效，无需重连。
+ * 未定义的变量替换为空串；非 `${...}` 文本原样保留。
+ */
+function interpolateEnv(value: string): string {
+    return value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_match, name: string) => process.env[name] ?? "");
+}
+
 function getTransportKind(config: McpServerConfig): McpTransportKind {
     if (config.transport) return config.transport;
     return config.url ? "streamable-http" : "stdio";
@@ -282,8 +296,12 @@ function buildHttpHeaders(
 ): Record<string, string> {
     const headers: Record<string, string> = {
         Accept: options?.accept ?? HTTP_ACCEPT,
-        ...(conn.config.headers ?? {}),
     };
+    // config.headers 的值支持 `${VAR}` 环境变量插值（如 Authorization: "Bearer ${ZAI_API_KEY}"）。
+    // 放在 Accept 之后写入，保留"配置项可覆盖 Accept"的原有语义。
+    for (const [key, value] of Object.entries(conn.config.headers ?? {})) {
+        headers[key] = interpolateEnv(value);
+    }
     if (options?.includeContentType !== false) {
         headers["Content-Type"] = "application/json";
     }
@@ -434,8 +452,13 @@ async function extractHttpResponseResult(conn: McpConnection, response: Response
     return result.value;
 }
 
+/** 解析 streamable-http 目标 URL，支持 `${VAR}` 环境变量插值。 */
+function resolveHttpUrl(conn: McpConnection): string {
+    return interpolateEnv(conn.config.url!);
+}
+
 async function postHttpMessage(conn: McpConnection, payload: JsonRpcMessage, options?: { skipSessionId?: boolean }): Promise<Response> {
-    return fetch(conn.config.url!, {
+    return fetch(resolveHttpUrl(conn), {
         method: "POST",
         headers: buildHttpHeaders(conn, { skipSessionId: options?.skipSessionId }),
         body: JSON.stringify(payload),
@@ -518,7 +541,7 @@ async function initializeHttpConnection(conn: McpConnection): Promise<void> {
 async function closeHttpConnection(conn: McpConnection): Promise<void> {
     if (!conn.sessionId) return;
     try {
-        const response = await fetch(conn.config.url!, {
+        const response = await fetch(resolveHttpUrl(conn), {
             method: "DELETE",
             headers: buildHttpHeaders(conn, { includeContentType: false, accept: "application/json" }),
         });
@@ -568,9 +591,12 @@ async function connectServer(config: McpServerConfig): Promise<McpConnection> {
 
     if (conn.transportKind === "stdio") {
         const env: Record<string, string> = { ...(process.env as Record<string, string>) };
-        if (config.env) Object.assign(env, config.env);
+        // command / args / env 的值同样支持 `${VAR}` 环境变量插值。
+        if (config.env) {
+            for (const [key, value] of Object.entries(config.env)) env[key] = interpolateEnv(value);
+        }
 
-        const child = spawn(config.command!, config.args ?? [], {
+        const child = spawn(interpolateEnv(config.command!), (config.args ?? []).map(interpolateEnv), {
             stdio: ["pipe", "pipe", "pipe"],
             env,
         });

--- a/tests/mcp-bridge.test.ts
+++ b/tests/mcp-bridge.test.ts
@@ -401,4 +401,78 @@ describe("mcp-bridge Streamable HTTP", () => {
             });
         }
     });
+
+    it("interpolates ${VAR} env placeholders in headers at request time (literal kept on disk)", async () => {
+        initMcpBridge({ persistPath: "" });
+        process.env.ZAI_TEST_KEY = "secret-zai-token";
+
+        let serverUrl = "";
+        const seenAuthHeaders: string[] = [];
+
+        const server = createServer(async (req, res) => {
+            const authHeader = req.headers.authorization;
+            if (authHeader) seenAuthHeaders.push(String(authHeader));
+
+            if (req.method === "DELETE") { res.writeHead(204); res.end(); return; }
+            if (req.method !== "POST") { res.writeHead(405); res.end(); return; }
+
+            const body = await readBody(req);
+            const msg = JSON.parse(body) as { id?: number; method?: string };
+
+            if (msg.method === "initialize") {
+                writeJson(res, {
+                    jsonrpc: "2.0", id: msg.id,
+                    result: { protocolVersion: "2025-03-26", capabilities: { tools: {} }, serverInfo: { name: "zai", version: "1.0.0" } },
+                }, { "Mcp-Session-Id": "sess-zai" });
+                return;
+            }
+            if (msg.method === "notifications/initialized") { res.writeHead(202); res.end(); return; }
+            if (msg.method === "tools/list") {
+                writeJson(res, { jsonrpc: "2.0", id: msg.id, result: { tools: [{ name: "webSearchPrime", description: "search" }] } });
+                return;
+            }
+            if (msg.method === "tools/call") {
+                writeJson(res, { jsonrpc: "2.0", id: msg.id, result: { content: [{ type: "text", text: "ok" }] } });
+                return;
+            }
+            res.writeHead(404); res.end();
+        });
+
+        await new Promise<void>((resolve) => {
+            server.listen(0, "127.0.0.1", () => {
+                const address = server.address();
+                if (!address || typeof address === "string") throw new Error("Failed to bind mock MCP server");
+                serverUrl = `http://127.0.0.1:${address.port}/mcp`;
+                resolve();
+            });
+        });
+
+        try {
+            await mcpBridge.connect({
+                name: "zai",
+                transport: "streamable-http",
+                url: serverUrl,
+                headers: { Authorization: "Bearer ${ZAI_TEST_KEY}" },
+            });
+            await mcpBridge.call("zai", "webSearchPrime", { query: "x" });
+
+            // The server must have received the RESOLVED token on every request (init, list, call).
+            assert.ok(seenAuthHeaders.length > 0, "server should have seen Authorization headers");
+            assert.ok(
+                seenAuthHeaders.every((header) => header === "Bearer secret-zai-token"),
+                `all auth headers should be resolved; saw ${JSON.stringify(seenAuthHeaders)}`,
+            );
+
+            // The persisted/exported config must keep the LITERAL ${VAR}, never the resolved secret.
+            const configs = getConnectionConfigs();
+            assert.equal(configs[0]?.headers?.Authorization, "Bearer ${ZAI_TEST_KEY}");
+            assert.ok(!JSON.stringify(configs).includes("secret-zai-token"), "secret must not be persisted in config");
+        } finally {
+            delete process.env.ZAI_TEST_KEY;
+            await disconnectAll();
+            await new Promise<void>((resolve, reject) => {
+                server.close((err) => (err ? reject(err) : resolve()));
+            });
+        }
+    });
 });


### PR DESCRIPTION
MCP server 配置里的 `${VAR}` 占位符在连接时按环境变量插值,避免明文写密钥。

🤖 Generated with [Claude Code](https://claude.com/claude-code)