### PR TITLE
feat(triage): 剥离 triage reason 里预写的成句金句

### DIFF
--- a/src/context-engine/providers/meta-providers.ts
+++ b/src/context-engine/providers/meta-providers.ts
@@ -11,6 +11,7 @@ import { formatMessageLine, type RawMessage, type StickerDescriptionLookup } fro
 import { getRawId } from "../../core/chat-id.js";
 import type { VisionConfig } from "../../core/config.js";
 import { formatTsForPrompt, getWeekdayLabel } from "../../core/timezone.js";
+import { sanitizeTriageReason } from "../../core/triage-sanitize.js";
 
 const META_ASSOCIATED_MEMORIES_ENABLED = false;
 
@@ -653,7 +654,8 @@ export const metaTopicDigestsProvider: SectionProvider<MetaTopicDigestData> = {
                 participants: digest.participants,
                 messageCount: digest.messageCount,
                 createdAt: digest.lastActivityAt,
-                triageReason: digest.triageReason,
+                // 兜底：Meta 看到的 triageReason 不含预写金句，杜绝照搬进 contentDirection
+                triageReason: sanitizeTriageReason(digest.triageReason),
             };
             const header = formatTopicList([topic], "");
             const extras: string[] = [];

--- a/src/core/triage-sanitize.ts
+++ b/src/core/triage-sanitize.ts
@@ -22,17 +22,28 @@ const PAIRS: ReadonlyArray<readonly [string, string]> = [
 const LEADER =
     "(比如|例如|可以说|可以回|不妨|顺着|调侃|吐槽(?:一句|道)?|回(?:一)?句|接(?:一)?句|说(?:一)?句|盯(?:一?句|住|一下)?|怼(?:一)?句?|损(?:一)?句?|催(?:一)?句?|嫌弃式?(?:地?一句)?)\\s*[:：]?\\s*";
 
+// 模式由常量拼成、永不变化：模块加载时预编译一次，避免每次调用（每话题每次 flush）重建 8 个 RegExp。
+// 注意：用于 String.replace 的全局正则在每次 replace 后会把 lastIndex 复位为 0，复用安全。
+const SANITIZE_RULES: ReadonlyArray<{ readonly leader: RegExp; readonly solo: RegExp }> = PAIRS.map(
+    ([open, close]) => {
+        const inner = `[^${close}]`;
+        return {
+            // 引导词 + 成句（≥4 字）→ 留引导词
+            leader: new RegExp(`${LEADER}${open}${inner}{4,}${close}`, "g"),
+            // 落单的成句引号（≥6 字，像整句而非短标签/实体名）→ 抹内容
+            solo: new RegExp(`${open}${inner}{6,}${close}`, "g"),
+        };
+    },
+);
+
 export function sanitizeTriageReason(reason: string): string;
 export function sanitizeTriageReason(reason: string | undefined): string | undefined;
 export function sanitizeTriageReason(reason: string | undefined): string | undefined {
     if (!reason) return reason;
     let r = reason;
-    for (const [open, close] of PAIRS) {
-        const inner = `[^${close}]`;
-        // 引导词 + 成句（≥4 字）→ 留引导词
-        r = r.replace(new RegExp(`${LEADER}${open}${inner}{4,}${close}`, "g"), "$1（措辞临场发挥，勿照搬）");
-        // 落单的成句引号（≥6 字，像整句而非短标签/实体名）→ 抹内容
-        r = r.replace(new RegExp(`${open}${inner}{6,}${close}`, "g"), "（…）");
+    for (const { leader, solo } of SANITIZE_RULES) {
+        r = r.replace(leader, "$1（措辞临场发挥，勿照搬）");
+        r = r.replace(solo, "（…）");
     }
     return r;
 }

--- a/src/core/triage-sanitize.ts
+++ b/src/core/triage-sanitize.ts
@@ -1,0 +1,38 @@
+/**
+ * triage-sanitize.ts — 清洗 triage `reason` 里预写好的成句台词 / 金句。
+ *
+ * topic-triage 的 `reason` 只应描述方向（钩子 / 口吻 / 角度）供 Meta 判断；但模型常顺手把
+ * 一句具体的吐槽 / 比喻 / 金句写进去。这句现成台词会被注入 Meta、抄进 contentDirection，
+ * 再由回复模型原样发出，读起来工整刻意。本函数在 reason 流向下游前把成型的引号句子抹掉，
+ * 只留方向性描述，强制具体措辞留到真正回复时临场发挥。
+ *
+ * 仅处理成对方向引号（“” ‘’ 「」『』）：开 ≠ 闭，内层排除闭引号，故每个开引号只配到最近的
+ * 闭引号、不会跨串；短标签 / 实体名因不足长度阈值而保留。
+ */
+
+// 成对方向引号
+const PAIRS: ReadonlyArray<readonly [string, string]> = [
+    ["“", "”"],
+    ["‘", "’"],
+    ["「", "」"],
+    ["『", "』"],
+];
+
+// 引导词（比如/调侃/吐槽…）—— 命中后保留引导词、抹掉其后的成句草稿
+const LEADER =
+    "(比如|例如|可以说|可以回|不妨|顺着|调侃|吐槽(?:一句|道)?|回(?:一)?句|接(?:一)?句|说(?:一)?句|盯(?:一?句|住|一下)?|怼(?:一)?句?|损(?:一)?句?|催(?:一)?句?|嫌弃式?(?:地?一句)?)\\s*[:：]?\\s*";
+
+export function sanitizeTriageReason(reason: string): string;
+export function sanitizeTriageReason(reason: string | undefined): string | undefined;
+export function sanitizeTriageReason(reason: string | undefined): string | undefined {
+    if (!reason) return reason;
+    let r = reason;
+    for (const [open, close] of PAIRS) {
+        const inner = `[^${close}]`;
+        // 引导词 + 成句（≥4 字）→ 留引导词
+        r = r.replace(new RegExp(`${LEADER}${open}${inner}{4,}${close}`, "g"), "$1（措辞临场发挥，勿照搬）");
+        // 落单的成句引号（≥6 字，像整句而非短标签/实体名）→ 抹内容
+        r = r.replace(new RegExp(`${open}${inner}{6,}${close}`, "g"), "（…）");
+    }
+    return r;
+}

--- a/src/pipeline/recording-pipeline.ts
+++ b/src/pipeline/recording-pipeline.ts
@@ -16,6 +16,7 @@
 
 import { EventEmitter } from "node:events";
 import { createLogger } from "../core/logger.js";
+import { sanitizeTriageReason } from "../core/triage-sanitize.js";
 import { callLLMWithFallback, type ChatMessage } from "../core/llm.js";
 import { loadConfig, resolveComponentProfiles, resolveComponentTimeout, type LLMConfig, type VisionConfig } from "../core/config.js";
 import { topicClusteringProvider, topicTriageProvider } from "../context-engine/providers/pipeline-providers.js";
@@ -982,6 +983,8 @@ export class RecordingPipeline extends EventEmitter {
                 state: topic.state,
                 triageFound: !!triage,
                 triageReason: triage?.reason,
+                // 下游（Meta）实际拿到的是清洗后版本——记录以便核对金句是否被剥离
+                triageReasonClean: sanitizeTriageReason(triage?.reason),
                 msgCount: topicMsgs.length,
             });
             if (triage) {
@@ -1007,7 +1010,8 @@ export class RecordingPipeline extends EventEmitter {
                 }
 
                 const decision = {
-                    reason: triage.reason,
+                    // 兜底清洗：去掉 triage 替下游预写的成句金句，避免 Meta 照搬进 contentDirection
+                    reason: sanitizeTriageReason(triage.reason),
                 };
                 // 将 decision 持久化到 topic 对象，supply triageReason 给下游 toDigest
                 this.registry.setDecision(topic.id, decision);

--- a/src/pipeline/recording-pipeline.ts
+++ b/src/pipeline/recording-pipeline.ts
@@ -976,6 +976,8 @@ export class RecordingPipeline extends EventEmitter {
             if (!topic) continue;
 
             const triage = triageResult.topics.find(t => t.topicId === topicId);
+            // 清洗一次，日志与下游 decision 复用（避免每话题每次 flush 重复跑同一套正则）。
+            const triageReasonClean = sanitizeTriageReason(triage?.reason);
             log.info("updateRegistry: 话题处理", {
                 topicId: topic.id,
                 clusterTopicId: topicId,
@@ -984,7 +986,7 @@ export class RecordingPipeline extends EventEmitter {
                 triageFound: !!triage,
                 triageReason: triage?.reason,
                 // 下游（Meta）实际拿到的是清洗后版本——记录以便核对金句是否被剥离
-                triageReasonClean: sanitizeTriageReason(triage?.reason),
+                triageReasonClean,
                 msgCount: topicMsgs.length,
             });
             if (triage) {
@@ -1011,7 +1013,8 @@ export class RecordingPipeline extends EventEmitter {
 
                 const decision = {
                     // 兜底清洗：去掉 triage 替下游预写的成句金句，避免 Meta 照搬进 contentDirection
-                    reason: sanitizeTriageReason(triage.reason),
+                    // （triage 存在时 reason 必为 string；?? 仅为类型收窄，实际不会取右值）
+                    reason: triageReasonClean ?? triage.reason,
                 };
                 // 将 decision 持久化到 topic 对象，supply triageReason 给下游 toDigest
                 this.registry.setDecision(topic.id, decision);

--- a/tests/triage-sanitize.test.ts
+++ b/tests/triage-sanitize.test.ts
@@ -1,0 +1,81 @@
+/**
+ * triage-sanitize.test.ts — sanitizeTriageReason 清洗预写金句的单元测试
+ *
+ * 规则回顾（见 src/core/triage-sanitize.ts）：
+ *   - 4 种成对方向引号：“” ‘’ 「」『』
+ *   - 引导词（调侃/吐槽/比如…）+ 成句(≥4 字) → 保留引导词、抹掉成句
+ *   - 落单成句引号(≥6 字) → 整段抹成 （…）
+ *   - 短标签 / 实体名（不足长度阈值）保留；无引号的方向描述原样保留
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { sanitizeTriageReason } from "../src/core/triage-sanitize.js";
+
+const KEEP_LEADER = "（措辞临场发挥，勿照搬）";
+const STRIPPED = "（…）";
+
+describe("sanitizeTriageReason", () => {
+    // ─── 空值 / 透传 ───
+    it("undefined / 空串 原样返回（重载保留 undefined）", () => {
+        assert.equal(sanitizeTriageReason(undefined), undefined);
+        assert.equal(sanitizeTriageReason(""), "");
+    });
+
+    it("无引号的纯方向描述原样保留（即便含引导词）", () => {
+        const reason = "顺着对方话头调侃他的发型，口吻欠揍一点";
+        assert.equal(sanitizeTriageReason(reason), reason);
+    });
+
+    // ─── 引导词 + 成句 → 保留引导词、抹成句（阈值 ≥4） ───
+    it("引导词 + 成句（≥4 字）→ 保留引导词，抹掉具体台词", () => {
+        assert.equal(sanitizeTriageReason("调侃“你这操作真骚啊”"), `调侃${KEEP_LEADER}`);
+    });
+
+    it("引导词把成句阈值降到 4 字（短到 4 字也被抹）", () => {
+        assert.equal(sanitizeTriageReason("吐槽“菜就多练”"), `吐槽${KEEP_LEADER}`);
+    });
+
+    it("引导词与引号间的冒号/空格被吃掉、不进入保留部分", () => {
+        assert.equal(sanitizeTriageReason("吐槽：“菜就多练几把”"), `吐槽${KEEP_LEADER}`);
+        assert.equal(sanitizeTriageReason("比如 “这也能翻车”"), `比如${KEEP_LEADER}`);
+    });
+
+    // ─── 落单成句（无引导词，阈值 ≥6） ───
+    it("落单成句引号（≥6 字）→ 整段抹成 （…）", () => {
+        assert.equal(sanitizeTriageReason("他说“今天天气真不错啊”很开心"), `他说${STRIPPED}很开心`);
+    });
+
+    it("同串多个落单成句各自被抹", () => {
+        assert.equal(
+            sanitizeTriageReason("“句子一这边的内容”和“句子二那边的内容”"),
+            `${STRIPPED}和${STRIPPED}`,
+        );
+    });
+
+    // ─── 短标签 / 实体名保留（落单且 <6 字） ───
+    it("落单短标签（<6 字、无引导词）保留，不误伤实体名/梗名", () => {
+        assert.equal(sanitizeTriageReason("用了「细狗」这个标签"), "用了「细狗」这个标签");
+        assert.equal(sanitizeTriageReason("提到“摆烂”"), "提到“摆烂”");
+    });
+
+    // ─── 4 种引号都覆盖 ───
+    it("‘’ 引导词成句", () => {
+        assert.equal(sanitizeTriageReason("不妨‘随便说两句’"), `不妨${KEEP_LEADER}`);
+    });
+
+    it("『』 落单成句", () => {
+        assert.equal(sanitizeTriageReason("他写道『长长的一句话内容』"), `他写道${STRIPPED}`);
+    });
+
+    it("「」 落单成句", () => {
+        assert.equal(sanitizeTriageReason("引用「这是一句完整的话」收尾"), `引用${STRIPPED}收尾`);
+    });
+
+    // ─── 每个开引号只配到最近的闭引号、不跨串 ───
+    it("成句内部不吞掉后续闭引号（最近匹配）", () => {
+        // 第一段“……”被抹，"中间"是落单短标签保留，第二段不存在
+        const out = sanitizeTriageReason("开头“前面这句够长了吧”中间“后面这句也够长”结尾");
+        assert.equal(out, `开头${STRIPPED}中间${STRIPPED}结尾`);
+    });
+});


### PR DESCRIPTION
triage reason 里替下游预写的成句"金句"会被清洗,避免 Meta 照搬进 contentDirection;短标签/实体名保留。

🤖 Generated with [Claude Code](https://claude.com/claude-code)