### PR TITLE
feat(llm): per-profile reply_prompt（仅回复路径,贴 task prompt 末尾）

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -78,6 +78,11 @@ export interface LLMConfig {
     errorContentPatterns?: string[];
     /** OpenAI Responses API 请求模式：stream / non_stream。仅 provider=openai_responses 时生效，默认 non_stream。 */
     responsesRequestMode?: "stream" | "non_stream";
+    /**
+     * 仅在「生成回复」时（session/executor reply 路径）注入的额外提示词，贴在 task prompt 最末尾（recency 最高，紧贴生成）。
+     * 不影响 memory / meta / 决策路由等其它用途；system prompt 与 persona 均不改动。
+     */
+    replyPrompt?: string;
 }
 
 /** 相似度度量方法 */
@@ -1109,6 +1114,7 @@ function parseLLMProfile(raw: Record<string, unknown>): LLMConfig {
             ? raw.error_content_patterns.map(String)
             : undefined,
         responsesRequestMode: (str(raw.responses_request_mode) as "stream" | "non_stream" | undefined),
+        replyPrompt: str(raw.reply_prompt),
     };
 }
 
@@ -1217,6 +1223,7 @@ export function serializeConfigToObject(config: AppConfig): Record<string, unkno
         if (p.customHeaders && Object.keys(p.customHeaders).length > 0) entry.custom_headers = p.customHeaders;
         if (p.errorContentPatterns && p.errorContentPatterns.length > 0) entry.error_content_patterns = p.errorContentPatterns;
         if (p.responsesRequestMode) entry.responses_request_mode = p.responsesRequestMode;
