### PR TITLE
feat: add Codex CLI as a background dreaming harness

### DIFF
--- a/.github/workflows/ghcr-publish.yml
+++ b/.github/workflows/ghcr-publish.yml
@@ -91,3 +91,19 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=copilot
           cache-to: type=gha,mode=max,scope=copilot
+
+      - name: Build and push Docker image with OpenAI Codex CLI
+        if: github.ref == 'refs/heads/agentic'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.agentic-with-codex
+          platforms: linux/amd64,linux/arm64
+          push: true
+          pull: true
+          build-args: |
+            BASE_IMAGE=${{ steps.image.outputs.name }}:agentic
+          tags: ${{ steps.image.outputs.name }}:agentic-with-codex
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=codex
+          cache-to: type=gha,mode=max,scope=codex

--- a/Dockerfile.agentic-with-codex
+++ b/Dockerfile.agentic-with-codex
@@ -1,0 +1,9 @@
+ARG BASE_IMAGE=ghcr.io/archeb/cybergroupmate:agentic
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Install the official OpenAI Codex CLI package.
+RUN npm install -g @openai/codex \
+    && codex --version \
+    && codex exec --help >/dev/null

--- a/README.md
+++ b/README.md
@@ -215,14 +215,15 @@ docker run -d \
 docker logs -f cybergroupmate
 ```
 
-`agentic` 分支还会额外发布两个工具预装变体：
+`agentic` 分支还会额外发布三个工具预装变体：
 
 ```bash
 docker pull ghcr.io/archeb/cybergroupmate:agentic-with-cc       # 预装 Claude Code
+docker pull ghcr.io/archeb/cybergroupmate:agentic-with-codex    # 预装 Codex CLI
 docker pull ghcr.io/archeb/cybergroupmate:agentic-with-copilot  # 预装 Copilot CLI
 ```
 
-其中 `agentic-with-cc` 通过 Anthropic 官方原生安装脚本安装 Claude Code；`agentic-with-copilot` 通过官方 `@github/copilot` npm 包安装 GitHub Copilot CLI（`copilot` 命令）。运行时仍需按各工具要求完成认证。
+其中 `agentic-with-cc` 通过 Anthropic 官方原生安装脚本安装 Claude Code；`agentic-with-codex` 和 `agentic-with-copilot` 分别安装官方 `@openai/codex`、`@github/copilot` npm 包。运行时仍需按各工具要求完成认证。
 
 发布版本（v* tag）也会同步推送，可使用语义化版本号拉取：
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -489,8 +489,9 @@ metrics:
 #   enabled: true               # 是否启用 MCP Server（默认 true）
 #   mcp_port: 3100              # MCP Server 监听端口（默认 3100，仅本机 127.0.0.1）
 #   mcp_token: "your-token"     # 认证 token（不设则每次启动随机生成）
-#   harness: "claude-code"      # harness 类型："claude-code" 或 "copilot"
+#   harness: "claude-code"      # harness 类型："claude-code"、"codex" 或 "copilot"
 #   claude_code_path: "claude"  # Claude CLI 路径（harness=claude-code 时，默认 PATH 中的 claude）
+#   codex_path: "codex"         # Codex CLI 路径（harness=codex 时，默认 PATH 中的 codex）
 #   copilot_path: "copilot"     # Copilot CLI 路径（harness=copilot 时，默认 PATH 中的 copilot）
 #   harness_model: "sonnet"     # harness 使用的模型名称
 #   max_budget_usd: 5           # 单次做梦的最大花费（美元，仅 Claude Code 支持）

--- a/docs/background-agent-implementation.md
+++ b/docs/background-agent-implementation.md
@@ -102,6 +102,7 @@ src/harness/
 ├─ manager.ts         — HarnessManager 类
 ├─ launchers/
 │   ├─ claude-code.ts — Claude Code 启动逻辑
+│   ├─ codex-cli.ts — Codex CLI 启动逻辑
 │   └─ copilot-cli.ts — Copilot CLI 启动逻辑（Phase 4）
 ├─ types.ts           — 接口定义
 └─ prompt.ts          — 固定层 prompt 生成
@@ -194,7 +195,7 @@ scheduler.registerBuiltinCron('background-dreaming', config.backgroundAgent?.sch
 
 ---
 
-## Phase 4: 第二 Harness + 打磨 ✅ 已完成
+## Phase 4: 额外 Harness + 打磨 ✅ 已完成
 
 ### 4.1 Copilot CLI Launcher ✅
 
@@ -208,7 +209,8 @@ scheduler.registerBuiltinCron('background-dreaming', config.backgroundAgent?.sch
 ### 4.2 配置扩展 ✅
 
 `backgroundAgent` 配置增加：
-- `harness`: `"claude-code" | "copilot"` 双 harness 支持
+- `harness`: `"claude-code" | "codex" | "copilot"` 三种 harness 支持
+- `codexPath`: Codex CLI 路径
 - `copilotPath`: Copilot CLI 路径
 - `harnessModel`: 通用模型名称（兼容旧 `claudeModel`）
 - `extraArgs`: 自定义启动参数（字符串数组）
@@ -216,7 +218,7 @@ scheduler.registerBuiltinCron('background-dreaming', config.backgroundAgent?.sch
 ### 4.3 Dashboard ✅
 
 - 状态面板：显示当前 harness 类型
-- 设置面板：harness 选择（Claude Code / Copilot CLI）、模型输入、路径配置、自定义启动参数
+- 设置面板：harness 选择（Claude Code / Codex CLI / Copilot CLI）、模型输入、路径配置、自定义启动参数
 
 **预计工作量**：2-3 天
 
@@ -230,7 +232,7 @@ Phase 1: MCP Server                     ✅ M1 已完成
 Phase 1.5: sandbox_call（sandbox 执行）  ✅ 已完成
 Phase 2: HarnessManager                 ✅ 已完成
 Phase 3: 系统集成（idle/reflection）     ✅ 已完成
-Phase 4: 第二 Harness + 打磨            ✅ 已完成
+Phase 4: 额外 Harness + 打磨            ✅ 已完成
 ```
 
 ---
