### PR TITLE
fix(telegram): 只丢 real bot 首条自动 /start（带开关，默认开，替代 #43）

### DIFF
--- a/src/adapter/telegram-adapter.ts
+++ b/src/adapter/telegram-adapter.ts
@@ -270,6 +270,8 @@ export class TelegramAdapter implements PlatformAdapter {
     // ─── /invisible & /mute 状态 ───
     private invisibleUsers: Set<string> = loadInvisibleUsers();
     private mutedChats: Map<string, number> = new Map();  // chatId → expiry timestamp (ms)
+    /** 本次进程已收到过消息的 chatId（用于识别「会话首条」，以丢弃 real bot 自动 /start） */
+    private seenChats: Set<string> = new Set();
 
     /** 白名单 ID 集合（配置加载时构建，与 rawId 比对） */
     private readonly whitelistGroupIds: Set<string>;
@@ -2051,6 +2053,10 @@ export class TelegramAdapter implements PlatformAdapter {
     ): Promise<boolean> {
         const text = normalized.text.trim();
 
+        // 记录「会话首条」：每条入站消息都标记一次 chatId（用于下方丢弃 real bot 自动 /start）
+        const isFirstInChat = !this.seenChats.has(normalized.chatId);
+        this.seenChats.add(normalized.chatId);
+
         // ── 检查命令目标：若带 @username，必须与自己的用户名匹配 ──
         const cmdMentionMatch = text.match(/^\/(\S+?)@(\S+)/);
         if (cmdMentionMatch) {
@@ -2109,7 +2115,26 @@ export class TelegramAdapter implements PlatformAdapter {
             return true;
         }
 
+        // ── Telegram real bot：用户首次打开 bot 时客户端会自动下发一条 /start ──
+        // 只丢「会话首条且恰为 /start」这一条（避免把这条机械的握手消息当普通消息处理）；
+        // 之后的 slash（含用户手动再发的 /start）大概率是主动行为，一律放行交给管线。
+        // userbot 模式没有这套自动 /start，故不拦截。可由 telegram.dropInitialStart 关闭。
+        if (
+            this.config.dropInitialStart &&
+            this.config.mode === "bot" &&
+            isFirstInChat &&
+            this.isStartCommand(text)
+        ) {
+            log.info("已忽略 real bot 首条自动 /start（不进入处理管线）", { chatId: normalized.chatId });
+            return true;
+        }
+
         return false;
+    }
+
+    /** 是否为 /start 命令（可带 @bot 与 deep-link payload）。@其它bot 的情况已在上方 cmdMentionMatch 放行。 */
+    private isStartCommand(text: string): boolean {
+        return /^\/start(?:@\S+)?(?:\s|$)/i.test(text);
     }
 
     /**

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -166,6 +166,12 @@ export interface TelegramConfig {
     apiId: string;
     apiHash: string;
     phone: string;
+    /**
+     * 是否丢弃 Telegram 在用户首次打开 real bot 时自动下发的那条 `/start`。
+     * 仅作用于 bot 模式、且只丢一个会话里的第一条消息（恰为 /start 时）；
+     * 之后的 slash 大概率是用户主动发的，一律放行。默认 true。
+     */
+    dropInitialStart: boolean;
     /** 入站白名单（可选） */
     whitelist?: TelegramWhitelistConfig;
     /** bot 模式 mtcute pts 预热群列表（独立于白名单，用于无白名单时也能预热指定群） */
@@ -682,6 +688,8 @@ export function loadConfig(configPath?: string, forceReload?: boolean): AppConfi
             apiId: str(fileTG.api_id) ?? "",
             apiHash: str(fileTG.api_hash) ?? "",
             phone: str(fileTG.phone) ?? "",
+            // 默认 true：仅当显式写 false 才关闭
+            dropInitialStart: fileTG.drop_initial_start !== false,
             whitelist: parseTelegramWhitelist(fileTG),
             prewarm: parseTelegramPrewarm(fileTG),
             humanizedDelay: parseHumanizedDelay(fileTG),
@@ -1364,6 +1372,7 @@ export function serializeConfigToObject(config: AppConfig): Record<string, unkno
             api_id: config.telegram.apiId,
             api_hash: config.telegram.apiHash,
             phone: config.telegram.phone,
+            drop_initial_start: config.telegram.dropInitialStart,
         };
         if (config.telegram.humanizedDelay) {
             tg.humanized_delay = {

--- a/src/dashboard/ui/src/panels/ConfigPanel.svelte
+++ b/src/dashboard/ui/src/panels/ConfigPanel.svelte
@@ -142,7 +142,8 @@
       discordEnabled = !!config.discord?.botToken;
       onebotEnabled = !!(config.onebot?.wsUrl && config.onebot?.selfId);
       // 始终确保 UI 有空对象可绑定
-      if (!config.telegram) config.telegram = { mode: 'bot', botToken: '', apiId: '', apiHash: '', phone: '' };
+      if (!config.telegram) config.telegram = { mode: 'bot', botToken: '', apiId: '', apiHash: '', phone: '', dropInitialStart: true };
+      if (config.telegram.dropInitialStart == null) config.telegram.dropInitialStart = true;
       if (!config.telegram.whitelist) {
         config.telegram.whitelist = { enabled: false, groups: [], users: [] };
       }

--- a/src/dashboard/ui/src/panels/config/TelegramTab.svelte
+++ b/src/dashboard/ui/src/panels/config/TelegramTab.svelte
@@ -80,6 +80,19 @@
       /></label
     >
   </div>
+  <div class="divider text-xs opacity-50 my-3">命令处理</div>
+  <label class="cfg-check mb-2">
+    <input
+      type="checkbox"
+      class="toggle toggle-sm"
+      bind:checked={config.telegram.dropInitialStart}
+    />
+    <span class="text-sm">丢弃首条自动 /start（仅 bot 模式）</span>
+  </label>
+  <p class="text-xs opacity-50 mb-3">
+    用户首次打开 bot 时 Telegram 会自动下发一条 /start。开启后只丢这一条「会话首条
+    /start」；之后的 slash 命令（含手动再发的 /start）照常进入处理管线。userbot 模式不受影响。
+  </p>
   <div class="divider text-xs opacity-50 my-3">拟人化发送延迟</div>
   <label class="cfg-check mb-2">
     <input

--- a/tests/telegram-adapter.test.ts
+++ b/tests/telegram-adapter.test.ts
@@ -37,6 +37,7 @@ function makeConfig(overrides: Partial<TelegramConfig> = {}): TelegramConfig {
         apiId: "12345",
         apiHash: "hash",
         phone: "",
+        dropInitialStart: true,
         ...overrides,
     };
 }
@@ -1393,5 +1394,80 @@ interface TelegramClient {
 
         await adapter.stop();
         nc.dispose();
+    });
+
+    // ─── 首条自动 /start 丢弃 ───
+    function makeStartHarness(configOverrides: Partial<TelegramConfig> = {}) {
+        const nc = makeNC();
+        const events = captureEvents(nc);
+        let handler: ((msg: unknown) => void | Promise<void>) | null = null;
+        const fakeClient = {
+            async start() { return { id: 99, displayName: "Bot", username: "MyBot", isBot: true }; },
+            onNewMessage: {
+                add(h: (msg: unknown) => void | Promise<void>) { handler = h; },
+                remove() { handler = null; },
+            },
+            async sendText(chatId: unknown, text: unknown) {
+                return { id: 1, text, date: new Date(), chat: { id: chatId, type: "private" }, sender: { id: 99, isBot: true } };
+            },
+            async destroy() {},
+        };
+        const adapter = new TelegramAdapter(
+            makeConfig(configOverrides), nc, async () => "", () => {},
+            async () => fakeClient as never,
+        );
+        const send = (text: string, opts: { id?: number; chatId?: number } = {}) =>
+            handler!({
+                id: opts.id ?? 1, text, date: new Date(),
+                chat: { id: opts.chatId ?? 555, title: "DM", type: "private" },
+                sender: { id: 7, displayName: "User", isBot: false },
+            });
+        return { events, adapter, start: () => adapter.start(), send, stop: async () => { await adapter.stop(); nc.dispose(); } };
+    }
+
+    it("drops the first auto /start in bot mode, lets a later /start through", async () => {
+        const h = makeStartHarness();
+        await h.start();
+        await h.send("/start", { id: 1 });
+        assert.equal(h.events.length, 0, "first /start should be dropped (no NC push)");
+        await h.send("/start", { id: 2 });
+        assert.equal(h.events.length, 1, "a later /start passes through to the pipeline");
+        await h.stop();
+    });
+
+    it("does not drop /start when it is not the chat's first message", async () => {
+        const h = makeStartHarness();
+        await h.start();
+        await h.send("hello", { id: 1 });   // first msg (not /start) → marks chat seen, pushed
+        await h.send("/start", { id: 2 });  // no longer first → not dropped
+        assert.equal(h.events.length, 2, "neither the greeting nor the later /start is dropped");
+        await h.stop();
+    });
+
+    it("does not drop the first /start in userbot mode", async () => {
+        const h = makeStartHarness({ mode: "userbot", botToken: "", phone: "+8613800000000" });
+        await h.start();
+        await h.send("/start", { id: 1 });
+        assert.equal(h.events.length, 1, "userbot has no auto /start → not dropped");
+        await h.stop();
+    });
+
+    it("does not drop the first /start when dropInitialStart is disabled", async () => {
+        const h = makeStartHarness({ dropInitialStart: false });
+        await h.start();
+        await h.send("/start", { id: 1 });
+        assert.equal(h.events.length, 1, "toggle off → first /start passes through");
+        await h.stop();
+    });
+
+    it("first /start drop is tracked per chat", async () => {
+        const h = makeStartHarness();
+        await h.start();
+        await h.send("/start", { id: 1, chatId: 100 });  // chat A first → dropped
+        await h.send("/start", { id: 2, chatId: 200 });  // chat B first → dropped
+        assert.equal(h.events.length, 0, "first /start in each distinct chat is dropped");
+        await h.send("/start", { id: 3, chatId: 100 });  // chat A second → passes
+        assert.equal(h.events.length, 1, "second /start in chat A passes");
+        await h.stop();
     });
 });

