### PR TITLE
fix(onebot): preserve original filename when sending files

### DIFF
--- a/src/adapter/onebot-adapter.ts
+++ b/src/adapter/onebot-adapter.ts
@@ -1115,9 +1115,15 @@ export class OneBotAdapter implements PlatformAdapter {
                 segments.push({ type: "record", data: { file: String(file ?? "") } });
                 break;
             case "document":
-            default:
-                segments.push({ type: "file", data: { file: String(file ?? "") } });
+            default: {
+                const data: Record<string, string> = { file: String(file ?? "") };
+                const name = this.resolveOutgoingFileName(media);
+                if (name) {
+                    data.name = name;
+                }
+                segments.push({ type: "file", data });
                 break;
+            }
         }
 
         const caption = typeof media.caption === "string" ? media.caption : undefined;
@@ -1125,6 +1131,26 @@ export class OneBotAdapter implements PlatformAdapter {
             segments.push({ type: "text", data: { text: caption } });
         }
         return segments;
+    }
+
+    /**
+     * 计算发出去的文件在 NapCat 侧显示的文件名。
+     * 优先用调用方显式给的 media.fileName（sendFile 会自动填 basename）；
+     * 若没有（比如 agent 直接 sendMedia 只给了 file 路径），则回退到原始
+     * media.file 的 basename，避免 NapCat 生成 UUID 风格文件名、丢掉后缀。
+     */
+    private resolveOutgoingFileName(media: Record<string, unknown>): string | undefined {
+        if (typeof media.fileName === "string" && media.fileName.trim()) {
+            return media.fileName.trim();
+        }
+        const raw = media.file;
+        if (typeof raw !== "string") return undefined;
+        let value = raw.trim();
+        if (!value || value.startsWith("base64://") || value.startsWith("data:")) return undefined;
+        value = value.replace(/^file:\/\//i, "");
+        value = value.split(/[?#]/, 1)[0];
+        const base = path.basename(value);
+        return base ? base : undefined;
     }
 
     private normalizeOutgoingMessageArg(value: unknown): OneBotOutgoingMessage {

--- a/tests/onebot-adapter.test.ts
+++ b/tests/onebot-adapter.test.ts
@@ -335,4 +335,62 @@ describe("OneBotAdapter", () => {
 
         nc.dispose();
     });
+
+    it("should preserve fileName as OneBot file segment name", async () => {
+        const nc = makeNC();
+        const adapter = new OneBotAdapter(makeConfig(), nc);
+        const calls: Array<{ action: string; params: Record<string, unknown> }> = [];
+
+        // @ts-expect-error - override private method for payload inspection
+        adapter.callAction = async (action: string, params: Record<string, unknown>) => {
+            calls.push({ action, params });
+            return { message_id: 3 };
+        };
+
+        // @ts-expect-error - invoke private method for focused transport test
+        await adapter.sendMedia(
+            "onebot:group:979200391",
+            { type: "document", file: "media/report.pdf", fileName: "report.pdf" },
+            {},
+        );
+
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].action, "send_group_msg");
+        assert.equal(calls[0].params.group_id, 979200391);
+        assert.deepEqual(calls[0].params.message, [
+            { type: "file", data: { file: `file://${pathResolve(process.cwd(), "workspace", "media/report.pdf")}`, name: "report.pdf" } },
+        ]);
+
+        nc.dispose();
+    });
+
+    it("should fall back to file basename when fileName is omitted", async () => {
+        const nc = makeNC();
+        const adapter = new OneBotAdapter(makeConfig(), nc);
+        const calls: Array<{ action: string; params: Record<string, unknown> }> = [];
+
+        // @ts-expect-error - override private method for payload inspection
+        adapter.callAction = async (action: string, params: Record<string, unknown>) => {
+            calls.push({ action, params });
+            return { message_id: 4 };
+        };
+
+        // Mirrors how the agent actually sends files: sendMedia with a bare
+        // { type: "file", file } and no fileName. Without the basename fallback,
+        // NapCat drops the name and shows a UUID.
+        // @ts-expect-error - invoke private method for focused transport test
+        await adapter.sendMedia(
+            "onebot:private:1751431516",
+            { type: "file", file: "media/Hello World.txt" },
+            {},
+        );
+
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].action, "send_private_msg");
+        assert.deepEqual(calls[0].params.message, [
+            { type: "file", data: { file: `file://${pathResolve(process.cwd(), "workspace", "media/Hello World.txt")}`, name: "Hello World.txt" } },
+        ]);
+
+        nc.dispose();
+    });
 });


### PR DESCRIPTION
fix #48。

## 问题
通过 OneBot/NapCat 适配器发送文件时，接收端（QQ）显示的文件名为随机 UUID，原始文件名及后缀丢失。

## 根因
`src/adapter/onebot-adapter.ts` 的 `buildOutgoingSegments()` 在构造 OneBot file 消息段时仅设置 `data.file`，未设置 `data.name`。NapCat 在缺少展示文件名时会自行生成 UUID 风格名称。该适配器在接收方向本已使用 `data.name` 还原文件名，发送方向存在遗漏。

## 修改
在 file/document 段补充 `data.name`，取值规则如下：

1. 调用方显式提供 `fileName` 时优先采用（`sendFile` 会自动填入 basename）；
2. 未提供时，回退为原始 `media.file` 路径的 basename。

新增私有方法 `resolveOutgoingFileName()` 统一处理上述取值，并排除 `base64://`、`data:` 等非文件路径来源。

回退逻辑为必要项：`sendMedia({ type: "file", file })` 常在不带 `fileName` 的情况下被调用，缺少回退时文件名仍会丢失。

## 测试
- 新增两条回归测试，分别覆盖显式 `fileName` 与 basename 回退两条路径；
- `tests/onebot-adapter.test.ts` 全部通过（10/10）；
- 实机验证：在 QQ 上通过 `sendFile`、`sendMedia`（含自定义文件名）等路径实测，接收端文件名均正确显示。

<img width="698" height="524" alt="image" src="https://github.com/user-attachments/assets/68dfe73a-72dc-4693-bbf4-7201d7ef53a4" />