@@ -244,4 +246,4 @@ Phase 4: 第二 Harness + 打磨            ✅ 已完成
 | M1.5: sandbox 执行 | Background Agent 能通过 sandbox_call 执行平台 API | ✅ |
 | M2: 首次做梦 | Background Agent 被手动拉起，执行一个完整任务并通过 notify 回传结果 | ✅ |
 | M3: 自动做梦 | 凌晨 3 点自动拉起，第二天早上有成果 | ✅ |
-| M4: 双 Harness | Claude Code 和 Copilot CLI 都能跑 | ✅ |
+| M4: 多 Harness | Claude Code、Codex CLI 和 Copilot CLI 都能跑 | ✅ |

--- a/docs/background-agent.md
+++ b/docs/background-agent.md
@@ -33,7 +33,7 @@
 
 - Background Agent 与 Meta Agent **平级**，共享同一套 Core 能力（memory、conversation、agents、notify、skills），通过 MCP 协议访问
 - 人格设定与 Miu 一致，能看到记忆、画像、session digest
-- 运行在外部 agent harness（Claude Code / GitHub Copilot CLI）中，拥有完整的开发环境
+- 运行在外部 agent harness（Claude Code / OpenAI Codex CLI / GitHub Copilot CLI）中，拥有完整的开发环境
 
 ---
 
@@ -371,11 +371,11 @@ Background Agent 通过 MCP 访问的 Core 能力：
 
 ## 12. 验证计划
 
-先用 Claude Code 和 GitHub Copilot CLI 两个 harness 验证：
+先用 Claude Code、OpenAI Codex CLI 和 GitHub Copilot CLI 三个 harness 验证：
 
-1. **MCP 连通**：两个 harness 都能连上 CyberGroupmate MCP server，调通 digest/notify
+1. **MCP 连通**：三个 harness 都能连上 CyberGroupmate MCP server，调通 digest/notify
 2. **长任务执行**：给一个"写 skill"的任务，对比质量和耗时
