### PR TITLE
fix(recording+reflection): stop cluster flush death spiral + tolerate unterminated code fences

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -388,6 +388,10 @@ export interface RecordingPipelineConfig {
     normalSilenceMs?: number;
     /** 加速静默触发时间（毫秒）。默认 30000 (30 sec) */
     eagerSilenceMs?: number;
+    /** 单次 flush 最多处理的消息数（超出留 buffer 下轮排空）。默认 120。锁死 cluster 输出体积防 decode 超时 */
+    maxFlushBatch?: number;
+    /** buffer 总量硬上限（超出丢最旧消息，防持续失败时无限膨胀＝死亡螺旋）。默认 1000 */
+    maxBufferSize?: number;
 }
 
 /** Dashboard 外部配置 */
@@ -1063,6 +1067,8 @@ function parseRecordingPipelineConfig(fileConfig: Record<string, unknown>): Reco
         eagerThreshold: raw.eager_threshold != null ? num(raw.eager_threshold, 15) : undefined,
         normalSilenceMs: raw.normal_silence_ms != null ? num(raw.normal_silence_ms, 120000) : undefined,
         eagerSilenceMs: raw.eager_silence_ms != null ? num(raw.eager_silence_ms, 30000) : undefined,
+        maxFlushBatch: raw.max_flush_batch != null ? num(raw.max_flush_batch, 120) : undefined,
+        maxBufferSize: raw.max_buffer_size != null ? num(raw.max_buffer_size, 1000) : undefined,
     };
 }
 

