### PR TITLE
fix(recording): treat empty/invalid clustering as fallback, not re-buffer

### DIFF
--- a/src/pipeline/recording-pipeline.ts
+++ b/src/pipeline/recording-pipeline.ts
@@ -250,16 +250,17 @@ export class RecordingPipeline extends EventEmitter {
                 const existingTopics = this.registry.getByChat(chatId);
                 const messageContext = await this.buildRecordingMessageContext(chatMessages, chatId);
 
-                const clustering = await this.llmTopicClustering(chatMessages, existingTopics, messageContext);
+                let clustering = await this.llmTopicClustering(chatMessages, existingTopics, messageContext);
 
-                // 聚类返回空结果时，消息累积回 buffer 等待下轮 flush，不浪费 triage 调用
+                // 防御性兜底：llmTopicClustering 已保证非空有效 assignments。万一未来回归导致空结果，
+                // 也走本地默认归类而非 unshift 回 buffer——后者会被 finally 的 re-arm 当成功重排，
+                // 让同批消息 3s 后再跑一次、无限循环（死亡螺旋）。绝不把消息写回 buffer。
                 if (clustering.assignments.length === 0) {
-                    log.info("聚类结果为空，消息回退到 buffer", {
+                    log.warn("聚类结果为空，使用本地默认归类（不回退 buffer）", {
                         chatId,
                         messageCount: chatMessages.length,
                     });
-                    this.buffer.push(...chatMessages);
-                    continue;
+                    clustering = this.fallbackClustering(chatMessages);
                 }
 
                 // ─── Step 2: 摘要 + Triage（clusterOnly 模式跳过）───
@@ -493,17 +494,88 @@ export class RecordingPipeline extends EventEmitter {
             return this.fallbackClustering(messages);
         }
 
+        // LLM 调用成功、返回内容 → 交给归一化校验（解析失败 / 合法但语义空或无效 → 本地默认归类）。
+        return this.normalizeClusteringResult(response.content, messages);
+    }
+
+    /**
+     * 归一化 + 校验 cluster LLM 的原始输出。
+     *
+     * 关键不变量：**永不返回空 assignments**。空结果会被 flush() 视为「成功但没产出」，
+     * 若把消息 unshift 回 buffer，finally 的 re-arm 会把它当成功重排 → 同批消息 3s 后再跑一次
+     * → 无限循环（死亡螺旋）。因此这里把以下软失败全部降级为本地默认归类：
+     * - JSON 解析失败（raw 非合法 JSON）
+     * - 合法 JSON 但缺 assignments 数组
+     * - 合法 JSON 但 assignments 为空 / 全部无效（messageId 不在本批 / topicId 空）
+     * 日志按类别区分，便于与 LLM 调用失败（在 llmTopicClustering catch 处告警）对账。
+     *
+     * 部分有效时保留有效项，并给未被覆盖的消息补默认归类，保证消息绝不静默丢失。
+     */
+    private normalizeClusteringResult(rawContent: string, messages: Message[]): TopicClusteringResult {
+        let parsed: { assignments?: unknown; evolutions?: unknown };
         try {
             // 提取 JSON（处理可能的 markdown 包裹）
-            const jsonStr = response.content
+            const jsonStr = rawContent
                 .replace(/```json\s*/g, "")
                 .replace(/```\s*/g, "")
                 .trim();
-            return JSON.parse(jsonStr) as TopicClusteringResult;
+            parsed = JSON.parse(jsonStr) as { assignments?: unknown; evolutions?: unknown };
         } catch {
-            log.warn("话题聚类 LLM 输出解析失败，使用默认归类", { raw: response.content.slice(0, 200) });
+            log.warn("话题聚类 LLM 输出 JSON 解析失败，使用本地默认归类", { raw: rawContent.slice(0, 200) });
             return this.fallbackClustering(messages);
         }
+
+        if (!Array.isArray(parsed.assignments)) {
+            log.warn("话题聚类 LLM 输出合法但缺 assignments 数组，使用本地默认归类", {
+                raw: rawContent.slice(0, 200),
+                messageCount: messages.length,
+            });
+            return this.fallbackClustering(messages);
+        }
+
+        // 过滤非法 assignment：messageId 必须指向本批真实消息、topicId 必须非空字符串。
+        const messageIds = new Set(messages.map(m => m.id));
+        const validAssignments = (parsed.assignments as unknown[]).filter(
+            (a): a is TopicClusteringResult["assignments"][number] =>
+                typeof a === "object" && a !== null &&
+                typeof (a as { messageId?: unknown }).messageId === "string" &&
+                messageIds.has((a as { messageId: string }).messageId) &&
+                typeof (a as { topicId?: unknown }).topicId === "string" &&
+                (a as { topicId: string }).topicId.trim().length > 0,
+        );
+
+        if (validAssignments.length === 0) {
+            log.warn("话题聚类 LLM 输出合法但 assignments 为空或全部无效，使用本地默认归类", {
+                raw: rawContent.slice(0, 200),
+                messageCount: messages.length,
+            });
+            return this.fallbackClustering(messages);
+        }
+
+        // 覆盖完整性：给任何未被有效 assignment 覆盖的消息补默认归类，绝不让消息静默丢失。
+        const assignedIds = new Set(validAssignments.map(a => a.messageId));
+        const missingMessages = messages.filter(m => !assignedIds.has(m.id));
+        if (missingMessages.length > 0) {
+            log.warn("话题聚类 LLM 漏归部分消息，未覆盖部分补默认归类", {
+                missing: missingMessages.length,
+                total: messages.length,
+            });
+        }
+
+        return {
+            assignments: [
+                ...validAssignments,
+                ...missingMessages.map(m => ({
+                    messageId: m.id,
+                    topicId: "NEW_FALLBACK",
+                    topicLabel: "对话讨论",
+                    keywords: [] as string[],
+                })),
+            ],
+            evolutions: Array.isArray(parsed.evolutions)
+                ? (parsed.evolutions as TopicClusteringResult["evolutions"])
+                : [],
+        };
     }
 
     /**

--- a/tests/recording-pipeline-flush.test.ts
+++ b/tests/recording-pipeline-flush.test.ts
@@ -128,3 +128,126 @@ describe("recording pipeline flush batching + safety floor", () => {
         assert.equal((pipeline as any).shouldRearmDrain(false), false);
     });
 });
+
+/**
+ * 回归：cluster LLM 返回「合法 JSON、语义为空/无效」的软失败。
+ * 修复前——空 assignments 被当成功、消息 unshift 回 buffer、finally re-arm 无限重跑同批（死亡螺旋）。
+ * 修复后——normalizeClusteringResult 永不返回空 assignments，flush 正常排空。
+ */
+describe("recording pipeline clustering output validation", () => {
+    function normalize(pipeline: RecordingPipeline, raw: string, msgs: Message[]): TopicClusteringResult {
+        return (pipeline as any).normalizeClusteringResult(raw, msgs) as TopicClusteringResult;
+    }
+
+    it("合法空结果 → 本地 fallback（每条消息归到 NEW_1，绝不返回空）", () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu");
+        const msgs = makeMessages(5);
+
+        const result = normalize(pipeline, JSON.stringify({ assignments: [], evolutions: [] }), msgs);
+
+        assert.equal(result.assignments.length, 5);
+        assert.ok(result.assignments.every(a => a.topicId === "NEW_1"));
+        assert.deepEqual(result.evolutions, []);
+    });
+
+    it("缺失 assignments 字段 → fallback，不抛异常", () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu");
+        const msgs = makeMessages(4);
+
+        const result = normalize(pipeline, JSON.stringify({ evolutions: [] }), msgs);
+
+        assert.equal(result.assignments.length, 4);
+        assert.ok(result.assignments.every(a => a.topicId === "NEW_1"));
+    });
+
+    it("JSON 解析失败 → fallback", () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu");
+        const msgs = makeMessages(3);
+
+        const result = normalize(pipeline, "这不是 JSON {", msgs);
+
+        assert.equal(result.assignments.length, 3);
+        assert.ok(result.assignments.every(a => a.topicId === "NEW_1"));
+    });
+
+    it("assignments 全部引用不存在的 messageId → fallback", () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu");
+        const msgs = makeMessages(3);
+        const raw = JSON.stringify({
+            assignments: [{ messageId: "unknown", topicId: "NEW_1", topicLabel: "test", keywords: [] }],
+            evolutions: [],
+        });
+
+        const result = normalize(pipeline, raw, msgs);
+
+        assert.equal(result.assignments.length, 3);
+        assert.ok(result.assignments.every(a => a.topicId === "NEW_1"));
+    });
+
+    it("evolutions 缺失但 assignments 有效 → 接受并把 evolutions 规范化为 []", () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu");
+        const msgs = makeMessages(3);
+        const raw = JSON.stringify({
+            assignments: msgs.map(m => ({ messageId: m.id, topicId: "NEW_1", topicLabel: "话题", keywords: [] })),
+            // 无 evolutions 字段
+        });
+
+        const result = normalize(pipeline, raw, msgs);
+
+        assert.equal(result.assignments.length, 3);
+        assert.ok(result.assignments.every(a => a.topicId === "NEW_1"));
+        assert.deepEqual(result.evolutions, []);
+    });
+
+    it("部分 assignments 有效 → 保留有效项 + 未覆盖消息补 fallback（绝不丢消息）", () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu");
+        const msgs = makeMessages(4); // ids: 1000..1003
+        const raw = JSON.stringify({
+            assignments: [
+                { messageId: "1000", topicId: "NEW_1", topicLabel: "有效", keywords: [] }, // 有效
+                { messageId: "1001", topicId: "NEW_1", topicLabel: "有效", keywords: [] }, // 有效
+                { messageId: "unknown", topicId: "NEW_1", topicLabel: "坏", keywords: [] }, // 无效: 假 messageId
+                { messageId: "1002", topicId: "", topicLabel: "坏", keywords: [] },        // 无效: 空 topicId
+                // "1003" 完全未被提及
+            ],
+            evolutions: [],
+        });
+
+        const result = normalize(pipeline, raw, msgs);
+
+        // 覆盖完整：每条消息恰好一个 assignment，无丢失、无重复
+        assert.equal(result.assignments.length, 4);
+        const coveredIds = new Set(result.assignments.map(a => a.messageId));
+        assert.deepEqual([...coveredIds].sort(), ["1000", "1001", "1002", "1003"]);
+        // 有效项保留原 topicId；补齐项走 NEW_FALLBACK
+        const byId = new Map(result.assignments.map(a => [a.messageId, a]));
+        assert.equal(byId.get("1000")?.topicId, "NEW_1");
+        assert.equal(byId.get("1001")?.topicId, "NEW_1");
+        assert.equal(byId.get("1002")?.topicId, "NEW_FALLBACK");
+        assert.equal(byId.get("1003")?.topicId, "NEW_FALLBACK");
+    });
+
+    it("flush 遇到空聚类结果时正常排空 buffer（不回退、不无限重跑）", async () => {
+        const pipeline = new RecordingPipeline(new TopicRegistry(), "Miu", "Miu", undefined, undefined, {
+            maxFlushBatch: 50,
+            minFlushSize: 1,
+        });
+        // 模拟 cluster LLM 返回合法但语义为空的软失败（修复前会触发死亡螺旋）
+        (pipeline as any).llmTopicClustering = async (): Promise<TopicClusteringResult> => ({
+            assignments: [],
+            evolutions: [],
+        });
+        (pipeline as any).llmTopicSummaryTriage = async () => ({ topics: [] });
+        const registry: TopicRegistry = (pipeline as any).registry;
+        (pipeline as any).buffer = makeMessages(12);
+
+        await (pipeline as any).flush();
+
+        // buffer 完全排空（buffer < minFlushSize → finally 不会 re-arm drain，无限循环被切断）
+        assert.equal((pipeline as any).buffer.length, 0);
+        // 整批 fallback 落到单一新话题，12 条消息全部被记录、无丢失
+        const topics = registry.getAll();
+        assert.equal(topics.length, 1);
+        assert.equal(topics[0].messageCount, 12);
+    });
+});