-3. **Prompt 兼容性**：同一份 prompt 在两个 harness 里表现是否一致
+3. **Prompt 兼容性**：同一份 prompt 在三个 harness 里表现是否一致
 
 ---
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -560,8 +560,9 @@ export interface AppConfig {
         enabled?: boolean;
         mcpPort?: number;
         mcpToken?: string;
-        harness?: "claude-code" | "copilot";
+        harness?: "claude-code" | "codex" | "copilot";
         claudeCodePath?: string;
+        codexPath?: string;
         copilotPath?: string;
         harnessModel?: string;
         schedule?: string;
@@ -1142,6 +1143,7 @@ function parseBackgroundAgentConfig(fileConfig: Record<string, unknown>): AppCon
     if (!raw || typeof raw !== "object") return undefined;
     const harnessStr = str(raw.harness);
     const harness = harnessStr === "claude-code" ? "claude-code" as const
+        : harnessStr === "codex" ? "codex" as const
         : harnessStr === "copilot" ? "copilot" as const
         : undefined;
     return {
@@ -1150,6 +1152,7 @@ function parseBackgroundAgentConfig(fileConfig: Record<string, unknown>): AppCon
         mcpToken: str(raw.mcp_token) ?? undefined,
         harness,
         claudeCodePath: str(raw.claude_code_path) ?? undefined,
+        codexPath: str(raw.codex_path) ?? undefined,
         copilotPath: str(raw.copilot_path) ?? undefined,
         harnessModel: str(raw.harness_model) ?? str(raw.claude_model) ?? undefined,
         claudeModel: str(raw.claude_model) ?? undefined,
@@ -1717,6 +1720,7 @@ export function serializeConfigToObject(config: AppConfig): Record<string, unkno
         if (config.backgroundAgent.mcpToken != null) ba.mcp_token = config.backgroundAgent.mcpToken;
         if (config.backgroundAgent.harness != null) ba.harness = config.backgroundAgent.harness;
         if (config.backgroundAgent.claudeCodePath != null) ba.claude_code_path = config.backgroundAgent.claudeCodePath;
+        if (config.backgroundAgent.codexPath != null) ba.codex_path = config.backgroundAgent.codexPath;
         if (config.backgroundAgent.copilotPath != null) ba.copilot_path = config.backgroundAgent.copilotPath;
         if (config.backgroundAgent.harnessModel != null) ba.harness_model = config.backgroundAgent.harnessModel;
         if (config.backgroundAgent.claudeModel != null) ba.claude_model = config.backgroundAgent.claudeModel;

--- a/src/dashboard/ui/src/panels/BackgroundAgentPanel.svelte
+++ b/src/dashboard/ui/src/panels/BackgroundAgentPanel.svelte
@@ -276,6 +276,11 @@
     const subtype = ev.subtype == null ? '' : String(ev.subtype);
     if (NOISE.has(type) || (subtype && (NOISE.has(subtype) || NOISE.has(`${type}/${subtype}`)))) return [];
 
+    // Codex CLI (`codex exec --json`)
+    if (type === 'error') return [{ kind: 'error', text: stringifyContent(ev.message ?? ev.error ?? ev) }];
+    if (type.startsWith('thread.') || type.startsWith('turn.')) return [codexLifecycle(ev, type)];
+    if (type.startsWith('item.')) return codexItem(ev, type);
+
     // Claude Code (stream-json)
     if (type === 'assistant') return claudeAssistant(ev);
     if (type === 'user') return claudeUser(ev);
@@ -367,6 +372,83 @@
     return { kind: 'result', label: '运行结果', text: typeof ev.result === 'string' ? ev.result : '', chips };
   }
 
+  function codexLifecycle(ev, type) {
+    if (type === 'thread.started') {
+      return { kind: 'session', label: 'Codex 会话', chips: [{ k: 'Thread', v: ev.thread_id }] };
+    }
+    if (type === 'turn.started') return { kind: 'session', label: 'Codex 回合开始' };
+    if (type === 'turn.failed') {
+      return { kind: 'error', label: 'Codex 回合失败', text: stringifyContent(ev.error ?? ev.message ?? '') };
+    }
+    if (type === 'turn.completed') {
+      const usage = ev.usage ?? {};
+      const chips = [
+        { k: '输入', v: usage.input_tokens },
+        { k: '缓存', v: usage.cached_input_tokens },
+        { k: '输出', v: usage.output_tokens },
+        { k: '推理', v: usage.reasoning_output_tokens },
+      ].filter((c) => c.v != null);
+      return { kind: 'result', label: 'Codex 回合完成', chips };
+    }
+    return { kind: 'session', label: type.replace('.', ' · ') };
+  }
+
+  function codexItem(ev, type) {
+    const item = ev.item ?? {};
+    const completed = type === 'item.completed';
+    if (item.type === 'agent_message') {
+      return completed && item.text ? [{ kind: 'assistant', text: item.text }] : [];
+    }
+    if (item.type === 'reasoning') {
+      return completed && item.text ? [{ kind: 'thinking', text: item.text }] : [];
+    }
+    if (item.type === 'command_execution') {
+      if (!completed) {
+        return type === 'item.started'
+          ? [{ kind: 'tool_use', tool: { name: 'shell', input: item.command } }]
+          : [];
+      }
+      return [{
+        kind: 'tool_result',
+        tool: {
+          name: 'shell',
+          ok: item.status === 'completed' && (item.exit_code == null || item.exit_code === 0),
+          output: item.aggregated_output ?? item.output ?? '',
+        },
+      }];
+    }
+    if (item.type === 'mcp_tool_call') {
+      const name = [item.server, item.tool].filter(Boolean).join('.') || 'mcp';
+      if (!completed) {
+        return type === 'item.started'
+          ? [{ kind: 'tool_use', tool: { name, input: item.arguments } }]
+          : [];
+      }
+      return [{
+        kind: 'tool_result',
+        tool: {
+          name,
+          ok: item.status === 'completed' && !item.error,
+          output: stringifyContent(item.result ?? item.error ?? ''),
+        },
+      }];
+    }
+    if (item.type === 'web_search') {
+      return completed
+        ? [{ kind: 'tool_result', tool: { name: 'web_search', ok: item.status === 'completed', output: stringifyContent(item.result ?? '') } }]
+        : type === 'item.started'
+          ? [{ kind: 'tool_use', tool: { name: 'web_search', input: item.query } }]
+          : [];
+    }
+    if (item.type === 'file_change' && completed) {
+      return [{ kind: 'meta', label: '文件改动', text: stringifyContent(item.changes ?? item) }];
+    }
+    if (item.type === 'plan_update' && completed) {
+      return [{ kind: 'meta', label: '计划更新', text: stringifyContent(item.plan ?? item) }];
+    }
+    return completed ? [{ kind: 'raw', label: item.type ?? type, text: stringifyContent(item) }] : [];
+  }
+
   function copilotAssistant(ev) {
     const text = ev?.data?.content;
     if (typeof text === 'string' && text.trim()) {
@@ -443,7 +525,7 @@
       <div class="text-sm text-base-content/60">正在加载做梦系统状态...</div>
     {:else if !status?.enabled}
       <div class="alert">
-        <span>Background Agent 未启用。在配置编辑 → 做梦系统中选择一个 Harness 类型（Claude Code 或 Copilot CLI）。</span>
+        <span>Background Agent 未启用。在配置编辑 → 做梦系统中选择一个 Harness 类型（Claude Code、Codex CLI 或 Copilot CLI）。</span>
       </div>
     {:else}
       <div class="stats stats-vertical lg:stats-horizontal shadow-sm bg-base-200">

--- a/src/dashboard/ui/src/panels/BackgroundAgentPanel.svelte
+++ b/src/dashboard/ui/src/panels/BackgroundAgentPanel.svelte
@@ -413,7 +413,7 @@
         tool: {
           name: 'shell',
           ok: item.status === 'completed' && (item.exit_code == null || item.exit_code === 0),
-          output: item.aggregated_output ?? item.output ?? '',
+          output: stringifyContent(item.aggregated_output ?? item.output ?? ''),
         },
       }];
     }

