### PR TITLE
fix(dashboard): support Authorization Bearer header in /ws endpoint

### DIFF
--- a/src/dashboard/dashboard-server.ts
+++ b/src/dashboard/dashboard-server.ts
@@ -65,7 +65,8 @@ export class DashboardServer {
         // WebSocket upgrade with token auth
         this.server.on("upgrade", (request, socket, head) => {
             const url = new URL(request.url ?? "", `http://localhost:${this.config.port}`);
-            const token = url.searchParams.get("token");
+            const token = url.searchParams.get("token")
+                || request.headers.authorization?.replace("Bearer ", "");
             if (token !== this.config.token) {
                 socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
                 socket.destroy();


### PR DESCRIPTION
WebSocket upgrade handler only checked ?token= query parameter, ignoring the Authorization: Bearer header that /api routes already support. This made Bearer auth effectively unusable for WS clients.

Now both /ws and /api use the same token extraction logic: query parameter takes precedence, falling back to Authorization header.