### PR TITLE
fix(core): pass subagent.codeAct config to CodeActExecutor constructors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ data/
 # Agent instructions (local only)
 AGENTS.md
 CLAUDE.md
+workspace

--- a/src/main.ts
+++ b/src/main.ts
@@ -1075,7 +1075,12 @@ async function main(): Promise<void> {
         const subagent = subagentManager.getOrCreate(chatId);
         let executor = subagent.codeActExecutor as CodeActExecutor | null | undefined;
         if (!executor) {
-            executor = new CodeActExecutor(chatId);
+            const codeActCfg = loadConfig().subagent?.codeAct;
+            executor = new CodeActExecutor(chatId, codeActCfg ? {
+                maxExecutionTimeMs: codeActCfg.maxExecutionTimeMs,
+                maxSessionMessages: codeActCfg.maxSessionMessages,
+                maxTurns: codeActCfg.maxTurns,
+            } : undefined);
             subagent.codeActExecutor = executor;
         }
 

--- a/src/meta-sandbox/meta-api/dispatch.ts
+++ b/src/meta-sandbox/meta-api/dispatch.ts
@@ -1,4 +1,5 @@
 import type { GroundingConfig } from "../../core/config.js";
+import { loadConfig } from "../../core/config.js";
 import { shortUuid } from "../../core/ids.js";
 import { runParallelGrounding } from "../../main-agent/grounding-util.js";
 import type { AttentionAccumulator } from "../../accumulator/attention-accumulator.js";
@@ -259,7 +260,12 @@ async function ensureExecutor(
 ): Promise<ExecutorLike> {
     let executor = subagent.codeActExecutor as ExecutorLike | null | undefined;
     if (!executor) {
-        executor = deps.executorFactory?.(chatId) ?? new CodeActExecutor(chatId);
+        const codeActCfg = loadConfig().subagent?.codeAct;
+        executor = deps.executorFactory?.(chatId) ?? new CodeActExecutor(chatId, codeActCfg ? {
+            maxExecutionTimeMs: codeActCfg.maxExecutionTimeMs,
+            maxSessionMessages: codeActCfg.maxSessionMessages,
+            maxTurns: codeActCfg.maxTurns,
+        } : undefined);
         subagent.codeActExecutor = executor;
     }
 

--- a/src/subagent/subagent-manager.ts
+++ b/src/subagent/subagent-manager.ts
@@ -18,6 +18,7 @@ import { CodeActExecutor } from "./code-act-executor.js";
 import type { SubagentConfig, GroupStickiness, StickinessLevel } from "./types.js";
 import { DEFAULT_SUBAGENT_CONFIG } from "./types.js";
 import { createLogger } from "../core/logger.js";
+import { loadConfig } from "../core/config.js";
 import { existsSync, readdirSync, mkdirSync } from "node:fs";
 import { join, basename } from "node:path";
 import { chatIdToFileName, fileNameToChatId, getPlatform, type PlatformName } from "../core/chat-id.js";
@@ -162,7 +163,12 @@ export class SubagentManager {
 
                         // 创建 CodeActExecutor 并恢复 session
                         if (!subagent.codeActExecutor) {
-                            const executor = new CodeActExecutor(chatId);
+                            const codeActCfg = loadConfig().subagent?.codeAct;
+                            const executor = new CodeActExecutor(chatId, codeActCfg ? {
+                                maxExecutionTimeMs: codeActCfg.maxExecutionTimeMs,
+                                maxSessionMessages: codeActCfg.maxSessionMessages,
+                                maxTurns: codeActCfg.maxTurns,
+                            } : undefined);
                             const loaded = executor.loadSession(filePath);
 
                             if (loaded) {


### PR DESCRIPTION
## 模块: Core / Config

## 问题
三处 \`new CodeActExecutor(chatId)\` 均未透传配置中的 \`maxSessionMessages/maxTurns/maxExecutionTimeMs\`，导致执行器使用硬编码回退值（maxSessionMessages=100），config.yaml 中设的 51 不生效，compact 延迟触发。

## 修复
- \`src/main.ts\`: ensureCodeActExecutor() 透传 config
- \`src/meta-sandbox/meta-api/dispatch.ts\`: ensureExecutor() 透传 config  
- \`src/subagent/subagent-manager.ts\`: restoreAll() 透传 config