--- a/src/dashboard/ui/src/panels/config/BackgroundAgentTab.svelte
+++ b/src/dashboard/ui/src/panels/config/BackgroundAgentTab.svelte
@@ -15,7 +15,7 @@
   <i class="fa-solid fa-moon opacity-50 mr-1"></i> Background Agent
 </h3>
 <p class="text-xs opacity-50 mb-3">
-  做梦系统配置。MCP Server 暴露内部 API 给外部 harness（Claude Code / Copilot CLI），harness 在后台执行任务。
+  做梦系统配置。MCP Server 暴露内部 API 给外部 harness（Claude Code / Codex CLI / Copilot CLI），harness 在后台执行任务。
 </p>
 
 <div class="cfg-grid-3">
@@ -44,6 +44,7 @@
     <select class="select select-xs select-bordered w-full" bind:value={config.backgroundAgent.harness}>
       <option value={undefined}>不启用</option>
       <option value="claude-code">Claude Code</option>
+      <option value="codex">Codex CLI</option>
       <option value="copilot">Copilot CLI</option>
     </select>
   </label>
@@ -51,7 +52,7 @@
     <span class="cfg-label">模型</span>
     <input type="text" class="input input-xs input-bordered w-full"
       bind:value={config.backgroundAgent.harnessModel}
-      placeholder={config.backgroundAgent.harness === "copilot" ? "gpt-5.2" : "claude-sonnet-4-6"} />
+      placeholder={config.backgroundAgent.harness === "claude-code" ? "claude-sonnet-4-6" : "gpt-5.2"} />
   </label>
   <label class="cfg-field">
     <span class="cfg-label">单次预算 (USD)</span>
@@ -66,6 +67,12 @@
       <span class="cfg-label">Claude CLI 路径</span>
       <input type="text" class="input input-xs input-bordered w-full"
         bind:value={config.backgroundAgent.claudeCodePath} placeholder="claude" />
+    </label>
+  {:else if config.backgroundAgent.harness === "codex"}
+    <label class="cfg-field">
+      <span class="cfg-label">Codex CLI 路径</span>
+      <input type="text" class="input input-xs input-bordered w-full"
+        bind:value={config.backgroundAgent.codexPath} placeholder="codex" />
     </label>
   {:else if config.backgroundAgent.harness === "copilot"}
     <label class="cfg-field">

--- a/src/harness/home.ts
+++ b/src/harness/home.ts
@@ -2,29 +2,42 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-export type HarnessInstructionTarget = "claude-code" | "copilot" | string;
+export type HarnessInstructionTarget = "claude-code" | "codex" | "copilot" | string;
 
 export function getHarnessHome(env: NodeJS.ProcessEnv = process.env): string {
     return env.HOME || env.USERPROFILE || homedir();
 }
 
