### PR TITLE
fix: preserve Codex user configuration

### DIFF
--- a/src/harness/launchers/codex-cli.ts
+++ b/src/harness/launchers/codex-cli.ts
@@ -24,7 +24,6 @@ export class CodexCliLauncher implements HarnessLauncher {
             "--json",
             "--ephemeral",
             "--dangerously-bypass-approvals-and-sandbox",
-            "--ignore-user-config",
             "-c", `mcp_servers=${serializeCodexMcpConfig(options.mcpConfig)}`,
         ];
 


### PR DESCRIPTION
## Summary

Remove `--ignore-user-config` from the Codex background harness invocation.

## Why

This is a follow-up to #50. The harness already supplies its model, permission mode, and per-run MCP configuration explicitly, so ignoring the entire user `config.toml` is unnecessarily broad. It also prevents valid Codex settings such as custom providers, proxies, and feature flags from being applied to background runs.

## Impact

Codex background runs now preserve the user's normal CLI configuration while retaining the harness-specific command-line overrides.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec tsx --test tests/harness-manager.test.ts` (4/4 passed)