### PR DESCRIPTION
## Problem

`#55` (the flush-batch cap fix) stopped the death spiral for the **LLM-error** path, but a valid-but-empty clustering response still loops:

```json
{ "assignments": [], "evolutions": [] }
```

This is valid JSON, so it slips past the parse-failure fallback. `flush()` then treats it as a success, pushes the batch back to `buffer`, and returns without error. The drain re-arm (`buffer.length >= minFlushSize`) fires a fresh flush ~3s later on the **same** batch → infinite loop, re-requesting identical messages forever.

## Fix

Root-cause fix (does **not** touch `shouldRearmDrain` — that would only mask the symptom):

- **New `normalizeClusteringResult()`** — extracted from `llmTopicClustering`, guarantees it **never returns empty `assignments`**. Degrades to `fallbackClustering()` for three distinct soft-failure classes, each with its own log line:
  - JSON parse failure
  - valid JSON but missing `assignments` array
  - valid JSON but `assignments` empty / all invalid (`messageId` not in batch, or empty `topicId`)
- **Partial validity** keeps the valid assignments and back-fills any uncovered messages with a `NEW_FALLBACK` assignment — no message is silently dropped. `evolutions` normalized to `[]` when missing/non-array.
- **`flush()`** no longer re-buffers on an empty result; it uses `fallbackClustering()` as a defensive belt instead, so the batch always drains.

## Logs now distinguish
- LLM call failure (existing)
- JSON parse failure
- valid JSON but semantically empty/invalid
- local fallback used

## Tests

New `clustering output validation` suite: empty result, missing `assignments`, JSON parse failure, all-unknown `messageId`, missing `evolutions`, partial validity (exact-once coverage, no loss), plus an end-to-end `flush` regression asserting the buffer drains to 0 and the batch lands in a single fallback topic. The end-to-end test fails against the pre-fix code and passes now.

Follows up #55.