-export function getHarnessInstructionPath(homeDir: string, launcherName: HarnessInstructionTarget): string {
+export function getHarnessInstructionPath(
+    homeDir: string,
+    launcherName: HarnessInstructionTarget,
+    env: NodeJS.ProcessEnv = process.env,
+): string {
     if (launcherName === "copilot") {
         return join(homeDir, ".copilot", "copilot-instructions.md");
+    }
+    if (launcherName === "codex") {
+        const codexHome = env.CODEX_HOME?.trim() || join(homeDir, ".codex");
+        return join(codexHome, "AGENTS.override.md");
     }
     return join(homeDir, ".claude", "CLAUDE.md");
 }
 
-export function writeHarnessInstructions(homeDir: string, launcherName: HarnessInstructionTarget, systemPrompt: string): string {
-    const instructionPath = getHarnessInstructionPath(homeDir, launcherName);
+export function writeHarnessInstructions(
+    homeDir: string,
+    launcherName: HarnessInstructionTarget,
+    systemPrompt: string,
+    env: NodeJS.ProcessEnv = process.env,
+): string {
+    const instructionPath = getHarnessInstructionPath(homeDir, launcherName, env);
     mkdirSync(dirname(instructionPath), { recursive: true });
     writeFileSync(instructionPath, systemPrompt.trim() + "\n", "utf-8");
     return instructionPath;
 }
 
 /**
- * 做梦前写入 harness 指令（CLAUDE.md / copilot-instructions.md），并返回一个 restore 函数，
- * 用于做梦结束后把这个共享文件还原成做梦前的样子——避免污染同机器上其它 claude 实例。
+ * 做梦前写入 harness 指令（CLAUDE.md / copilot-instructions.md / AGENTS.override.md），并返回一个 restore 函数，
+ * 用于做梦结束后把这个共享文件还原成做梦前的样子——避免污染同机器上其它 harness 实例。
  *
  * 做梦前如果文件已存在，记下原内容并在 restore 时写回；如果原本不存在，restore 时删除我们写的文件。
  */
@@ -32,12 +45,13 @@ export function writeHarnessInstructionsWithRestore(
     homeDir: string,
     launcherName: HarnessInstructionTarget,
     systemPrompt: string,
+    env: NodeJS.ProcessEnv = process.env,
 ): { instructionPath: string; restore: () => void } {
-    const instructionPath = getHarnessInstructionPath(homeDir, launcherName);
+    const instructionPath = getHarnessInstructionPath(homeDir, launcherName, env);
     const existedBefore = existsSync(instructionPath);
     const previousContent = existedBefore ? readFileSync(instructionPath, "utf-8") : null;
 
-    writeHarnessInstructions(homeDir, launcherName, systemPrompt);
+    writeHarnessInstructions(homeDir, launcherName, systemPrompt, env);
 
     let restored = false;
     const restore = () => {

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -1,5 +1,6 @@
 export { HarnessManager, type HarnessManagerConfig } from "./manager.js";
-export { serializeClaudeMcpConfig, serializeCopilotMcpConfig } from "./mcp-config.js";
+export { serializeClaudeMcpConfig, serializeCodexMcpConfig, serializeCopilotMcpConfig } from "./mcp-config.js";
 export { ClaudeCodeLauncher } from "./launchers/claude-code.js";
+export { CodexCliLauncher } from "./launchers/codex-cli.js";
 export { CopilotCliLauncher } from "./launchers/copilot-cli.js";
 export type { HarnessLauncher, HarnessMcpConfig, HarnessNotify, HarnessRunRecord, HarnessLaunchOptions } from "./types.js";

--- a/src/harness/launchers/codex-cli.ts
+++ b/src/harness/launchers/codex-cli.ts
@@ -1,0 +1,60 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createLogger } from "../../core/logger.js";
+import { buildHarnessEnv, getHarnessHome, writeHarnessInstructionsWithRestore } from "../home.js";
+import { serializeCodexMcpConfig } from "../mcp-config.js";
+import type { HarnessLaunchOptions, HarnessLauncher } from "../types.js";
+
+const log = createLogger("harness-codex-cli");
+
+export class CodexCliLauncher implements HarnessLauncher {
+    readonly name = "codex";
+    private codexPath: string;
+
+    constructor(codexPath?: string) {
+        this.codexPath = codexPath ?? "codex";
+    }
+
+    async start(options: HarnessLaunchOptions): Promise<ChildProcess> {
+        const homeDir = getHarnessHome();
+        // Codex gives AGENTS.override.md precedence, so the dreaming prompt is guaranteed to win for this run.
+        const { instructionPath, restore } = writeHarnessInstructionsWithRestore(homeDir, this.name, options.systemPrompt);
+
+        const args = [
+            "exec",
+            "--json",
+            "--ephemeral",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--ignore-user-config",
+            "-c", `mcp_servers=${serializeCodexMcpConfig(options.mcpConfig)}`,
+        ];
+
+        if (options.model) {
+            args.push("--model", options.model);
+        }
+
+        if (options.extraArgs) {
+            args.push(...options.extraArgs);
+        }
+
+        args.push(options.prompt);
+
+        log.info("launching codex cli", {
+            codex: this.codexPath,
+            model: options.model ?? "(default)",
+            home: homeDir,
+            instructionPath,
+        });
+
+        const child = spawn(this.codexPath, args, {
+            cwd: options.workDir,
+            stdio: ["ignore", "pipe", "pipe"],
+            env: buildHarnessEnv(process.env),
+        });
+
+        const cleanup = () => { restore(); };
+        child.once("exit", cleanup);
+        child.once("error", cleanup);
+
+        return child;
+    }
+}

--- a/src/harness/manager.ts
+++ b/src/harness/manager.ts
@@ -653,7 +653,7 @@ export class HarnessManager {
                         record.resultSummary = item.text.slice(0, 500);
                     }
                 } else if (event.type === "turn.completed") {
-                    log.info("codex harness turn completed", { usage: event.usage });
+                    log.debug("codex harness turn completed", { usage: event.usage });
                     onResult?.();
                 }
             } catch {

--- a/src/harness/manager.ts
+++ b/src/harness/manager.ts
@@ -535,6 +535,13 @@ export class HarnessManager {
                 }
                 if (typeof raw.result === "string") record.resultSummary = raw.result.slice(0, 500);
                 if (record.exitCode == null && raw.exitCode != null) record.exitCode = Number(raw.exitCode);
+            } else if (raw?.type === "item.completed") {
+                const item = raw.item && typeof raw.item === "object"
+                    ? raw.item as Record<string, unknown>
+                    : null;
+                if (item?.type === "agent_message" && typeof item.text === "string") {
+                    record.resultSummary = item.text.slice(0, 500);
+                }
             }
         }
         if (record.durationMs == null && record.endedAt != null) record.durationMs = record.endedAt - record.startedAt;