+        if (p.replyPrompt) entry.reply_prompt = p.replyPrompt;
         if (p.supportsPrefill === false) entry.supports_prefill = false;
         if (p.pricing) {
             const pricing: Record<string, unknown> = {

--- a/src/core/llm.ts
+++ b/src/core/llm.ts
@@ -133,6 +133,12 @@ export interface LLMCallOptions {
     prefill?: string;
     /** Stop sequences — LLM 遇到这些字符串时停止生成 */
     stop?: string[];
+    /**
+     * 应用当前 profile 的 per-profile 补充提示词（LLMConfig.replyPrompt）：贴到最后一条 user 消息末尾
+     * （recency 最高，紧贴生成）。在 callLLM 入口按"实际选中的 profile"应用，使 fallback 切换 profile 时
+     * 用的是该 profile 自己的 replyPrompt，而非固定的 profile[0]。仅 reply 路径（session-runner）开启。
+     */
+    applyReplyPrompt?: boolean;
     /** 请求超时（毫秒）。来自 llmRouting.timeouts[component]，未设置则使用默认 60000 */
     timeoutMs?: number;
     /** Profile 名称（用于限速器按 profile 限速） */
@@ -249,11 +255,30 @@ function isAuthError(err: unknown): boolean {
  * @param options - 可选的调用参数覆盖
  * @returns LLM 响应（含生成文本和 token 用量）
  */
+/** 把 replyPrompt 追加到最后一条字符串内容的 user 消息末尾，返回新数组（不修改入参）。 */
+function appendReplyPrompt(messages: ChatMessage[], replyPrompt: string): ChatMessage[] {
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const m = messages[i];
+        if (m.role === "user" && typeof m.content === "string") {
+            const copy = messages.slice();
+            copy[i] = { ...m, content: m.content ? `${m.content}\n\n${replyPrompt}` : replyPrompt };
+            return copy;
+        }
+    }
+    return messages;
+}
+
 export async function callLLM(
     messages: ChatMessage[],
     config: LLMConfig,
     options?: LLMCallOptions
 ): Promise<LLMResponse> {
+    // ── per-profile replyPrompt：按实际选中的 profile 追加到最后一条 user 消息（不改原数组） ──
+    // 放在 callLLM 入口，使 fallback 选中 configs[i] 时用的是 configs[i] 自己的 replyPrompt。
+    if (options?.applyReplyPrompt && config.replyPrompt) {
+        messages = appendReplyPrompt(messages, config.replyPrompt);
+    }
+
     // ── Pool 模式：委托给 callLLMWithPool ──
     if (config.pool && config.pool.members.length > 0) {
         return callLLMWithPool(messages, config, options);

--- a/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
+++ b/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
@@ -236,6 +236,21 @@
             }}
           />
         </div>
+        <div class="divider text-xs opacity-50 my-2"><i class="fa-solid fa-comment-dots mr-1"></i>回复提示词（可选）</div>
+        <p class="text-xs opacity-40 mb-2">仅在生成回复时追加到 prompt 末尾的补充提示词（如微调语气、格式）；不改动 system prompt / persona，留空则不注入。</p>
+        <div class="cfg-field">
+          <span class="cfg-label">回复提示词 (reply_prompt)</span>
+          <textarea
+            class="textarea textarea-xs textarea-bordered w-full font-mono text-xs"
+            rows="4"
+            placeholder="（可选）仅在生成回复时附加的提示词……"
+            value={p.replyPrompt ?? ""}
+            on:input={(e) => {
+              p.replyPrompt = e.target.value || undefined;
+              config = config;
+            }}
+          ></textarea>
+        </div>
         <div class="divider text-xs opacity-50 my-2"><i class="fa-solid fa-coins mr-1"></i>Pricing（可选）</div>
         <p class="text-xs opacity-40 mb-2">每百万 token 的价格（美元），用于 token 消耗统计。留空则不计费。</p>
         <div class="cfg-grid-2">

--- a/src/sandbox/session-runner.ts
+++ b/src/sandbox/session-runner.ts
@@ -568,6 +568,8 @@ export async function runCodeActSession(
         try {
             llmResponse = await callLLMWithFallback(messages, configs, {
                 caller: "session-runner",
+                // reply 路径：让实际选中的 profile 追加自己的 replyPrompt（fallback 时不会错用 profile[0] 的）。
+                applyReplyPrompt: true,
                 ...(prefill ? { prefill } : {}),
                 ...(stopSequences ? { stop: stopSequences } : {}),
                 ...(contextManifest ? { contextManifest } : {}),

--- a/src/subagent/code-act-executor.ts
+++ b/src/subagent/code-act-executor.ts
@@ -794,6 +794,11 @@ export class CodeActExecutor {
             taskPrompt = taskPromptParts.join("\n\n");
         }
 
+        // 仅回复生成时注入：当前 session 主模型的 per-model 补充提示词（贴 task prompt 末尾，recency 最高，紧贴生成）。
+        // 不改 system prompt / persona；只影响 reply 路径。
+        const replyBoost = resolveComponentProfiles("session")[0]?.replyPrompt;
+        if (replyBoost) taskPrompt = (taskPrompt ? taskPrompt + "\n\n" : "") + replyBoost;
+
         // ═══ Fix 2: 构建 messages 时注入历史 session 上下文 ═══
         const messages: ChatMessage[] = [
             { role: "system", content: systemPrompt, cacheBreakpoint: true },

--- a/src/subagent/code-act-executor.ts
+++ b/src/subagent/code-act-executor.ts
@@ -794,10 +794,8 @@ export class CodeActExecutor {
             taskPrompt = taskPromptParts.join("\n\n");
         }
 
-        // 仅回复生成时注入：当前 session 主模型的 per-model 补充提示词（贴 task prompt 末尾，recency 最高，紧贴生成）。
-        // 不改 system prompt / persona；只影响 reply 路径。
-        const replyBoost = resolveComponentProfiles("session")[0]?.replyPrompt;
-        if (replyBoost) taskPrompt = (taskPrompt ? taskPrompt + "\n\n" : "") + replyBoost;
+        // per-profile replyPrompt 的注入已下沉到 LLM 调用层（session-runner → callLLM applyReplyPrompt），
+        // 按实际选中的 profile 在调用时追加，fallback 切换 profile 时也能用对自己的 replyPrompt。
 
         // ═══ Fix 2: 构建 messages 时注入历史 session 上下文 ═══
         const messages: ChatMessage[] = [

--- a/tests/reply-prompt.test.ts
+++ b/tests/reply-prompt.test.ts
@@ -1,0 +1,94 @@
+/**
+ * reply-prompt.test.ts — per-profile reply_prompt 解析 / 路由查找 / 序列化往返
+ *
+ * 覆盖 commit de801d0 的数据契约：
+ *   - config 解析 `reply_prompt` → LLMConfig.replyPrompt
+ *   - executor 用 resolveComponentProfiles("session")[0]?.replyPrompt 读取该值（这里复刻同一查找）
+ *   - 空串不落成假值；未配置则 undefined（executor 的 `if (replyBoost)` 据此跳过注入）
+ *   - serializeConfigToObject 往返：有值回写 reply_prompt、无值不写键
+ */
+
+import { after, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    clearConfigCache,
+    loadConfig,
+    resolveComponentProfiles,
+    serializeConfigToObject,
+} from "../src/core/config.js";
+
+const tempDirs: string[] = [];
+
+function writeConfig(lines: string[]): string {
+    const dir = join(tmpdir(), `reply-prompt-${randomUUID()}`);
+    mkdirSync(dir, { recursive: true });
+    tempDirs.push(dir);
+    const p = join(dir, "config.yaml");
+    writeFileSync(p, lines.join("\n"));
+    return p;
+}
+
+const REPLY_TEXT = "保持简短口语，别用书面腔。";
+
+/** 一份带 replier(有 reply_prompt) + plain(无) 的最小配置，session 路由到 replier。 */
+function baseConfigLines(replyPromptLine?: string): string[] {
+    return [
+        "llm_profiles:",
+        "  replier:",
+        "    provider: openai",
+        "    base_url: https://example.test/v1",
+        "    api_key: x",
+        "    model: test-model",
+        ...(replyPromptLine ? [`    ${replyPromptLine}`] : []),
+        "  plain:",
+        "    provider: openai",
+        "    base_url: https://example.test/v1",
+        "    api_key: x",
+        "    model: test-model",
+        "llm_routing:",
+        "  session: replier",
+    ];
+}
+
+after(() => {
+    clearConfigCache();
+    for (const d of tempDirs) if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("reply_prompt 配置", () => {
+    it("session profile 解析出 replyPrompt（executor 据此在 task prompt 末尾注入）", () => {
+        clearConfigCache();
+        const cfg = loadConfig(writeConfig(baseConfigLines(`reply_prompt: "${REPLY_TEXT}"`)));
+        // executor 实际用的查找：resolveComponentProfiles("session")[0]?.replyPrompt
+        const sessionProfile = resolveComponentProfiles("session", cfg)[0];
+        assert.equal(sessionProfile.replyPrompt, REPLY_TEXT);
+    });
+
+    it("未配置 reply_prompt 的 profile → replyPrompt 为 undefined（注入被跳过）", () => {
+        clearConfigCache();
+        const cfg = loadConfig(writeConfig(baseConfigLines()));
+        assert.equal(resolveComponentProfiles("session", cfg)[0].replyPrompt, undefined);
+        assert.equal(cfg.llmProfiles.plain.replyPrompt, undefined);
+    });
+
+    it("空串 reply_prompt 归一为 undefined（不会注入一段空提示）", () => {
+        clearConfigCache();
+        const cfg = loadConfig(writeConfig(baseConfigLines(`reply_prompt: ""`)));
+        assert.equal(cfg.llmProfiles.replier.replyPrompt, undefined);
+    });
+
+    it("序列化往返：有值回写 reply_prompt、无值不写该键", () => {
+        clearConfigCache();
+        const cfg = loadConfig(writeConfig(baseConfigLines(`reply_prompt: "${REPLY_TEXT}"`)));
+        const obj = serializeConfigToObject(cfg) as { llm_profiles: Record<string, any> };
+        assert.equal(obj.llm_profiles.replier.reply_prompt, REPLY_TEXT);
+        assert.ok(
+            !("reply_prompt" in obj.llm_profiles.plain),
+            "无 reply_prompt 的 profile 不应序列化出该键",
+        );
+    });
+});


### PR DESCRIPTION
每个 LLM profile 可配 `reply_prompt`,仅在回复生成时注入(recency 最高,紧贴生成),不改 system/persona。注入下沉到 LLM 调用层,fallback 切换 profile 时用的是该 profile 自己的 replyPrompt。

🤖 Generated with [Claude Code](https://claude.com/claude-code)