### PR TITLE
fix(tasks): 对账泄漏的 dispatched-task 终态;interrupted→SKIPPED

### DIFF
--- a/src/main-agent/global-state.ts
+++ b/src/main-agent/global-state.ts
@@ -385,6 +385,7 @@ export class GlobalState {
         this.markDirty();
         // 终态立即落盘：否则 30s 自动保存窗口内若进程重启，这次 COMPLETED/ERROR 写入会丢失，
         // 任务永远停留在 RUNNING（见 reconcileLeakedDispatchedTasks 的启动对账兜底）。
+        // 注意：这是一条有意的持久化契约（tests/s6-global-state #10 同步读校验），不可改为异步去抖。
         if (isTerminal) {
             this.save();
         }

--- a/src/main-agent/global-state.ts
+++ b/src/main-agent/global-state.ts
@@ -48,6 +48,14 @@ const DEFAULT_CONFIG: GlobalStateConfig = {
 const MAX_SESSION_DIGESTS = 30;
 const MAX_DISPATCHED_SUBAGENT_TASKS = 500;
 
+/** 派发任务的终态集合：进入终态即视为不可逆，立即落盘并补全 completedAt */
+const TERMINAL_TASK_STATUSES: ReadonlySet<DispatchedSubagentTaskRecord["status"]> = new Set([
+    "COMPLETED",
+    "ERROR",
+    "SKIPPED",
+    "TIMEOUT",
+]);
+
 /**
  * GlobalState — 主 Agent 全局状态管理器
  */
@@ -60,6 +68,14 @@ export class GlobalState {
     constructor(config?: Partial<GlobalStateConfig>) {
         this.config = { ...DEFAULT_CONFIG, ...config };
         this.state = this.load();
+
+        // 启动对账：上次进程退出时仍在飞行（RUNNING/PENDING）的派发任务，其执行进程
+        // 已随重启消失，不可能再自行收尾 → 标记为 TIMEOUT，避免永久泄漏为 RUNNING。
+        const reconciled = this.reconcileLeakedDispatchedTasks();
+        if (reconciled > 0) {
+            log.info("启动对账：将中断的派发任务标记为 TIMEOUT", { count: reconciled });
+            this.save();
+        }
 
         // 自动保存
         if (this.config.autoSaveInterval > 0) {
@@ -352,13 +368,26 @@ export class GlobalState {
         if (index === -1) {
             return null;
         }
+        const now = new Date().toISOString();
+        const isTerminal = patch.status != null && TERMINAL_TASK_STATUSES.has(patch.status);
         const updated: DispatchedSubagentTaskRecord = {
             ...this.state.dispatchedSubagentTasks[index],
             ...patch,
-            updatedAt: new Date().toISOString(),
+            updatedAt: now,
         };
+        // 进入终态时补全 completedAt（dashboard 展示 + 启动对账依赖它）
+        if (isTerminal && updated.completedAt == null) {
+            updated.completedAt = now;
+        }
         this.state.dispatchedSubagentTasks.splice(index, 1, updated);
+        // 始终先置脏：若终态的立即 save() 因 writeFileSync 失败而未清脏，
+        // 30s 自动保存 / dispose() 仍会重试落盘，不会永久丢失这次写入。
         this.markDirty();
+        // 终态立即落盘：否则 30s 自动保存窗口内若进程重启，这次 COMPLETED/ERROR 写入会丢失，
+        // 任务永远停留在 RUNNING（见 reconcileLeakedDispatchedTasks 的启动对账兜底）。
+        if (isTerminal) {
+            this.save();
+        }
         return { ...updated };
     }
 
@@ -445,6 +474,26 @@ export class GlobalState {
 
     private markDirty(): void {
         this.dirty = true;
+    }
+
+    /**
+     * 启动对账：把残留在 RUNNING/PENDING 的派发任务标记为 TIMEOUT（中断）。
+     * 返回被对账的任务数。仅在 load() 之后调用一次。
+     */
+    private reconcileLeakedDispatchedTasks(): number {
+        const now = new Date().toISOString();
+        const note = "reconciled on startup: process exited mid-flight";
+        let count = 0;
+        for (const task of this.state.dispatchedSubagentTasks) {
+            if (task.status === "RUNNING" || task.status === "PENDING") {
+                task.status = "TIMEOUT";
+                task.completedAt = task.completedAt ?? now;
+                task.error = task.error ? `${task.error}; ${note}` : note;
+                task.updatedAt = now;
+                count++;
+            }
+        }
+        return count;
     }
 
     private load(): MainAgentGlobalState {

--- a/src/subagent/code-act-executor.ts
+++ b/src/subagent/code-act-executor.ts
@@ -397,6 +397,19 @@ function formatExecutionRecordForCompact(rec: SessionExecutionRecord): string | 
 }
 
 /**
+ * session endReason → 派发任务终态映射：
+ *   - error       → ERROR
+ *   - interrupted → SKIPPED（被新消息/用户打断，是主动让路，非失败，不应误记 COMPLETED）
+ *   - 其余（end_turn / max_turns）→ COMPLETED
+ * 注意：TIMEOUT 不在此产生——它只由 GlobalState 启动对账（进程中途退出残留 RUNNING）补写。
+ */
+export function endReasonToTaskStatus(endReason: string | undefined): SubagentCallback["status"] {
+    return endReason === "error" ? "ERROR"
+        : endReason === "interrupted" ? "SKIPPED"
+            : "COMPLETED";
+}
+
+/**
  * CodeActExecutor — per-group CodeAct 执行器
  *
  * 注意：Sandbox 实例由 SandboxPool 管理，此处只持有引用。
@@ -936,14 +949,15 @@ export class CodeActExecutor {
         });
 
         // 5. 构建 callback
-        const isError = sessionResult.endReason === "error";
+        // endReason → 终态映射（见 endReasonToTaskStatus）。
+        const status: SubagentCallback["status"] = endReasonToTaskStatus(sessionResult.endReason);
         const callback: SubagentCallback = {
             taskId: task.taskId,
             chatId: this.chatId,
             chatTitle: ctx.chatTitle ?? ctx.groupModel?.chatTitle,
             isDirectMessage: ctx.isDirectMessage,
             executionType: "CODEACT",
-            status: isError ? "ERROR" : "COMPLETED",
+            status,
             summary: thinkingTranscript,
             replyContent: sessionResult.turns
                 .filter((t: any) => t.role === "assistant" && t.content)

--- a/tests/end-reason-status.test.ts
+++ b/tests/end-reason-status.test.ts
@@ -1,0 +1,40 @@
+/**
+ * end-reason-status.test.ts — session endReason → 派发任务终态映射
+ *
+ * 覆盖 commit cb84af9 的执行器侧映射：interrupted 是「让路」而非失败，必须落 SKIPPED，
+ * 不能被误记为 COMPLETED；error→ERROR；正常收尾→COMPLETED。
+ * （TIMEOUT 由 GlobalState 启动对账补写，不在此函数产生——见 s6-global-state.test.ts。）
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { endReasonToTaskStatus } from "../src/subagent/code-act-executor.js";
+
+describe("endReasonToTaskStatus", () => {
+    it("interrupted → SKIPPED（被新消息/用户打断，主动让路非失败）", () => {
+        assert.equal(endReasonToTaskStatus("interrupted"), "SKIPPED");
+    });
+
+    it("error → ERROR", () => {
+        assert.equal(endReasonToTaskStatus("error"), "ERROR");
+    });
+
+    it("end_turn → COMPLETED（正常收尾）", () => {
+        assert.equal(endReasonToTaskStatus("end_turn"), "COMPLETED");
+    });
+
+    it("max_turns → COMPLETED（跑满轮数也算完成，非失败）", () => {
+        assert.equal(endReasonToTaskStatus("max_turns"), "COMPLETED");
+    });
+
+    it("undefined / 未知 endReason → COMPLETED（兜底不误判为失败）", () => {
+        assert.equal(endReasonToTaskStatus(undefined), "COMPLETED");
+        assert.equal(endReasonToTaskStatus("something-else"), "COMPLETED");
+    });
+
+    it("永不产出 TIMEOUT（TIMEOUT 仅由启动对账补写）", () => {
+        for (const r of ["interrupted", "error", "end_turn", "max_turns", undefined]) {
+            assert.notEqual(endReasonToTaskStatus(r), "TIMEOUT");
+        }
+    });
+});

--- a/tests/s6-global-state.test.ts
+++ b/tests/s6-global-state.test.ts
@@ -234,4 +234,70 @@ describe("S6: Global State", () => {
         assert.equal(gs.getSchedulerEvents("chat-1")[0].id, cron.id);
         gs.dispose();
     });
+
+    it("#10 终态更新立即落盘（即使 autosave 关闭）", () => {
+        const dir = tempDir();
+        const path = join(dir, "s.json");
+        // autoSaveInterval: 0 → 仅终态的立即 save() 能把状态写到磁盘
+        const gs1 = new GlobalState({ filePath: path, autoSaveInterval: 0 });
+        gs1.recordDispatchedSubagentTask({
+            taskId: "task-1",
+            chatId: "telegram:1",
+            contentDirection: "reply",
+            createdAt: new Date().toISOString(),
+        });
+        const updated = gs1.updateDispatchedSubagentTask("task-1", { status: "COMPLETED" });
+        assert.equal(updated?.status, "COMPLETED");
+        assert.ok(updated?.completedAt, "终态应自动补全 completedAt");
+        // 故意不调用 save()/dispose() —— 验证终态写入已经落盘
+        const gs2 = new GlobalState({ filePath: path, autoSaveInterval: 0 });
+        const reloaded = gs2.getDispatchedSubagentTask("task-1");
+        assert.equal(reloaded?.status, "COMPLETED");
+        assert.ok(reloaded?.completedAt);
+        gs1.dispose();
+        gs2.dispose();
+    });
+
+    it("#11 启动对账：残留 RUNNING/PENDING 任务被标记为 TIMEOUT", () => {
+        const dir = tempDir();
+        const path = join(dir, "s.json");
+        const gs1 = new GlobalState({ filePath: path, autoSaveInterval: 0 });
+        // RUNNING 任务（执行中崩溃）
+        gs1.recordDispatchedSubagentTask({
+            taskId: "running-1",
+            chatId: "telegram:1",
+            contentDirection: "reply",
+            createdAt: new Date().toISOString(),
+        });
+        gs1.updateDispatchedSubagentTask("running-1", { status: "RUNNING" });
+        // PENDING 任务（入队未执行就崩溃）
+        gs1.recordDispatchedSubagentTask({
+            taskId: "pending-1",
+            chatId: "telegram:1",
+            contentDirection: "reply",
+            createdAt: new Date().toISOString(),
+        });
+        // 已完成任务不应被对账
+        gs1.recordDispatchedSubagentTask({
+            taskId: "done-1",
+            chatId: "telegram:1",
+            contentDirection: "reply",
+            createdAt: new Date().toISOString(),
+        });
+        gs1.updateDispatchedSubagentTask("done-1", { status: "COMPLETED" });
+        gs1.save();
+        gs1.dispose();
+
+        const gs2 = new GlobalState({ filePath: path, autoSaveInterval: 0 });
+        const running = gs2.getDispatchedSubagentTask("running-1");
+        const pending = gs2.getDispatchedSubagentTask("pending-1");
+        const done = gs2.getDispatchedSubagentTask("done-1");
+        assert.equal(running?.status, "TIMEOUT");
+        assert.ok(running?.completedAt);
+        assert.match(running?.error ?? "", /process exited mid-flight/);
+        assert.equal(pending?.status, "TIMEOUT");
+        assert.match(pending?.error ?? "", /process exited mid-flight/);
+        assert.equal(done?.status, "COMPLETED", "已完成任务不应被对账改写");
+        gs2.dispose();
+    });
 });


### PR DESCRIPTION
修复派发任务终态:进程中途退出残留 RUNNING 由 GlobalState 启动对账补写;`interrupted`(被新消息/用户打断)是主动让路,落 SKIPPED 而非误记 COMPLETED。

🤖 Generated with [Claude Code](https://claude.com/claude-code)