@@ -638,6 +645,16 @@ export class HarnessManager {
                     if (event.duration_ms != null) record.durationMs = Number(event.duration_ms);
                     if (event.result) record.resultSummary = String(event.result).slice(0, 500);
                     onResult?.();
+                } else if (event.type === "item.completed") {
+                    const item = event.item && typeof event.item === "object"
+                        ? event.item as Record<string, unknown>
+                        : null;
+                    if (item?.type === "agent_message" && typeof item.text === "string") {
+                        record.resultSummary = item.text.slice(0, 500);
+                    }
+                } else if (event.type === "turn.completed") {
+                    log.info("codex harness turn completed", { usage: event.usage });
+                    onResult?.();
                 }
             } catch {
                 log.debug("harness stdout", { line: line.slice(0, 200) });
@@ -698,6 +715,29 @@ function summarizeHarnessEvent(event: Record<string, unknown>): string {
         const cost = event.cost_usd != null ? ` cost=$${event.cost_usd}` : "";
         const duration = event.duration_ms != null ? ` duration=${event.duration_ms}ms` : "";
         return result ? `result:${cost}${duration} ${truncate(result, 500)}` : `result:${cost}${duration}`.trim();
+    }
+
+    if (type.startsWith("item.")) {
+        const item = event.item && typeof event.item === "object"
+            ? event.item as Record<string, unknown>
+            : null;
+        if (item?.type === "agent_message" && typeof item.text === "string") {
+            return `assistant: ${truncate(item.text, 700)}`;
+        }
+        if (item?.type === "reasoning" && typeof item.text === "string") {
+            return `reasoning: ${truncate(item.text, 700)}`;
+        }
+        if (item?.type === "command_execution") {
+            return truncate(`${type}: ${String(item.command ?? "command")} (${String(item.status ?? "")})`, 700);
+        }
+        if (item?.type === "mcp_tool_call") {
+            const tool = [item.server, item.tool].filter(Boolean).join(".") || "mcp";
+            return truncate(`${type}: ${tool} (${String(item.status ?? "")})`, 700);
+        }
+    }
+
+    if (type === "turn.completed" && event.usage && typeof event.usage === "object") {
+        return `turn.completed ${JSON.stringify(event.usage)}`;
     }
 
     const message = event.message;

--- a/src/harness/mcp-config.ts
+++ b/src/harness/mcp-config.ts
@@ -15,6 +15,15 @@ export function serializeCopilotMcpConfig(config: HarnessMcpConfig): string {
     }, null, 2);
 }
 
