### PR TITLE
fix(dashboard): move MemoryEditModal to root so it works from non-memory tabs

### DIFF
--- a/src/dashboard/ui/src/App.svelte
+++ b/src/dashboard/ui/src/App.svelte
@@ -25,6 +25,7 @@
   import BackgroundAgentPanel from './panels/BackgroundAgentPanel.svelte';
   import TopicDetailPanel from './panels/TopicDetailPanel.svelte';
   import EnqueueModal from './panels/EnqueueModal.svelte';
+  import MemoryEditModal from './panels/MemoryEditModal.svelte';
 
   let refreshTimer;
 
@@ -80,5 +81,6 @@
     <div class:hidden={$activeTab !== 'topic-detail'}><TopicDetailPanel /></div>
 
     <EnqueueModal />
+    <MemoryEditModal />
   </div>
 </div>

--- a/src/dashboard/ui/src/panels/MemoryPanel.svelte
+++ b/src/dashboard/ui/src/panels/MemoryPanel.svelte
@@ -8,7 +8,6 @@
   import InteractionsTab from "./memory/InteractionsTab.svelte";
   import RecallTab from "./memory/RecallTab.svelte";
   import ChatLogTab from "./memory/ChatLogTab.svelte";
-  import MemoryEditModal from "./MemoryEditModal.svelte";
 
   const subTabs = [
     { id: "m-persons", label: "用户画像", icon: "fa-user" },
@@ -82,8 +81,6 @@
     {/key}
   </div>
 </div>
-
-<MemoryEditModal />
 
 <style>
   /* ── Two-column layout ── */


### PR DESCRIPTION
## 模块: Dashboard UI

## 问题
MemoryEditModal 组件定义在 \`MemoryPanel.svelte\` 内部，导致从非 memory tab（如 Agent 面板）触发编辑时弹窗无法正常显示。

## 修复
将 MemoryEditModal 移到 \`App.svelte\` 根组件，使其在所有 tab 中均可正常使用。

- \`src/dashboard/ui/src/App.svelte\`: +2 行（引入 Modal）
- \`src/dashboard/ui/src/panels/MemoryPanel.svelte\`: -3 行（移出 Modal）