--- a/src/memory-v2/reflection.ts
+++ b/src/memory-v2/reflection.ts
@@ -1516,9 +1516,14 @@ function clamp01(value: number): number {
  * 支持纯 JSON 和 markdown 代码块包裹两种格式
  */
 export function parseReflectionJSON(raw: string): ReflectionLLMOutput | null {
-    // 尝试提取 markdown 代码块中的 JSON
+    // 尝试提取 markdown 代码块中的 JSON。优先匹配成对的 ```...```；
+    // 若只有起始围栏而无收尾（常见于输出撞 maxTokens 被截断），也剥掉起始/残留围栏，
+    // 否则开头的 ``` 会让 JSON.parse 直接抛 "Unexpected token `" 而整轮反思零落库。
     const codeBlockMatch = raw.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
-    const jsonStr = codeBlockMatch ? codeBlockMatch[1].trim() : raw.trim();
+    const jsonStr = (codeBlockMatch
+        ? codeBlockMatch[1]
+        : raw.trim().replace(/^```(?:json)?[ \t]*\r?\n?/i, "").replace(/\r?\n?```[ \t]*$/i, "")
+    ).trim();
 
     try {
         const parsed = JSON.parse(jsonStr) as Partial<ReflectionLLMOutput>;

--- a/src/pipeline/recording-pipeline.ts
+++ b/src/pipeline/recording-pipeline.ts
@@ -67,6 +67,15 @@ const DEFAULT_EAGER_THRESHOLD = 15;
 const DEFAULT_NORMAL_SILENCE = 2 * 60 * 1000;  // 2 min
 /** 加速静默触发（毫秒） */
 const DEFAULT_EAGER_SILENCE = 30 * 1000;       // 30 sec
+/**
+ * 单次 flush 最多处理的消息数，超出的留 buffer 下轮排空。
+ * cluster 输出∝消息数、decode 仅 ~40-80 tok/s，批次过大必撞超时；封顶把输出锁在安全区。
+ */
+const DEFAULT_MAX_FLUSH_BATCH = 120;
+/** buffer 总量硬上限：持续失败时防止 unshift 回退让 buffer 无限膨胀（越滚越大死亡螺旋），超出丢最旧。 */
+const DEFAULT_MAX_BUFFER_SIZE = 1000;
+/** 本轮批次未排空时，下一次自动 flush 的短延迟（毫秒），用于尽快排空积压。 */
+const DRAIN_REARM_DELAY_MS = 3000;
 
 
 
@@ -94,6 +103,8 @@ export class RecordingPipeline extends EventEmitter {
     private readonly eagerThreshold: number;
     private readonly normalSilence: number;
     private readonly eagerSilence: number;
+    private readonly maxFlushBatch: number;
+    private readonly maxBufferSize: number;
 
     constructor(
         private registry: TopicRegistry,
@@ -111,6 +122,8 @@ export class RecordingPipeline extends EventEmitter {
         this.eagerThreshold = pipelineConfig?.eagerThreshold ?? DEFAULT_EAGER_THRESHOLD;
         this.normalSilence = pipelineConfig?.normalSilenceMs ?? DEFAULT_NORMAL_SILENCE;
         this.eagerSilence = pipelineConfig?.eagerSilenceMs ?? DEFAULT_EAGER_SILENCE;
+        this.maxFlushBatch = pipelineConfig?.maxFlushBatch ?? DEFAULT_MAX_FLUSH_BATCH;
+        this.maxBufferSize = pipelineConfig?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
     }
 
     /**
@@ -207,12 +220,14 @@ export class RecordingPipeline extends EventEmitter {
         if (this.isFlushing || this.buffer.length === 0) return;
 
         this.isFlushing = true;
-        const messages = [...this.buffer];
-        this.buffer = [];
+        // 批次上限：单次最多处理 maxFlushBatch 条，其余留在 buffer 下轮排空。
+        // 输出∝消息数、decode ~40-80 tok/s，批次过大 cluster 必撞超时——封顶从根上锁死单次输出体积。
+        const messages = this.buffer.slice(0, this.maxFlushBatch);
+        this.buffer = this.buffer.slice(this.maxFlushBatch);
         this.isEagerMode = false;  // 每次 flush 后重置
         const clusterOnly = options?.clusterOnly ?? false;
 
-        log.info("flush 开始", { messageCount: messages.length, clusterOnly });
+        log.info("flush 开始", { messageCount: messages.length, remaining: this.buffer.length, clusterOnly });
         this.emit("flush:start", messages.length);
 
         try {
@@ -385,8 +400,21 @@ export class RecordingPipeline extends EventEmitter {
             this.emit("flush:error", err);
             // 把消息放回缓冲头部，避免丢失
             this.buffer.unshift(...messages);
+            // 保底回退：buffer 总量封顶。持续失败时（非 LLM 错误，如落盘异常）unshift 会让 buffer 无限膨胀，
+            // 批次越滚越大 → 更必然失败＝死亡螺旋。超出上限即丢弃最旧（含反复失败的批次），保留最新消息、自愈。
+            if (this.buffer.length > this.maxBufferSize) {
+                const dropped = this.buffer.length - this.maxBufferSize;
+                this.buffer = this.buffer.slice(-this.maxBufferSize);
+                log.warn("buffer 超过上限，丢弃最旧消息以防死亡螺旋", { dropped, cap: this.maxBufferSize });
+            }
         } finally {
             this.isFlushing = false;
+            // 本轮批次上限有溢出（或回退的消息）→ 短延迟后继续排空，别干等下一条消息/静默定时器。
+            // unref：这条排空定时器不该独自把进程吊住（长活进程无所谓，测试/退出时要能干净结束）。
+            if (!this.disposed && this.buffer.length >= this.minFlushSize) {
+                const drainTimer = setTimeout(() => this.triggerFlush(), DRAIN_REARM_DELAY_MS);
+                drainTimer.unref?.();
+            }
         }
     }
 
@@ -427,7 +455,18 @@ export class RecordingPipeline extends EventEmitter {
             { role: "user", content: prompt },
         ];
 
-        const response = await callLLMWithFallback(llmMessages, resolveComponentProfiles("recording_cluster"), { caller: "recording-cluster", timeoutMs: resolveComponentTimeout("recording_cluster") });
+        let response;
+        try {
+            response = await callLLMWithFallback(llmMessages, resolveComponentProfiles("recording_cluster"), { caller: "recording-cluster", timeoutMs: resolveComponentTimeout("recording_cluster") });
+        } catch (err) {
+            // 保底回退：LLM 彻底失败（超时/网关，所有 profile+重试用尽）时不抛出，降级为本地单话题归类。
+            // 关键：这样本批次仍被记录并从 buffer 排空，绝不把整批 unshift 回 buffer 头触发死亡螺旋。
+            log.warn("话题聚类 LLM 调用失败，保底降级为单话题归类", {
+                error: err instanceof Error ? err.message : String(err),
+                messageCount: messages.length,
+            });
+            return this.fallbackClustering(messages);
+        }
 
         try {
             // 提取 JSON（处理可能的 markdown 包裹）
@@ -438,17 +477,24 @@ export class RecordingPipeline extends EventEmitter {
             return JSON.parse(jsonStr) as TopicClusteringResult;
         } catch {
             log.warn("话题聚类 LLM 输出解析失败，使用默认归类", { raw: response.content.slice(0, 200) });
-            // 回退：所有消息归为一个新话题
-            return {
-                assignments: messages.map(m => ({
-                    messageId: m.id,
-                    topicId: "NEW_1",
-                    topicLabel: "对话讨论",
-                    keywords: [],
-                })),
-                evolutions: [],
-            };
+            return this.fallbackClustering(messages);
         }
+    }
+
+    /**
+     * 保底降级归类：LLM 不可用（超时/网关挂/输出解析失败）时，把整批消息归为一个新话题。
+     * 目的是保证消息仍被落盘、buffer 被排空——牺牲话题粒度换取「绝不死循环」。
+     */
+    private fallbackClustering(messages: Message[]): TopicClusteringResult {
+        return {
+            assignments: messages.map(m => ({
+                messageId: m.id,
+                topicId: "NEW_1",
+                topicLabel: "对话讨论",
+                keywords: [],
+            })),
+            evolutions: [],
+        };
     }
 
     /**
@@ -497,7 +543,17 @@ export class RecordingPipeline extends EventEmitter {
             { role: "user", content: userMessage },
         ];
 
-        const response = await callLLMWithFallback(llmMessages, resolveComponentProfiles("recording_triage"), { caller: "recording-triage", timeoutMs: resolveComponentTimeout("recording_triage") });
+        let response;
+        try {
+            response = await callLLMWithFallback(llmMessages, resolveComponentProfiles("recording_triage"), { caller: "recording-triage", timeoutMs: resolveComponentTimeout("recording_triage") });
+        } catch (err) {
+            // 保底回退：triage LLM 彻底失败时不抛出（否则 flush 进 catch → 回退 buffer → 死亡螺旋）。
+            // 返回空 triage：话题仍按 clustering 落盘，仅缺 LLM 摘要（后续 reflection 可补）。
+            log.warn("话题摘要 Triage LLM 调用失败，跳过摘要（话题仍落盘）", {
+                error: err instanceof Error ? err.message : String(err),
+            });
+            return { topics: [] };
+        }
 
         let result: TopicSummaryTriageResult;
         try {

--- a/src/pipeline/recording-pipeline.ts
+++ b/src/pipeline/recording-pipeline.ts
@@ -77,6 +77,17 @@ const DEFAULT_MAX_BUFFER_SIZE = 1000;
 /** 本轮批次未排空时，下一次自动 flush 的短延迟（毫秒），用于尽快排空积压。 */
 const DRAIN_REARM_DELAY_MS = 3000;
 
+/**
+ * 把配置里的批次/缓冲上限夹到「有限正整数」，非法值（0/负数/小数/NaN/Infinity）回退默认。
+ * 防两个陷阱：maxFlushBatch=0 → slice(0,0) 空批 + 每 3s 空转排空；
+ * maxBufferSize=0 → slice(-0)===slice(0) 反而保留整个 buffer、封顶失效。
+ */
+function clampPositiveInt(value: number | undefined, fallback: number): number {
+    if (value == null) return fallback;
+    const n = Math.floor(value);
+    return Number.isFinite(n) && n >= 1 ? n : fallback;
+}
+
 
 
 /**
@@ -122,8 +133,8 @@ export class RecordingPipeline extends EventEmitter {
         this.eagerThreshold = pipelineConfig?.eagerThreshold ?? DEFAULT_EAGER_THRESHOLD;
         this.normalSilence = pipelineConfig?.normalSilenceMs ?? DEFAULT_NORMAL_SILENCE;
         this.eagerSilence = pipelineConfig?.eagerSilenceMs ?? DEFAULT_EAGER_SILENCE;
-        this.maxFlushBatch = pipelineConfig?.maxFlushBatch ?? DEFAULT_MAX_FLUSH_BATCH;
-        this.maxBufferSize = pipelineConfig?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+        this.maxFlushBatch = clampPositiveInt(pipelineConfig?.maxFlushBatch, DEFAULT_MAX_FLUSH_BATCH);
+        this.maxBufferSize = clampPositiveInt(pipelineConfig?.maxBufferSize, DEFAULT_MAX_BUFFER_SIZE);
     }
 
     /**
@@ -230,6 +241,7 @@ export class RecordingPipeline extends EventEmitter {
         log.info("flush 开始", { messageCount: messages.length, remaining: this.buffer.length, clusterOnly });
         this.emit("flush:start", messages.length);
 
+        let hadError = false;
         try {
             // ─── Step 1: 话题聚类 ───
             const groupedByChat = this.groupByChat(messages);
@@ -396,6 +408,7 @@ export class RecordingPipeline extends EventEmitter {
                 this.emit("flush:complete", updatedTopics);
             }
         } catch (err) {
+            hadError = true;
             log.error("flush 失败", { error: err instanceof Error ? err.message : String(err) });
             this.emit("flush:error", err);
             // 把消息放回缓冲头部，避免丢失
@@ -411,11 +424,23 @@ export class RecordingPipeline extends EventEmitter {
             this.isFlushing = false;
             // 本轮批次上限有溢出（或回退的消息）→ 短延迟后继续排空，别干等下一条消息/静默定时器。
             // unref：这条排空定时器不该独自把进程吊住（长活进程无所谓，测试/退出时要能干净结束）。
-            if (!this.disposed && this.buffer.length >= this.minFlushSize) {
-                const drainTimer = setTimeout(() => this.triggerFlush(), DRAIN_REARM_DELAY_MS);
+            if (this.shouldRearmDrain(hadError)) {
+                const drainTimer = setTimeout(() => { void this.flush(); }, DRAIN_REARM_DELAY_MS);
                 drainTimer.unref?.();
             }
         }
+    }
+
+    /**
+     * flush 收尾时是否安排「排空定时器」继续处理积压。
+     * - 成功路径：只要 buffer 还有余量就排空——含 < minFlushSize 的尾巴（如批次上限切剩的 1–9 条），
+     *   否则这段尾巴会一直滞留到该群下次活跃/静默触发才落盘。
+     * - 失败路径：沿用 minFlushSize 阈值。持续失败（非 LLM 错误，如落盘异常）时若无脑排空，
+     *   会变成每 3s 对同一小批次热重试刷屏；保留阈值让小残留等更多消息再一起重试。
+     */
+    private shouldRearmDrain(hadError: boolean): boolean {
+        if (this.disposed || this.buffer.length === 0) return false;
+        return hadError ? this.buffer.length >= this.minFlushSize : true;
     }
 
     /**

--- a/tests/recording-pipeline-flush.test.ts
+++ b/tests/recording-pipeline-flush.test.ts
@@ -85,4 +85,46 @@ describe("recording pipeline flush batching + safety floor", () => {
         assert.ok(result.assignments.every(a => a.topicId === "NEW_1"));
         assert.deepEqual(result.evolutions, []);
     });
+
+    it("clamps out-of-range maxFlushBatch/maxBufferSize (0/负/小数/Infinity) to safe values", () => {
+        // 非法值回退默认（maxFlushBatch=120 / maxBufferSize=1000）：
+        // 0 → slice(0,0) 空批 + 每 3s 空转；负/-0 → slice(-0)===slice(0) 保留整个 buffer、封顶失效
+        const bad = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu", undefined, undefined, {
+            maxFlushBatch: 0,
+            maxBufferSize: -5,
+        });
+        assert.equal((bad as any).maxFlushBatch, 120);
+        assert.equal((bad as any).maxBufferSize, 1000);
+
+        // Infinity 也视为非法（等于不封顶＝重新引入死亡螺旋）→ 回退默认
+        const infinite = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu", undefined, undefined, {
+            maxFlushBatch: Infinity,
+        });
+        assert.equal((infinite as any).maxFlushBatch, 120);
+
+        // 合法值原样透传，小数向下取整为整数（7.9 → 7）
+        const ok = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu", undefined, undefined, {
+            maxFlushBatch: 7.9,
+            maxBufferSize: 42,
+        });
+        assert.equal((ok as any).maxFlushBatch, 7);
+        assert.equal((ok as any).maxBufferSize, 42);
+    });
+
+    it("re-arms drain for a sub-minFlushSize tail on success, but throttles it on error", () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu", undefined, undefined, {
+            minFlushSize: 10,
+        });
+        // 成功路径：批次上限切剩的 3 条尾巴（< minFlushSize 10）仍要排空，否则滞留到下次活跃/静默才落盘
+        (pipeline as any).buffer = makeMessages(3);
+        assert.equal((pipeline as any).shouldRearmDrain(false), true);
+        // 失败路径：同样 3 条不排空——避免对持续失败的小批次每 3s 热重试刷屏
+        assert.equal((pipeline as any).shouldRearmDrain(true), false);
+        // 失败路径：积压 >= minFlushSize 仍排空以追赶
+        (pipeline as any).buffer = makeMessages(10);
+        assert.equal((pipeline as any).shouldRearmDrain(true), true);
+        // buffer 空：任何路径都不排空
+        (pipeline as any).buffer = [];
+        assert.equal((pipeline as any).shouldRearmDrain(false), false);
+    });
 });

--- a/tests/recording-pipeline-flush.test.ts
+++ b/tests/recording-pipeline-flush.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { RecordingPipeline } from "../src/pipeline/recording-pipeline.js";
+import { TopicRegistry } from "../src/pipeline/topic-registry.js";
+import type { Message, TopicClusteringResult } from "../src/pipeline/types.js";
+
+function makeMessages(n: number, chatId = "telegram:-100"): Message[] {
+    const base = 1_700_000_000_000;
+    return Array.from({ length: n }, (_, i) => ({
+        id: String(1000 + i),
+        chatId,
+        senderId: `u${i % 3}`,
+        senderName: `user${i % 3}`,
+        text: `msg ${i}`,
+        timestamp: base + i * 1000,
+    })) as Message[];
+}
+
+/** 让 cluster 步骤返回「单话题归类」（模拟保底降级或正常成功），三态不触网。 */
+function stubSuccess(pipeline: RecordingPipeline): void {
+    (pipeline as any).llmTopicClustering = async (msgs: Message[]): Promise<TopicClusteringResult> => ({
+        assignments: msgs.map(m => ({ messageId: m.id, topicId: "NEW_1", topicLabel: "对话讨论", keywords: [] })),
+        evolutions: [],
+    });
+    (pipeline as any).llmTopicSummaryTriage = async () => ({ topics: [] });
+}
+
+describe("recording pipeline flush batching + safety floor", () => {
+    it("caps a flush to maxFlushBatch, leaving the remainder buffered", async () => {
+        // memory 省略 → flush 的 Step4 落盘被 `if (this.memory)` 跳过，只跑聚类/triage/registry
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu", undefined, undefined, {
+            maxFlushBatch: 5,
+            minFlushSize: 1,
+        });
+        stubSuccess(pipeline);
+        (pipeline as any).buffer = makeMessages(12);
+
+        await (pipeline as any).flush();
+
+        // 只处理 5 条，其余 7 条留 buffer 下轮排空（输出体积被锁死）
+        assert.equal((pipeline as any).buffer.length, 7);
+    });
+
+    it("drains a backlog across repeated flushes", async () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu", undefined, undefined, {
+            maxFlushBatch: 5,
+            minFlushSize: 1,
+        });
+        stubSuccess(pipeline);
+        (pipeline as any).buffer = makeMessages(12);
+
+        await (pipeline as any).flush();
+        assert.equal((pipeline as any).buffer.length, 7);
+        await (pipeline as any).flush();
+        assert.equal((pipeline as any).buffer.length, 2);
+        await (pipeline as any).flush();
+        assert.equal((pipeline as any).buffer.length, 0);
+    });
+
+    it("caps the buffer on repeated failure instead of growing unbounded (no death spiral)", async () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu", undefined, undefined, {
+            maxFlushBatch: 5,
+            maxBufferSize: 10,
+            minFlushSize: 1,
+        });
+        // 模拟持续失败（非 LLM 错误逃逸到 flush catch）
+        (pipeline as any).llmTopicClustering = async () => { throw new Error("boom"); };
+        (pipeline as any).buffer = makeMessages(12);
+
+        await (pipeline as any).flush();
+
+        // 失败批次 unshift 回去后总量 12 > cap 10 → 丢最旧、封顶在 10，绝不越滚越大
+        assert.equal((pipeline as any).buffer.length, 10);
+        assert.ok((pipeline as any).buffer.length <= 10);
+    });
+
+    it("fallbackClustering assigns every message to a single topic (drains, no re-buffer)", () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu");
+        const msgs = makeMessages(37);
+
+        const result: TopicClusteringResult = (pipeline as any).fallbackClustering(msgs);
+
+        assert.equal(result.assignments.length, 37);
+        assert.ok(result.assignments.every(a => a.topicId === "NEW_1"));
+        assert.deepEqual(result.evolutions, []);
+    });
+});


