### PR TITLE
fix(tasks): 沉默跳过判为 SKIPPED + 超时拆出 TIMEOUT（补全 #41）

### DIFF
--- a/src/sandbox/modules/discord/index.ts
+++ b/src/sandbox/modules/discord/index.ts
@@ -294,6 +294,15 @@ export function createDiscordClientProxy(
         sendReaction: async (channelId: string, messageId: string, emoji: string) => {
             await env.callHost("discord.sendReaction", [channelId, messageId, emoji]);
             env.emitOutput(`[Discord] sendReaction ok channel=${channelId} msg=${messageId} emoji=${emoji}`);
+            // 表态计入对外动作，供 SentMessageCollector 区分"沉默跳过"
+            env.notifyHost({
+                type: "system.agent_reaction_sent",
+                scene: "discord",
+                chatId: channelId,
+                messageId,
+                emoji,
+                timestamp: Date.now(),
+            });
         },
         sendTyping: async (channelId: string) => {
             await env.callHost("discord.sendTyping", [channelId]);

--- a/src/sandbox/modules/telegram/index.ts
+++ b/src/sandbox/modules/telegram/index.ts
@@ -550,6 +550,17 @@ export function createTelegramClientProxy(
         sendReaction: async (chatId: number | string, messageId: number, emoji: string | null) => {
             await callTelegramHost("telegram.sendReaction", [chatId, messageId, emoji]);
             env.emitOutput(`[Telegram] sendReaction ok chat=${String(chatId)} msg=${messageId} emoji=${emoji ?? "(removed)"}`);
+            // 表态计入对外动作（emoji=null 是撤销表态，不计），供 SentMessageCollector 区分"沉默跳过"
+            if (emoji != null) {
+                env.notifyHost({
+                    type: "system.agent_reaction_sent",
+                    scene: "telegram",
+                    chatId: String(chatId),
+                    messageId,
+                    emoji,
+                    timestamp: Date.now(),
+                });
+            }
         },
         editMessage: async (chatId: number | string, messageId: number, text: string) => {
             const edited = hydrateTelegramMessage(await callTelegramHost("telegram.editMessage", [chatId, messageId, text]));

--- a/src/sandbox/session-runner.ts
+++ b/src/sandbox/session-runner.ts
@@ -92,12 +92,24 @@ export class SentMessageCollector {
     private duplicateWarningBuffer: string[] = [];
     /** 整个 session 累计的重复拦截次数 */
     duplicateBlockedCount = 0;
+    /**
+     * 整个 session 累计的表态（reaction）次数。
+     * 表态不进 allSent（它不是一条消息），但它是一次"对外动作"——
+     * 用于把"只贴了个表情、没发消息"与"完全沉默跳过"区分开。
+     */
+    reactionCount = 0;
 
     constructor(private readonly stickerDescriptionLookup?: StickerDescriptionLookup) {}
 
     /** 由 sandbox notify 事件回调调用 */
     collect(event: Record<string, unknown>): void {
         const type = String(event.type ?? "");
+
+        // 表态事件：计入对外动作，但不算一条已发消息
+        if (type === "system.agent_reaction_sent") {
+            this.reactionCount++;
+            return;
+        }
 
         // 处理重复消息拦截事件
         if (type === "system.duplicate_message_blocked") {
@@ -1035,4 +1047,14 @@ function truncateOutput(output: string): string {
 
 function isCodeExecutionTimeoutError(message: string): boolean {
     return message.includes("Code execution timed out after");
+}
+
+/**
+ * 宽口径超时判定：用于把派发任务的"超时"从泛 ERROR 中拆出来标为 TIMEOUT。
+ * 覆盖代码块执行超时（"Code execution timed out after …"）与 LLM 调用超时
+ * （TimeoutError / "timed out" / "timeout"）。
+ */
+export function isTimeoutError(message: string | undefined | null): boolean {
+    if (!message) return false;
+    return /timed out|timeout/i.test(message);
 }

--- a/src/subagent/code-act-executor.ts
+++ b/src/subagent/code-act-executor.ts
@@ -20,7 +20,7 @@ import type {
 import type { FactSearchResult, InteractionSearchResult, MemoryStoreV2, RecentMessageEntry } from "../memory-v2/index.js";
 import { SandboxPool } from "../sandbox/sandbox-pool.js";
 import { NotificationCenter } from "../event/notification-center.js";
-import { runCodeActSession, SentMessageCollector, type SessionResult, type SentMessageRecord } from "../sandbox/session-runner.js";
+import { runCodeActSession, SentMessageCollector, isTimeoutError, type SessionResult, type SentMessageRecord } from "../sandbox/session-runner.js";
 import { loadModuleRegistry, lookupFullDocs, generateBriefOverview, gatePrivacyMarkSensitive, mergeModuleRegistries, type ModuleEntry } from "../sandbox/modules/module-registry.js";
 import { getMcpModuleEntries } from "../sandbox/modules/mcp-bridge/index.js";
 import { parseAllSkillDocs } from "../sandbox/skill-loader.js";
@@ -415,6 +415,23 @@ export function endReasonToTaskStatus(endReason: string | undefined): SubagentCa
 }
 
 /**
+ * 在 endReasonToTaskStatus 基础上叠加运行时信息，得出派发任务的最终终态：
+ *   - error 且错误为超时 → TIMEOUT（把执行/LLM 超时从泛 ERROR 中拆出来）
+ *   - 正常收尾（COMPLETED）但整轮没有任何对外动作（没发消息、没贴表态）→ SKIPPED
+ *     （"想过但决定不回复"——这是 end_turn，不是 interrupted，故 endReasonToTaskStatus 兜不住）
+ *   - 其余沿用 endReasonToTaskStatus（error→ERROR、interrupted→SKIPPED、end_turn/max_turns→COMPLETED）
+ */
+export function classifyDispatchedTaskStatus(
+    endReason: string | undefined,
+    opts: { producedOutput: boolean; error?: string | null },
+): SubagentCallback["status"] {
+    const base = endReasonToTaskStatus(endReason);
+    if (base === "ERROR" && isTimeoutError(opts.error)) return "TIMEOUT";
+    if (base === "COMPLETED" && !opts.producedOutput) return "SKIPPED";
+    return base;
+}
+
+/**
  * CodeActExecutor — per-group CodeAct 执行器
  *
  * 注意：Sandbox 实例由 SandboxPool 管理，此处只持有引用。
@@ -626,6 +643,10 @@ export class CodeActExecutor {
         } catch (err) {
             const durationMs = Date.now() - startTime;
             const cancelledByUser = this.cancelRequested;
+            const timedOut = !cancelledByUser && isTimeoutError(String(err));
+            const status: SubagentCallback["status"] = cancelledByUser
+                ? "SKIPPED"
+                : (timedOut ? "TIMEOUT" : "ERROR");
             const thinkingSummary = cancelledByUser
                 ? formatThinkingPlaceholder("执行已被用户取消，未保留可用的思考记录")
                 : formatThinkingPlaceholder("执行在 session 外层异常中断，未保留可用的思考记录");
@@ -635,10 +656,10 @@ export class CodeActExecutor {
                 chatTitle: task.contextSnapshot.chatTitle ?? task.contextSnapshot.groupModel?.chatTitle,
                 isDirectMessage: task.contextSnapshot.isDirectMessage,
                 executionType: "CODEACT",
-                status: cancelledByUser ? "SKIPPED" : "ERROR",
+                status,
                 summary: cancelledByUser
                     ? `Execution cancelled by user\n\n${thinkingSummary}`
-                    : `Execution failed: ${String(err)}\n\n${thinkingSummary}`,
+                    : `Execution ${timedOut ? "timed out" : "failed"}: ${String(err)}\n\n${thinkingSummary}`,
                 error: cancelledByUser ? undefined : String(err),
                 durationMs,
                 createdAt: new Date().toISOString(),
@@ -961,8 +982,13 @@ export class CodeActExecutor {
         });
 
         // 5. 构建 callback
-        // endReason → 终态映射（见 endReasonToTaskStatus）。
-        const status: SubagentCallback["status"] = endReasonToTaskStatus(sessionResult.endReason);
+        // 终态判定（见 classifyDispatchedTaskStatus）：endReason 映射 + 超时拆分 +
+        // "正常收尾但没发消息/没贴表态" 判为 SKIPPED（贴纸/媒体走 allSent，故 sticker-only 仍是 COMPLETED）。
+        const producedOutput = sentCollector.allSent.length > 0 || sentCollector.reactionCount > 0;
+        const status: SubagentCallback["status"] = classifyDispatchedTaskStatus(sessionResult.endReason, {
+            producedOutput,
+            error: sessionResult.error,
+        });
         const callback: SubagentCallback = {
             taskId: task.taskId,
             chatId: this.chatId,

--- a/tests/end-reason-status.test.ts
+++ b/tests/end-reason-status.test.ts
@@ -1,14 +1,15 @@
 /**
  * end-reason-status.test.ts — session endReason → 派发任务终态映射
  *
- * 覆盖 commit cb84af9 的执行器侧映射：interrupted 是「让路」而非失败，必须落 SKIPPED，
- * 不能被误记为 COMPLETED；error→ERROR；正常收尾→COMPLETED。
- * （TIMEOUT 由 GlobalState 启动对账补写，不在此函数产生——见 s6-global-state.test.ts。）
+ * endReasonToTaskStatus：纯 endReason 映射（interrupted 是「让路」非失败→SKIPPED；error→ERROR；正常收尾→COMPLETED）。
+ * classifyDispatchedTaskStatus：在其上叠加运行时信息——超时从 ERROR 拆出为 TIMEOUT；
+ *   正常收尾但整轮没有任何对外动作（没发消息、没贴表态）→ SKIPPED（"想过但决定不回复"）。
+ * （进程中途退出残留 RUNNING/PENDING 的 TIMEOUT 由 GlobalState 启动对账补写——见 s6-global-state.test.ts。）
  */
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { endReasonToTaskStatus } from "../src/subagent/code-act-executor.js";
+import { endReasonToTaskStatus, classifyDispatchedTaskStatus } from "../src/subagent/code-act-executor.js";
 
 describe("endReasonToTaskStatus", () => {
     it("interrupted → SKIPPED（被新消息/用户打断，主动让路非失败）", () => {
@@ -36,5 +37,27 @@ describe("endReasonToTaskStatus", () => {
         for (const r of ["interrupted", "error", "end_turn", "max_turns", undefined]) {
             assert.notEqual(endReasonToTaskStatus(r), "TIMEOUT");
         }
+    });
+});
+
+describe("classifyDispatchedTaskStatus", () => {
+    it("正常收尾但没有任何对外动作 → SKIPPED（想过但决定不回复）", () => {
+        assert.equal(classifyDispatchedTaskStatus("end_turn", { producedOutput: false }), "SKIPPED");
+        assert.equal(classifyDispatchedTaskStatus("max_turns", { producedOutput: false }), "SKIPPED");
+    });
+
+    it("正常收尾且发了消息/贴了表态 → COMPLETED", () => {
+        assert.equal(classifyDispatchedTaskStatus("end_turn", { producedOutput: true }), "COMPLETED");
+    });
+
+    it("error 且错误为超时 → TIMEOUT，否则 → ERROR", () => {
+        assert.equal(classifyDispatchedTaskStatus("error", { producedOutput: false, error: "Code execution timed out after 60000ms" }), "TIMEOUT");
+        assert.equal(classifyDispatchedTaskStatus("error", { producedOutput: false, error: "boom" }), "ERROR");
+        assert.equal(classifyDispatchedTaskStatus("error", { producedOutput: false }), "ERROR");
+    });
+
+    it("interrupted → SKIPPED（让路语义优先，不受 producedOutput 影响）", () => {
+        assert.equal(classifyDispatchedTaskStatus("interrupted", { producedOutput: true }), "SKIPPED");
+        assert.equal(classifyDispatchedTaskStatus("interrupted", { producedOutput: false }), "SKIPPED");
     });
 });

--- a/tests/platform-dedup.test.ts
+++ b/tests/platform-dedup.test.ts
@@ -168,7 +168,40 @@ describe("platform proxy duplicate tracking", () => {
             args: ["channel-100", "msg-42", "😄"],
         }]);
         assert.ok(outputs.some((line) => line.includes("[Discord] sendReaction ok channel=channel-100 msg=msg-42 emoji=😄")));
+        // 表态不进 dedup history（它不是一条消息）……
         assert.deepEqual([...sentHistory.entries()], []);
-        assert.deepEqual(notifications, []);
+        // ……但会发一条 agent_reaction_sent 事件，供 SentMessageCollector 把"贴了表态"与"沉默跳过"区分开
+        assert.equal(notifications.length, 1);
+        assert.equal(notifications[0].type, "system.agent_reaction_sent");
+        assert.equal(notifications[0].scene, "discord");
+        assert.equal(notifications[0].chatId, "channel-100");
+        assert.equal(notifications[0].messageId, "msg-42");
+        assert.equal(notifications[0].emoji, "😄");
+    });
+
+    it("telegram reaction emits an action event, but removing one (emoji=null) does not", async () => {
+        const notifications: Array<Record<string, unknown>> = [];
+        const env: CapabilityRegistryEnv = {
+            ctx: {},
+            emitOutput: () => {},
+            notifyHost: (event) => notifications.push(event),
+            requestInput: async () => "",
+            printToHost: () => {},
+            spawnTask: () => {},
+            killTask: () => {},
+            listTasks: () => [],
+            callHost: async () => null,
+        };
+        const client = createTelegramClientProxy(env, new Map<string, Set<string>>()) as {
+            sendReaction(chatId: string, messageId: number, emoji: string | null): Promise<void>;
+        };
+
+        await client.sendReaction("100", 42, "👍");
+        assert.equal(notifications.length, 1);
+        assert.equal(notifications[0].type, "system.agent_reaction_sent");
+        assert.equal(notifications[0].emoji, "👍");
+
+        await client.sendReaction("100", 42, null); // 撤销表态，不算一次对外动作
+        assert.equal(notifications.length, 1);
     });
 });

--- a/tests/session-runner.test.ts
+++ b/tests/session-runner.test.ts
@@ -6,7 +6,36 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { parseResponse } from "../src/sandbox/session-runner.js";
+import { parseResponse, SentMessageCollector, isTimeoutError } from "../src/sandbox/session-runner.js";
+
+describe("isTimeoutError", () => {
+    it("matches code-execution and LLM timeouts, not generic errors", () => {
+        assert.equal(isTimeoutError("Code execution timed out after 60000ms"), true);
+        assert.equal(isTimeoutError("LLM call failed: TimeoutError: socket"), true);
+        assert.equal(isTimeoutError("Request timeout"), true);
+        assert.equal(isTimeoutError("Sandbox execution aborted: boom"), false);
+        assert.equal(isTimeoutError(undefined), false);
+        assert.equal(isTimeoutError(""), false);
+    });
+});
+
+describe("SentMessageCollector reaction tracking", () => {
+    it("counts agent_reaction_sent without adding to allSent", () => {
+        const c = new SentMessageCollector();
+        c.collect({ type: "system.agent_reaction_sent", chatId: "telegram:1", emoji: "👍" });
+        c.collect({ type: "system.agent_reaction_sent", chatId: "telegram:1", emoji: "🔥" });
+        assert.equal(c.reactionCount, 2);
+        assert.equal(c.allSent.length, 0);
+    });
+
+    it("keeps messages and reactions in separate counters", () => {
+        const c = new SentMessageCollector();
+        c.collect({ type: "system.agent_message_sent", chatId: "telegram:1", text: "hi" });
+        c.collect({ type: "system.agent_reaction_sent", chatId: "telegram:1", emoji: "👍" });
+        assert.equal(c.allSent.length, 1);
+        assert.equal(c.reactionCount, 1);
+    });
+});
 
 describe("parseResponse", () => {
     it("should parse thinking only (no code blocks)", () => {


### PR DESCRIPTION
## 背景

#41 给派发任务终态加了 `endReasonToTaskStatus`（`interrupted→SKIPPED`、`error→ERROR`、其余→`COMPLETED`）以及 global-state 的启动对账 / 终态立即落盘。

但线上复查发现问题没真正解决：最近 **500 条派发任务 100% 都是 `COMPLETED`**，其中约 20%（98 条）整轮没发任何消息——这些是「想过之后决定不回复」的有意沉默（思考记录里明确写着「够了不用再接」「话题自然收尾」之类）。

根因：真正的「沉默跳过」是 `end_turn` + 零产出，**不是** `interrupted`（`interrupted` 只在被新消息打断时才出现）。#41 只挂在 `interrupted` 上，所以主流的沉默跳过仍然落 `COMPLETED`。

> 🙏 先为 #41 那版不完整的修复道个歉：当时把「跳过」判定挂在 `endReason === "interrupted"` 上是认错了信号——绝大多数主动不回复的轮次其实是正常 `end_turn` 收尾、只是没发消息，结果一条都没被正确标成 `SKIPPED`，等于没修到点子上。这个 PR 补上真正的判定。

## 改动

- 新增 `classifyDispatchedTaskStatus(endReason, { producedOutput, error })`，在 `endReasonToTaskStatus` 之上叠加运行时信息：
  - 正常收尾（`end_turn` / `max_turns`）但**整轮没有任何对外动作**（没发消息、没贴表态）→ `SKIPPED`
  - `error` 且错误是超时 → `TIMEOUT`（把执行 / LLM 超时从泛 `ERROR` 拆出来）
  - 其余沿用 `endReasonToTaskStatus`
- 表态计入「对外动作」：`telegram` / `discord` 的 `sendReaction` 发 `system.agent_reaction_sent`，`SentMessageCollector` 累计 `reactionCount`（贴纸 / 媒体已走 `allSent`，故 sticker-only 仍 `COMPLETED`；telegram `emoji=null` 撤销表态不计）。
- catch 路径：超时异常 → `TIMEOUT`（区别于用户取消的 `SKIPPED` 和泛 `ERROR`）。
- `isTimeoutError`：宽口径超时判定（代码块执行超时 + LLM 调用超时）。
- global-state 的启动对账 / 终态立即落盘沿用 #41 实现，未改动。

## 测试

- `end-reason-status.test.ts`：新增 `classifyDispatchedTaskStatus` 用例（无产出→SKIPPED、有产出→COMPLETED、超时→TIMEOUT、interrupted 让路语义）。
- `session-runner.test.ts`：`isTimeoutError` + `SentMessageCollector` 表态计数。
- `platform-dedup.test.ts`：telegram / discord 表态事件（含 telegram `emoji=null` 不发事件）。

## 验证

已在测试机（萩原）上线并验证：Telegram 连接正常、Restarts=0、无报错；新派发任务现在会正确出现 `SKIPPED` / `TIMEOUT`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