--- a/tests/telegram-guides.test.ts
+++ b/tests/telegram-guides.test.ts
@@ -20,6 +20,7 @@ function makeConfig(): TelegramConfig {
         apiId: "12345",
         apiHash: "hash",
         phone: "+8613800000000",
+        dropInitialStart: true,
     };
 }
 


### PR DESCRIPTION
## 背景

#43 的做法是静默丢弃**所有** bot slash 命令（`/start /help …`），被认为太宽泛——除了 Telegram 在用户**首次打开 real bot** 时自动下发的那条 `/start`，后续的 slash 大概率是用户主动发的，不该一律拦截。

这个 PR 收窄为：**只丢那条自动 `/start`**，并加一个可关的开关（默认开）。

## 改动

只在以下条件**全部**满足时丢弃首条 `/start`：

- `telegram.drop_initial_start` = true（新增配置，默认 true）
- `mode === "bot"`（userbot 没有这套自动 /start 机制）
- 是本会话该 chat 的**第一条**消息（进程内 `seenChats` Set 追踪 —— 仅本次进程；重启后某个老会话的下一条若恰是手动 `/start` 会被丢一次，无害）
- 文本是 `/start`（可带 `@bot` 与 deep-link payload）

其余一律放行进入处理管线：之后的 `/start`、`/help`、任何 slash 都正常处理（交给 triage / Meta 决定要不要回）。

Dashboard：Telegram 设置页新增开关「丢弃首条自动 /start（仅 bot 模式）」，默认开；`drop_initial_start` 随 `config.yaml` 往返保存。既有 `/invisible` `/mute` `/unmute` 处理不受影响（仍先于本逻辑判定）。

## 测试

`tests/telegram-adapter.test.ts` 新增：首条 `/start` 被丢、之后 `/start` 放行、非首条不丢、userbot 模式不丢、开关关闭不丢、按 chat 独立追踪。`tsc` 干净。

> 基于当前 `agentic` 重做（#43 基于较旧的 base，已关闭）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