### PR DESCRIPTION
## What

Two independent reliability fixes for the memory/recording path, plus a small hardening follow-up.

1. **`fix(reflection): tolerate unterminated code fences in LLM JSON output`**
   Reflection JSON extraction now strips a lone opening/trailing ` ``` ` fence in addition to properly paired fences, so a model that forgets to close its fence no longer breaks parsing. Verified against paired / plain / opening-only / trailing-only / multi-fence inputs.

2. **`fix(recording): cap flush batch + graceful fallback to stop cluster death spiral`**
   Fixes an observed production spiral: a busy chat's flush batch grows unbounded → the topic-clustering LLM emits one assignment per message → decode (~40–80 tok/s) blows past the 60s timeout → the batch is re-buffered and the next one is even bigger → that chat's memory never records (observed 544→811 msgs, 82% of cluster calls timing out).
   - Cap each flush to `maxFlushBatch` (default 120); leave the remainder buffered and drain it on a short unref'd timer.
   - Graceful fallback: on total LLM failure, clustering degrades to a local single-topic assignment and triage returns empty instead of throwing — the batch still records and drains, never re-buffers into a spiral.
   - Buffer hard-cap (default 1000) on the failure path so a non-LLM error can't grow the buffer without bound.
   - Both bounds configurable via `recording_pipeline.max_flush_batch` / `max_buffer_size`.

3. **`fix(recording): clamp flush-cap config + drain sub-minFlushSize tail`** (review hardening)
   - Clamp the two new config values to finite positive ints (`0`/negative/`NaN`/`Infinity` → defaults), closing two footguns: `max_flush_batch:0` → empty-batch 3s spin, and `max_buffer_size:0` → `slice(-0)` keeping the whole buffer (cap no-op).
   - Drain the final `1..(minFlushSize-1)` remainder after a capped flush instead of stranding it until the next burst, while throttling drain on the error path to avoid a 3s hot-retry loop.

## Verification

- Reviewed by Codex; reflection fix cleared as-is, recording fix reviewed and the two actionable findings folded into commit 3.
- `tests/recording-pipeline-flush.test.ts` extended (6 tests, all pass); `tsc --noEmit` clean.

## Known limitation (out of scope, pre-existing)

The `flush()` error path `unshift`s the whole batch back to the buffer. If a **non-LLM** error is thrown *after* `updateRegistry()` has already mutated state, a retry can double-count via `TopicRegistry.addMessages()` (no dedup) / `incrementProfileStats` (delta). This predates these commits and is unrelated to the spiral being fixed here — the graceful-fallback change actually shrinks how often that path is hit. A proper fix (idempotent apply / rollback) is left as follow-up.
