### PR TITLE
feat(llm): support "xhigh" reasoning effort (Responses API + dashboard)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -44,7 +44,7 @@ llm_profiles:
     temperature: 1
     max_tokens: 8192
     # max_context_tokens: 500000
-    thinking_level: medium  # none | low | medium | high（Gemini 特有）
+    thinking_level: medium  # none | low | medium | high | xhigh（Gemini 特有）
     # pricing:
     #   input: 1.25
     #   output: 10.00

--- a/src/core/llm/openai-responses.ts
+++ b/src/core/llm/openai-responses.ts
@@ -77,7 +77,7 @@ export async function callOpenAIResponses(
         input,
         temperature,
         max_output_tokens: maxTokens,
-        ...(reasoningEffort ? { reasoning: { effort: reasoningEffort } } : {}),
+        ...(reasoningEffort ? { reasoning: { effort: reasoningEffort as ReasoningEffort } } : {}),
         ...(stop && stop.length > 0 ? { stop } : {}),
         ...(config.extraBody ?? {}),
     };
@@ -107,8 +107,11 @@ export async function callOpenAIResponses(
     };
 }
 
-function toReasoningEffort(value?: string): ReasoningEffort | undefined {
-    if (value === "low" || value === "medium" || value === "high") {
+// "xhigh" 未在 SDK 的 ReasoningEffort 联合类型里，但部分模型/网关支持，透传出去
+type ReasoningEffortExtended = ReasoningEffort | "xhigh";
+
+function toReasoningEffort(value?: string): ReasoningEffortExtended | undefined {
+    if (value === "low" || value === "medium" || value === "high" || value === "xhigh") {
         return value;
     }
     return undefined;

--- a/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
+++ b/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
@@ -104,7 +104,7 @@
           <label class="cfg-field"><span class="cfg-label">Max Context Tokens</span><input type="number" class="input input-xs input-bordered w-full" bind:value={p.maxContextTokens} placeholder="(默认)" /></label>
           <label class="cfg-field"><span class="cfg-label">Thinking Level</span>
             <select class="select select-xs select-bordered w-full" bind:value={p.thinkingLevel}>
-              <option value={undefined}>无</option><option value="none">none</option><option value="low">low</option><option value="medium">medium</option><option value="high">high</option>
+              <option value={undefined}>无</option><option value="none">none</option><option value="low">low</option><option value="medium">medium</option><option value="high">high</option><option value="xhigh">xhigh</option>
             </select></label>
           <label class="cfg-check"><input type="checkbox" class="checkbox checkbox-xs" bind:checked={p.vision} /><span>Vision</span></label>
           <label class="cfg-check"><input


### PR DESCRIPTION
## What

Add support for the `xhigh` reasoning effort tier end-to-end.

- **`feat(llm): accept "xhigh" reasoning effort for Responses API`** — the OpenAI Responses adapter now accepts `xhigh` as a valid `reasoning.effort` value (previously silently dropped/rejected), plus a `config.example.yaml` doc note.
- **`feat(dashboard): add "xhigh" to Thinking Level dropdown`** — exposes the new tier in the LLM Profiles config UI so it can actually be selected.

## Why

`xhigh` is a real effort level for the newer reasoning models; without both the backend acceptance and the UI option it wasn't reachable.

## Notes

- Two cherry-picked commits, self-contained (Responses adapter + one Svelte dropdown option + example config).
- No behavior change for existing effort levels (`low`/`medium`/`high` untouched).
