### PR TITLE
fix: honor llm_routing.timeouts for meta and session components

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import { createMemoryStore } from "./core/memory-factory.js";
 import {
     loadConfig,
     resolveComponentProfiles,
+    resolveComponentTimeout,
     resolveEmbeddingConfig,
     type AppConfig,
     type EnvironmentVariable,
@@ -1150,7 +1151,7 @@ async function main(): Promise<void> {
         getLlmConfigs: () => resolveComponentProfiles("meta", loadConfig()),
         maxTurns: 10,
         codeTimeout: 30_000,
-        llmTimeoutMs: 60_000,
+        llmTimeoutMs: resolveComponentTimeout("meta", loadConfig()) ?? 60_000,
     }));
 
     log.info("MainAgentLoop 配置完成");

--- a/src/sandbox/session-runner.ts
+++ b/src/sandbox/session-runner.ts
@@ -24,6 +24,7 @@ import {
     type ImagePart,
 } from "../core/llm.js";
 import type { LLMConfig } from "../core/config.js";
+import { resolveComponentTimeout } from "../core/config.js";
 import type { ContextManifest } from "../context-engine/types.js";
 import { ulid } from "ulid";
 import { createLogger } from "../core/logger.js";
@@ -568,6 +569,7 @@ export async function runCodeActSession(
         try {
             llmResponse = await callLLMWithFallback(messages, configs, {
                 caller: "session-runner",
+                timeoutMs: resolveComponentTimeout("session"),
                 // reply 路径：让实际选中的 profile 追加自己的 replyPrompt（fallback 时不会错用 profile[0] 的）。
                 applyReplyPrompt: true,
                 ...(prefill ? { prefill } : {}),


### PR DESCRIPTION
The per-component request timeouts under llm_routing.timeouts were ignored on the reply hot path, so meta and session LLM calls always aborted at the 60s default no matter what was configured:

- The meta session handler was built with a hardcoded llmTimeoutMs: 60_000 in main.ts, overriding llm_routing.timeouts.meta.
- runCodeActSession (the CodeAct reply loop) never passed timeoutMs to callLLMWithFallback, so it hit the 60s fallback in callLLM; llm_routing.timeouts.session had no reader at all.

Background components (recording, reflection, memory, compact, vision) already resolve their timeout via resolveComponentTimeout(). This wires the same resolver into the meta and session paths, so their configured timeouts take effect. Both fall back to the previous 60s default when unset.