### PR TITLE
test(ci): metrics 校验在 config.yaml 缺失时回退 config.example.yaml

### DIFF
--- a/tests/metrics-deployment-verification.test.ts
+++ b/tests/metrics-deployment-verification.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, after } from "node:test";
 import assert from "node:assert/strict";
 import http from "node:http";
-import { readFileSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -287,7 +287,12 @@ describe("Metrics Deployment Verification", () => {
 
     describe("Configuration", () => {
         it("#12 metrics can be enabled by default without an explicit config section", async () => {
-            const configContent = readFileSync(join(projectRoot, "config.yaml"), "utf-8");
+            // config.yaml 是 gitignore 的本地文件，CI / 全新 checkout 可能不存在；回退到提交进仓库的示例配置
+            // （loadConfig() 本身也走同样的回退）。
+            const configPath = existsSync(join(projectRoot, "config.yaml"))
+                ? join(projectRoot, "config.yaml")
+                : join(projectRoot, "config.example.yaml");
+            const configContent = readFileSync(configPath, "utf-8");
             const configMod = await import("../src/core/config.js");
             const config = configMod.loadConfig();
             const metricsEnabled = config.metrics?.enabled !== false;


### PR DESCRIPTION
config.yaml 是 gitignore 的本地文件,CI/全新 checkout 可能不存在;metrics 部署校验测试回退到提交进仓库的示例配置(与 loadConfig 同样的回退)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)