### PR TITLE
fix(telegram-adapter): ChatMember object & getUserProfile alias fallback

### DIFF
--- a/src/adapter/telegram-adapter.ts
+++ b/src/adapter/telegram-adapter.ts
@@ -573,7 +573,8 @@ export class TelegramAdapter implements PlatformAdapter {
             case "telegram.getChatMembers": {
                 const peer = await this.ensurePeerCached(args[0]);
                 const peers = await this.client.getChatMembers(peer, args[1]);
-                return peers.map((p: any) => this.normalizePeer(p));
+                // mtcute ChatMember 的 id/username 在 .user 子对象里，展平后才能拿到
+                return peers.map((p: any) => this.normalizePeer(p?.user ?? p));
             }
             case "telegram.getHistory": {
                 try {

--- a/src/sandbox/host-call-handler.ts
+++ b/src/sandbox/host-call-handler.ts
@@ -827,7 +827,16 @@ export function createSandboxHostCallHandler(chatId: string, deps: CreateSandbox
             const ctx = policy();
             // R1（显式 target）：显式查别的私密会话的群内画像 → 收窄回当前会话视角。
             const effective = (targetChatId && isExplicitReadBlocked(targetChatId, ctx)) ? chatId : (targetChatId ?? chatId);
-            const profile = memory.getUserProfile(userId, effective) as unknown as Record<string, unknown> | null;
+            // Alias fallback: agent 可能传 displayName/username 而非规范 userId
+            let resolvedUserId = userId;
+            if (!memory.getPersonIdentity(userId)) {
+                const aliasHits = memory.searchByAlias(userId, 1);
+                if (aliasHits.length > 0) {
+                    resolvedUserId = aliasHits[0].userId;
+                    log.info("getUserProfile alias resolved", { from: userId, to: resolvedUserId } as any);
+                }
+            }
+            const profile = memory.getUserProfile(resolvedUserId, effective) as unknown as Record<string, unknown> | null;
             if (profile && Array.isArray((profile as { recentFacts?: unknown[] }).recentFacts)) {
                 (profile as { recentFacts: unknown[] }).recentFacts =
                     scrubFactsByVisibility((profile as { recentFacts: any[] }).recentFacts, ctx, method).kept;


### PR DESCRIPTION
## 模块: Telegram Adapter

## 修复内容

### 1. resolve mtcute ChatMember nested .user object
mtcute 的 \`ChatMember\` 对象中 \`id/username\` 在 \`.user\` 子对象里，需要展平后才能拿到正确的用户信息。

### 2. add alias fallback for getUserProfile
当 agent 传 \`displayName/username\` 而非规范 \`userId\` 时，自动通过 \`searchByAlias\` 解析到正确的 userId。