+/** Serialize MCP servers as a TOML inline table accepted by `codex -c mcp_servers=...`. */
+export function serializeCodexMcpConfig(config: HarnessMcpConfig): string {
+    const servers = Object.entries(config.mcpServers).map(([name, server]) => {
+        const entry = toCodexMcpServer(server, name === "cybergroupmate");
+        return `${tomlKey(name)} = ${tomlInlineTable(entry)}`;
+    });
+    return `{ ${servers.join(", ")} }`;
+}
+
 function toCopilotMcpServer(server: HarnessMcpServerConfig): Record<string, unknown> {
     if (server.type === "streamable-http") {
         const entry: Record<string, unknown> = {
@@ -34,4 +43,42 @@ function toCopilotMcpServer(server: HarnessMcpServerConfig): Record<string, unkn
     if (server.args) entry.args = server.args;
     if (server.env) entry.env = server.env;
     return entry;
+}
+
+function toCodexMcpServer(server: HarnessMcpServerConfig, required: boolean): Record<string, unknown> {
+    if (server.type === "streamable-http") {
+        const entry: Record<string, unknown> = {};
+        if (server.url) entry.url = server.url;
+        if (server.headers) entry.http_headers = server.headers;
+        if (required) entry.required = true;
+        return entry;
+    }
+
+    const entry: Record<string, unknown> = {};
+    if (server.command) entry.command = server.command;
+    if (server.args) entry.args = server.args;
+    if (server.env) entry.env = server.env;
+    if (required) entry.required = true;
+    return entry;
+}
+
+function tomlKey(value: string): string {
+    return /^[A-Za-z0-9_-]+$/.test(value) ? value : tomlString(value);
+}
+
+function tomlString(value: string): string {
+    return JSON.stringify(value);
+}
+
+function tomlInlineTable(value: Record<string, unknown>): string {
+    const entries = Object.entries(value).map(([key, item]) => `${tomlKey(key)} = ${tomlValue(item)}`);
+    return `{ ${entries.join(", ")} }`;
+}
+
+function tomlValue(value: unknown): string {
+    if (typeof value === "string") return tomlString(value);
+    if (typeof value === "boolean" || typeof value === "number") return String(value);
+    if (Array.isArray(value)) return `[${value.map(tomlValue).join(", ")}]`;
+    if (value && typeof value === "object") return tomlInlineTable(value as Record<string, unknown>);
+    throw new TypeError(`Unsupported TOML value: ${String(value)}`);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1282,12 +1282,14 @@ async function main(): Promise<void> {
 
     // ─── Background Agent HarnessManager ───
     const bgHarness = appConfig.backgroundAgent?.harness;
-    if (mcpServerInstance && (bgHarness === "claude-code" || bgHarness === "copilot")) {
-        const { HarnessManager, ClaudeCodeLauncher, CopilotCliLauncher } = await import("./harness/index.js");
+    if (mcpServerInstance && (bgHarness === "claude-code" || bgHarness === "codex" || bgHarness === "copilot")) {
+        const { HarnessManager, ClaudeCodeLauncher, CodexCliLauncher, CopilotCliLauncher } = await import("./harness/index.js");
         const { buildDreamingDigest } = await import("./harness/dreaming-context.js");
         const launcher = bgHarness === "copilot"
             ? new CopilotCliLauncher(appConfig.backgroundAgent!.copilotPath)
-            : new ClaudeCodeLauncher(appConfig.backgroundAgent!.claudeCodePath);
+            : bgHarness === "codex"
+                ? new CodexCliLauncher(appConfig.backgroundAgent!.codexPath)
+                : new ClaudeCodeLauncher(appConfig.backgroundAgent!.claudeCodePath);
         const model = appConfig.backgroundAgent!.harnessModel ?? appConfig.backgroundAgent!.claudeModel;
         harnessManager = new HarnessManager({
             launcher,

--- a/tests/harness-manager.test.ts
+++ b/tests/harness-manager.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 
 import { buildHarnessEnv, getHarnessHome, getHarnessInstructionPath, writeHarnessInstructions } from "../src/harness/home.js";
 import { HarnessManager } from "../src/harness/manager.js";
-import { serializeClaudeMcpConfig, serializeCopilotMcpConfig } from "../src/harness/mcp-config.js";
+import { serializeClaudeMcpConfig, serializeCodexMcpConfig, serializeCopilotMcpConfig } from "../src/harness/mcp-config.js";
 import { buildSystemPrompt, buildTaskPrompt } from "../src/harness/prompt.js";
 import type { HarnessMcpConfig } from "../src/harness/types.js";
 
@@ -75,7 +75,7 @@ describe("HarnessManager MCP config loading", () => {
 });
 
 describe("Harness MCP config serialization", () => {
-    it("keeps Claude Code streamable-http and maps Copilot to its MCP schema", () => {
+    it("maps each harness schema and escapes Codex TOML boundary values", () => {
         const config: HarnessMcpConfig = {
             mcpServers: {
                 "remote-http": {
@@ -86,8 +86,12 @@ describe("Harness MCP config serialization", () => {
                 "stdio-tool": {
                     type: "stdio",
                     command: "node",
-                    args: ["server.js"],
-                    env: { API_KEY: "secret" },
+                    args: ["server.js", "say \"hello\""],
+                    env: { API_KEY: "secret value" },
+                },
+                cybergroupmate: {
+                    type: "streamable-http",
+                    url: "http://127.0.0.1:3100/mcp?token=dream",
                 },
             },
         };
@@ -104,12 +108,24 @@ describe("Harness MCP config serialization", () => {
                 "stdio-tool": {
                     type: "local",
                     command: "node",
-                    args: ["server.js"],
-                    env: { API_KEY: "secret" },
+                    args: ["server.js", "say \"hello\""],
+                    env: { API_KEY: "secret value" },
+                    tools: ["*"],
+                },
+                cybergroupmate: {
+                    type: "http",
+                    url: "http://127.0.0.1:3100/mcp?token=dream",
                     tools: ["*"],
                 },
             },
         });
+
+        assert.equal(
+            serializeCodexMcpConfig(config),
+            '{ remote-http = { url = "http://127.0.0.1:9999/mcp", http_headers = { Authorization = "Bearer token" } }, '
+            + 'stdio-tool = { command = "node", args = ["server.js", "say \\"hello\\""], env = { API_KEY = "secret value" } }, '
+            + 'cybergroupmate = { url = "http://127.0.0.1:3100/mcp?token=dream", required = true } }',
+        );
     });
 });
 
@@ -145,17 +161,24 @@ describe("Harness prompt and user home handling", () => {
         try {
             const claudeHome = getHarnessHome({ HOME: join(root, "user-home") });
             const copilotHome = getHarnessHome({ HOME: join(root, "user-home") });
+            const codexHome = getHarnessHome({ HOME: join(root, "user-home") });
+            const codexEnv = { CODEX_HOME: join(root, "codex-home") };
             const claudePath = writeHarnessInstructions(claudeHome, "claude-code", "system for claude");
             const copilotPath = writeHarnessInstructions(copilotHome, "copilot", "system for copilot");
+            const codexPath = writeHarnessInstructions(codexHome, "codex", "system for codex", codexEnv);
 
             assert.equal(claudePath, getHarnessInstructionPath(claudeHome, "claude-code"));
             assert.equal(copilotPath, getHarnessInstructionPath(copilotHome, "copilot"));
+            assert.equal(codexPath, getHarnessInstructionPath(codexHome, "codex", codexEnv));
             assert.ok(claudePath.endsWith(join(".claude", "CLAUDE.md")));
             assert.ok(copilotPath.endsWith(join(".copilot", "copilot-instructions.md")));
+            assert.equal(codexPath, join(root, "codex-home", "AGENTS.override.md"));
             assert.equal(readFileSync(claudePath, "utf-8"), "system for claude\n");
             assert.equal(readFileSync(copilotPath, "utf-8"), "system for copilot\n");
+            assert.equal(readFileSync(codexPath, "utf-8"), "system for codex\n");
             assert.equal(existsSync(claudePath), true);
             assert.equal(existsSync(copilotPath), true);
+            assert.equal(existsSync(codexPath), true);
 
             const env = buildHarnessEnv({ HOME: "real-home", USERPROFILE: "real-profile" }, { CLAUDE_CODE_ENTRYPOINT: "background-agent" });
             assert.equal(env.HOME, "real-home");


### PR DESCRIPTION
## Summary

Add OpenAI Codex CLI as a third Background Agent harness alongside Claude Code and GitHub Copilot CLI.

## Changes

- Add a `CodexCliLauncher` based on `codex exec --json`
- Inject HTTP and stdio MCP servers through per-run TOML config overrides
- Mark the internal `cybergroupmate` MCP server as required
- Load dreaming instructions through `CODEX_HOME/AGENTS.override.md` and restore the previous file after each run
- Parse Codex JSONL events and display messages, reasoning, commands, MCP calls, file changes, and token usage in the Dashboard
- Add `codex` / `codex_path` configuration support
- Add the `agentic-with-codex` GHCR image variant
- Update configuration examples and Background Agent documentation

## Configuration

```yaml
background_agent:
  harness: codex
  codex_path: codex
  harness_model: your-model
```

## Validation

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec tsx --test tests/harness-manager.test.ts`
- [x] Dashboard production build
- [x] Codex CLI parsing of generated HTTP/stdio MCP configuration
- [x] Manual Background Agent run with Codex CLI
