### PR TITLE
feat: LLM Circuit Breaker 熔断器系统

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -11,6 +11,7 @@
 import { readFileSync, existsSync, writeFileSync } from "node:fs";
 import { parse as parseYAML, stringify as stringifyYAML } from "yaml";
 import { clearAllPools } from "./llm-pool.js";
+import { profileBreaker, type CircuitBreakerConfig } from "./llm-profile-breaker.js";
 
 // ─── 类型定义 ───
 
@@ -33,6 +34,8 @@ export interface PoolConfig {
 }
 
 export interface LLMConfig {
+    /** Profile name（自动注入，用于熔断器身份标识；非用户配置字段） */
+    name?: string;
     provider: "anthropic" | "openai" | "openai_responses" | "google";
     baseUrl: string;
     apiKey: string;
@@ -559,6 +562,8 @@ export interface AppConfig {
     grounding?: GroundingConfig;
     /** LLM 请求限速配置 */
     rateLimiting?: import("./llm-rate-limiter.js").RateLimitConfig;
+    /** Profile 级熔断器配置 */
+    circuitBreaker: CircuitBreakerConfig;
     /** Background Agent 配置 */
     backgroundAgent?: {
         enabled?: boolean;
@@ -631,11 +636,13 @@ export function loadConfig(configPath?: string, forceReload?: boolean): AppConfi
     const fileProfiles = (fileConfig.llm_profiles ?? {}) as Record<string, Record<string, unknown>>;
 
     for (const [name, raw] of Object.entries(fileProfiles)) {
-        llmProfiles[name] = parseLLMProfile(raw);
+        const cfg = parseLLMProfile(raw);
+        cfg.name = name;
+        llmProfiles[name] = cfg;
     }
 
     if (Object.keys(llmProfiles).length === 0) {
-        llmProfiles["default"] = { ...DEFAULT_LLM };
+        llmProfiles["default"] = { ...DEFAULT_LLM, name: "default" };
     }
 
     // ─── LLM Routing（组件级路由） ───
@@ -762,10 +769,15 @@ export function loadConfig(configPath?: string, forceReload?: boolean): AppConfi
         mcpServers: parseMcpServersConfig(fileConfig),
         grounding: parseGroundingConfig(fileConfig),
         rateLimiting: parseRateLimitingConfig(fileConfig),
+        circuitBreaker: parseCircuitBreakerConfig(fileConfig),
         backgroundAgent: parseBackgroundAgentConfig(fileConfig),
     };
 
     _cached = config;
+
+    // 将熔断配置推入单例（避免 config.ts ↔ breaker 循环依赖：breaker 不反向 import config）
+    profileBreaker.setConfig(config.circuitBreaker);
+
     return config;
 }
 
@@ -827,6 +839,8 @@ export function clearConfigCache(): void {
     _cached = null;
     // Pool 实例与配置绑定，配置变更时需同步清理以保证新 pool 生效
     clearAllPools();
+    // 熔断状态与旧 profile 绑定，配置重载时需重置以免残留误判
+    profileBreaker.resetAll();
 }
 
 // ─── Embedding 配置解析 ───
@@ -1141,6 +1155,20 @@ function parseRateLimitingConfig(fileConfig: Record<string, unknown>): import(".
         maxConcurrency: num(raw.max_concurrency, 0),
         requestsPerMinute: num(raw.requests_per_minute, 0),
         perProfile: Object.keys(perProfile).length > 0 ? perProfile : undefined,
+    };
+}
+
+function parseCircuitBreakerConfig(fileConfig: Record<string, unknown>): CircuitBreakerConfig {
+    const raw = fileConfig.circuit_breaker as Record<string, unknown> | undefined;
+    if (!raw || typeof raw !== "object") {
+        return { enabled: true, failureThreshold: 5, cooldownBaseMs: 60_000, cooldownFactor: 1.5, cooldownMaxMs: 300_000 };
+    }
+    return {
+        enabled: raw.enabled !== false,
+        failureThreshold: num(raw.failure_threshold, 5),
+        cooldownBaseMs: num(raw.cooldown_base_ms, 60_000),
+        cooldownFactor: num(raw.cooldown_factor, 1.5),
+        cooldownMaxMs: num(raw.cooldown_max_ms, 300_000),
     };
 }
 
@@ -1716,6 +1744,17 @@ export function serializeConfigToObject(config: AppConfig): Record<string, unkno
             rl.per_profile = pp;
         }
         obj.rate_limiting = rl;
+    }
+
+    // circuit_breaker
+    if (config.circuitBreaker) {
+        obj.circuit_breaker = {
+            enabled: config.circuitBreaker.enabled,
+            failure_threshold: config.circuitBreaker.failureThreshold,
+            cooldown_base_ms: config.circuitBreaker.cooldownBaseMs,
+            cooldown_factor: config.circuitBreaker.cooldownFactor,
+            cooldown_max_ms: config.circuitBreaker.cooldownMaxMs,
+        };
     }
 
     // background_agent

--- a/src/core/llm-profile-breaker.ts
+++ b/src/core/llm-profile-breaker.ts
@@ -1,0 +1,235 @@
+/**
+ * llm-profile-breaker.ts — Profile 级熔断器
+ *
+ * 按 component + profileName 维度做熔断隔离：某个 profile 连续失败超过阈值时进入 open
+ * 状态，在冷却期内跳过该 profile；冷却到期后放一个真实业务请求作为探针（half_open），
+ * 探针成功则恢复（closed），探针失败则重新 open 并以更长冷却退避。
+ *
+ * 设计要点：
+ * - 单例模式，与 llm-rate-limiter.ts / llm-pool.ts 保持一致的风格。
+ * - 所有方法同步执行——JS 事件循环保证 check+set 在同一同步块内原子完成。
+ * - 不依赖 config.ts（避免循环导入）：配置由 config.ts 在 loadConfig 后通过 setConfig 推入。
+ * - 熔断只决定"是否跳过某个 profile"，不会让原本成功的调用失败，也不会让原本失败的调用
+ *   静默成功。callLLMWithFallback 在所有 profile 均被熔断时会 reset 后强制重试一轮（兜底）。
+ */
+
+import { createLogger } from "./logger.js";
+
+const log = createLogger("profile-breaker");
+
+// ─── 类型定义 ───
+
+export type BreakerState = "closed" | "open" | "half_open";
+
+interface BreakerEntry {
+    state: BreakerState;
+    consecutiveErrors: number;
+    /** 冷却到期时间戳（epoch ms）；0 表示未在冷却 */
+    cooldownUntil: number;
+    /** half_open 状态下是否有探针请求在途 */
+    probing: boolean;
+    lastStateChangeAt: number;
+}
+
+export interface CircuitBreakerConfig {
+    /** 是否启用熔断 */
+    enabled: boolean;
+    /** 连续失败多少次后熔断（open） */
+    failureThreshold: number;
+    /** 冷却基数（ms） */
+    cooldownBaseMs: number;
+    /** 冷却退避因子（每次重新 open 都乘以此因子） */
+    cooldownFactor: number;
+    /** 冷却上限（ms） */
+    cooldownMaxMs: number;
+}
+
+export interface BreakerStatusEntry {
+    component: string;
+    profileName: string;
+    state: BreakerState;
+    consecutiveErrors: number;
+    /** 剩余冷却 ms；未在冷却时为 0 */
+    cooldownRemainingMs: number;
+    probing: boolean;
+}
+
+// ─── 默认配置 ───
+
+const DEFAULT_CONFIG: CircuitBreakerConfig = {
+    enabled: true,
+    failureThreshold: 5,
+    cooldownBaseMs: 60_000,
+    cooldownFactor: 1.5,
+    cooldownMaxMs: 300_000,
+};
+
+// ─── 熔断器实现 ───
+
+class LLMProfileBreaker {
+    private _entries = new Map<string, BreakerEntry>();
+    private _config: CircuitBreakerConfig = { ...DEFAULT_CONFIG };
+
+    /** 由 config.ts 在 loadConfig 后调用，覆盖默认配置（支持部分字段） */
+    setConfig(cfg: Partial<CircuitBreakerConfig>): void {
+        this._config = { ...DEFAULT_CONFIG, ...cfg };
+        log.info("Profile breaker config updated", {
+            enabled: this._config.enabled,
+            failureThreshold: this._config.failureThreshold,
+            cooldownBaseMs: this._config.cooldownBaseMs,
+            cooldownFactor: this._config.cooldownFactor,
+            cooldownMaxMs: this._config.cooldownMaxMs,
+        });
+    }
+
+    getConfig(): CircuitBreakerConfig {
+        return { ...this._config };
+    }
+
+    private _key(component: string, profileName: string): string {
+        return `${component}::${profileName}`;
+    }
+
+    private _getOrCreate(component: string, profileName: string): BreakerEntry {
+        const k = this._key(component, profileName);
+        let entry = this._entries.get(k);
+        if (!entry) {
+            entry = {
+                state: "closed",
+                consecutiveErrors: 0,
+                cooldownUntil: 0,
+                probing: false,
+                lastStateChangeAt: Date.now(),
+            };
+            this._entries.set(k, entry);
+        }
+        return entry;
+    }
+
+    /**
+     * 尝试获取一次调用许可。
+     * - 熔断关闭（enabled=false）→ 永远放行 { try: true, probe: false }
+     * - closed → 放行
+     * - open 且未到冷却 → 拒绝 { try: false }
+     * - open 且冷却到期 → 转为 half_open 并放行首个探针
+     * - half_open 且探针在途 → 拒绝（仅允许一个探针）
+     * - half_open 且无探针在途 → 放行并标记为探针
+     */
+    tryAcquire(component: string, profileName: string): { try: boolean; probe: boolean } {
+        if (!this._config.enabled) {
+            return { try: true, probe: false };
+        }
+        const entry = this._getOrCreate(component, profileName);
+        const now = Date.now();
+
+        switch (entry.state) {
+            case "closed":
+                return { try: true, probe: false };
+
+            case "open":
+                if (now < entry.cooldownUntil) {
+                    // 仍在冷却期 → 跳过
+                    return { try: false, probe: false };
+                }
+                // 冷却到期 → 转为 half_open，等待探针
+                entry.state = "half_open";
+                entry.probing = false;
+                entry.lastStateChangeAt = now;
+                // fall through 到 half_open 分支：本次调用作为首个探针
+                entry.probing = true;
+                return { try: true, probe: true };
+
+            case "half_open":
+                if (entry.probing) {
+                    // 已有探针在途 → 跳过
+                    return { try: false, probe: false };
+                }
+                // 无探针在途 → 本次作为探针
+                entry.probing = true;
+                return { try: true, probe: true };
+        }
+    }
+
+    /** 调用成功：重置为 closed（已恢复） */
+    recordSuccess(component: string, profileName: string): void {
+        const k = this._key(component, profileName);
+        const entry = this._entries.get(k);
+        if (!entry) return;
+        const wasOpen = entry.state !== "closed";
+        entry.state = "closed";
+        entry.consecutiveErrors = 0;
+        entry.cooldownUntil = 0;
+        entry.probing = false;
+        entry.lastStateChangeAt = Date.now();
+        if (wasOpen) {
+            log.info("profile breaker closed (recovered)", { component, profileName });
+        } else {
+            log.debug("profile breaker closed (recovered)", { component, profileName });
+        }
+    }
+
+    /** 调用失败：累计错误，达到阈值则熔断；half_open 失败则重新 open 并加长冷却 */
+    recordFailure(component: string, profileName: string): void {
+        const entry = this._getOrCreate(component, profileName);
+        const now = Date.now();
+        entry.consecutiveErrors += 1;
+        entry.probing = false; // 无论成败，清除探针标记
+
+        if (entry.consecutiveErrors >= this._config.failureThreshold) {
+            // 计算退避冷却：base * factor^(errors - threshold)
+            const exponent = entry.consecutiveErrors - this._config.failureThreshold;
+            const cooldownMs = Math.min(
+                this._config.cooldownBaseMs * Math.pow(this._config.cooldownFactor, exponent),
+                this._config.cooldownMaxMs,
+            );
+            entry.state = "open";
+            entry.cooldownUntil = now + cooldownMs;
+            entry.lastStateChangeAt = now;
+            log.warn("profile breaker OPEN", {
+                component,
+                profileName,
+                errors: entry.consecutiveErrors,
+                cooldownMs,
+            });
+        } else {
+            // 仍在累计错误，未达阈值，保持 closed
+            log.debug("profile breaker accumulating errors", {
+                component,
+                profileName,
+                errors: entry.consecutiveErrors,
+                threshold: this._config.failureThreshold,
+            });
+        }
+    }
+
+    /** 清除所有熔断状态（配置重载 / 全员熔断兜底时调用） */
+    resetAll(): void {
+        this._entries.clear();
+        log.info("profile breaker: all states reset");
+    }
+
+    /** 获取全部熔断状态快照（供 Dashboard / API） */
+    getStatus(): { enabled: boolean; config: CircuitBreakerConfig; entries: BreakerStatusEntry[] } {
+        const now = Date.now();
+        const entries: BreakerStatusEntry[] = [];
+        for (const [k, entry] of this._entries) {
+            const [component, profileName] = k.split("::");
+            entries.push({
+                component,
+                profileName,
+                state: entry.state,
+                consecutiveErrors: entry.consecutiveErrors,
+                cooldownRemainingMs: Math.max(0, entry.cooldownUntil - now),
+                probing: entry.probing,
+            });
+        }
+        return {
+            enabled: this._config.enabled,
+            config: { ...this._config },
+            entries,
+        };
+    }
+}
+
+/** Singleton */
+export const profileBreaker = new LLMProfileBreaker();

--- a/src/core/llm.ts
+++ b/src/core/llm.ts
@@ -15,11 +15,12 @@ export { type LLMConfig } from "./config.js";
 // 从 llm/types.ts 重新导出类型，保持向后兼容
 export { type ImagePart, type ChatMessage, type LLMResponse } from "./llm/types.js";
 
-import type { LLMConfig } from "./config.js";
+import type { LLMConfig, RoutingComponentKey } from "./config.js";
 import type { ChatMessage, LLMResponse } from "./llm/types.js";
 import type { ContextManifest } from "../context-engine/types.js";
 import { getOrCreatePool } from "./llm-pool.js";
 import { rateLimiter } from "./llm-rate-limiter.js";
+import { profileBreaker } from "./llm-profile-breaker.js";
 import { loadConfig } from "./config.js";
 import { createLogger } from "./logger.js";
 import { sanitizePromptText } from "./text-safety.js";
@@ -153,6 +154,8 @@ export interface LLMCallOptions {
     contextManifest?: ContextManifest;
     /** 外部取消信号。用于上层在新消息到达时中断本次推理并重建 prompt。 */
     abortSignal?: AbortSignal;
+    /** 组件身份标识，用于 per-component 熔断器状态隔离 */
+    component?: RoutingComponentKey;
 }
 
 export const LLM_PENDING_MESSAGE_ABORT = "pending_message";
@@ -650,45 +653,67 @@ export async function callLLMWithFallback(
     if (configs.length === 0) {
         throw new Error("callLLMWithFallback: no LLM configs provided");
     }
-    if (configs.length === 1) {
-        return callLLM(messages, configs[0], options);
-    }
 
+    const component = options?.component;
+    const breakerOn = profileBreaker.getConfig().enabled && !!component;
+    let triedAny = false;
     let lastError: Error | null = null;
+
     for (let i = 0; i < configs.length; i++) {
+        const cfg = configs[i];
+        const profileName = cfg.name ?? `${cfg.model}:${cfg.baseUrl}`;
+        if (breakerOn && component) {
+            const acq = profileBreaker.tryAcquire(component, profileName);
+            if (!acq.try) continue; // open 或探针在途：跳过该 profile
+        }
         try {
-            return await callLLM(messages, configs[i], options);
+            const result = await callLLM(messages, cfg, options);
+            if (breakerOn && component) profileBreaker.recordSuccess(component, profileName);
+            return result;
         } catch (err) {
-            if (isLLMInterruptedByPendingMessage(err)) {
-                throw err;
-            }
+            // pending-message 中断：不计入熔断，立即上抛
+            if (isLLMInterruptedByPendingMessage(err)) throw err;
+            if (breakerOn && component) profileBreaker.recordFailure(component, profileName);
             lastError = err instanceof Error ? err : new Error(String(err));
+            triedAny = true;
 
-            // 最后一个 config 也失败 → 抛出
-            if (i === configs.length - 1) {
-                throw lastError;
+            // 分类仅用于日志（非最后一个 config 才记 "尝试下一个 profile"）
+            if (i < configs.length - 1) {
+                const msg = lastError.message;
+                const reason = (msg.includes("429") || msg.includes("quota") || msg.includes("RESOURCE_EXHAUSTED") ||
+                    msg.includes("rate limit") || msg.includes("overloaded") || msg.includes("402") ||
+                    msg.includes("payment") || msg.includes("insufficient"))
+                    ? "quota"
+                    : (msg.includes("401") || msg.includes("403") || msg.includes("PERMISSION_DENIED") ||
+                        msg.includes("billing") || msg.includes("Unauthorized") || msg.includes("Forbidden"))
+                        ? "auth"
+                        : "other";
+
+                log.warn("callLLMWithFallback: 错误，尝试下一个 profile", {
+                    failedModel: cfg.model,
+                    nextModel: configs[i + 1]?.model,
+                    attempt: i + 1,
+                    total: configs.length,
+                    reason,
+                    error: msg.slice(0, 150),
+                });
             }
-
-            // 分类仅用于日志
-            const msg = lastError.message;
-            const reason = (msg.includes("429") || msg.includes("quota") || msg.includes("RESOURCE_EXHAUSTED") ||
-                msg.includes("rate limit") || msg.includes("overloaded") || msg.includes("402") ||
-                msg.includes("payment") || msg.includes("insufficient"))
-                ? "quota"
-                : (msg.includes("401") || msg.includes("403") || msg.includes("PERMISSION_DENIED") ||
-                    msg.includes("billing") || msg.includes("Unauthorized") || msg.includes("Forbidden"))
-                    ? "auth"
-                    : "other";
-
-            log.warn("callLLMWithFallback: 错误，尝试下一个 profile", {
-                failedModel: configs[i].model,
-                nextModel: configs[i + 1]?.model,
-                attempt: i + 1,
-                total: configs.length,
-                reason,
-                error: msg.slice(0, 150),
-            });
         }
     }
+
+    // 所有 profile 均被熔断跳过且未尝试任何一个 → reset 后强制重试一轮（兜底，避免熔断自身导致服务不可用）
+    if (!triedAny && configs.length > 0) {
+        log.warn("callLLMWithFallback: 所有 profile 熔断中,reset 后强制重试一轮", { component });
+        profileBreaker.resetAll();
+        for (let i = 0; i < configs.length; i++) {
+            try {
+                return await callLLM(messages, configs[i], options);
+            } catch (err) {
+                if (isLLMInterruptedByPendingMessage(err)) throw err;
+                lastError = err instanceof Error ? err : new Error(String(err));
+            }
+        }
+    }
+
     throw lastError ?? new Error("callLLMWithFallback: unexpected state");
 }

--- a/src/core/message-enricher.ts
+++ b/src/core/message-enricher.ts
@@ -762,7 +762,7 @@ async function enrichWithOpenGraph(
                         imageParts: [{ url: dataUri }],
                     },
                 ];
-                const response = await callLLMWithFallback(visionMessages, visionLlmConfigs, { caller: "og-vision", timeoutMs: resolveComponentTimeout("vision") });
+                const response = await callLLMWithFallback(visionMessages, visionLlmConfigs, { caller: "og-vision", component: "vision", timeoutMs: resolveComponentTimeout("vision") });
                 const description = response.content.trim();
 
                 const entry = {

--- a/src/core/sticker-detector.ts
+++ b/src/core/sticker-detector.ts
@@ -99,6 +99,7 @@ export class StickerDetector {
 
         const response = await callLLMWithFallback(messages, this.deps.visionConfigs, {
             caller: "sticker-detector",
+            component: "vision",
         });
 
         const raw = response.content.trim();

--- a/src/core/vision-processor.ts
+++ b/src/core/vision-processor.ts
@@ -847,8 +847,9 @@ export async function describeImage(
         },
     ];
 
-    const response = await callLLMWithFallback(messages, visionConfigs, { caller: "vision", timeoutMs: resolveComponentTimeout("vision") });
-    return normalizeVisionDescription(response.content);
+    const response = await callLLMWithFallback(messages, visionConfigs, { caller: "vision", component: "vision", timeoutMs: resolveComponentTimeout("vision") });
+    const collapseNewlines = !trimmedPrompt;
+    return normalizeVisionDescription(response.content, collapseNewlines);
 }
 
 /**
@@ -886,7 +887,7 @@ async function describeSticker(
         },
     ];
 
-    const response = await callLLMWithFallback(messages, visionConfigs, { caller: "vision" });
+    const response = await callLLMWithFallback(messages, visionConfigs, { caller: "vision", component: "vision" });
     const raw = response.content.trim();
 
     // 尝试解析 JSON（先直接解析，失败再从文本中抽取 {...} 片段救一把）

--- a/src/dashboard/api-routes.ts
+++ b/src/dashboard/api-routes.ts
@@ -16,6 +16,7 @@ import { createLogger } from "../core/logger.js";
 import { loadConfig, validateConfig, saveConfig } from "../core/config.js";
 import { DEFAULT_BANNED_WORDS } from "../core/banned-words.js";
 import { rateLimiter } from "../core/llm-rate-limiter.js";
+import { profileBreaker } from "../core/llm-profile-breaker.js";
 import { discoverSkills } from "../sandbox/skill-loader.js";
 import {
     listAllPrompts,
@@ -1731,6 +1732,11 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
     // ─── Rate Limiter Stats ───
     router.get("/rate-limiter/stats", (_req, res) => {
         res.json(rateLimiter.getStats());
+    });
+
+    // ─── Circuit Breaker Status ───
+    router.get("/circuit-breaker/status", (_req, res) => {
+        res.json(profileBreaker.getStatus());
     });
 
     // ─── Config Editor ───

--- a/src/dashboard/ui/src/panels/ConfigPanel.svelte
+++ b/src/dashboard/ui/src/panels/ConfigPanel.svelte
@@ -21,6 +21,7 @@
   import SystemPromptsTab from "./config/SystemPromptsTab.svelte";
   import GroundingTab from "./config/GroundingTab.svelte";
   import RateLimitingTab from "./config/RateLimitingTab.svelte";
+  import CircuitBreakerTab from "./config/CircuitBreakerTab.svelte";
   import BackgroundAgentTab from "./config/BackgroundAgentTab.svelte";
   import MetricsTab from "./config/MetricsTab.svelte";
   import ChatFilterTab from "./config/ChatFilterTab.svelte";
@@ -68,6 +69,7 @@
     { id: "systemPrompts", label: "System Prompts", icon: "fa-file-lines" },
     { id: "grounding", label: "Grounding", icon: "fa-globe" },
     { id: "rateLimiting", label: "请求限速", icon: "fa-gauge-high" },
+    { id: "circuitBreaker", label: "熔断器", icon: "fa-bolt-lightning" },
     { id: "backgroundAgent", label: "做梦系统", icon: "fa-moon" },
     { id: "chatFilter", label: "聊天过滤", icon: "fa-filter" },
     { id: "metrics", label: "Metrics", icon: "fa-chart-line" },
@@ -654,6 +656,8 @@
             <EnvVarsTab bind:config {pwFocus} {pwBlur} {addEnvVar} {removeEnvVar} />
           {:else if currentSection === "rateLimiting"}
             <RateLimitingTab bind:config profileNames={Object.keys(config.llmProfiles ?? {})} />
+          {:else if currentSection === "circuitBreaker"}
+            <CircuitBreakerTab bind:config />
           {:else if currentSection === "backgroundAgent"}
             <BackgroundAgentTab bind:config {pwFocus} {pwBlur} />
           {:else if currentSection === "chatFilter"}

--- a/src/dashboard/ui/src/panels/config/CircuitBreakerTab.svelte
+++ b/src/dashboard/ui/src/panels/config/CircuitBreakerTab.svelte
@@ -1,0 +1,327 @@
+<script>
+  import { onMount, onDestroy } from "svelte";
+  import { api } from "../../lib/api.js";
+
+  export let config;
+
+  let status = null;
+  let statusTimer = null;
+
+  // Ensure circuitBreaker object exists
+  $: if (!config.circuitBreaker) {
+    config.circuitBreaker = {
+      enabled: true,
+      failureThreshold: 5,
+      cooldownBaseMs: 60000,
+      cooldownFactor: 1.5,
+      cooldownMaxMs: 300000,
+    };
+  }
+
+  async function fetchStatus() {
+    try {
+      status = await api("/circuit-breaker/status");
+    } catch {}
+  }
+
+  /** 毫秒 → 人类可读简短时长 */
+  function formatMs(ms) {
+    if (ms == null || isNaN(ms)) return "—";
+    const n = Number(ms);
+    if (n <= 0) return "0s";
+    const sec = Math.round(n / 1000);
+    if (sec < 60) return sec + "s";
+    const min = Math.floor(sec / 60);
+    const rem = sec % 60;
+    if (rem === 0) return min + "min";
+    return min + "min" + rem + "s";
+  }
+
+  /** 计算退避序列预览 */
+  $: ladder = (() => {
+    const cb = config.circuitBreaker;
+    if (!cb) return [];
+    const base = Number(cb.cooldownBaseMs);
+    const factor = Number(cb.cooldownFactor);
+    const max = Number(cb.cooldownMaxMs);
+    if (!(base > 0) || !(factor >= 1) || !(max > 0)) return [];
+    const steps = [];
+    let cur = base;
+    for (let i = 0; i < 6; i++) {
+      steps.push(Math.min(cur, max));
+      if (cur >= max) break;
+      const next = cur * factor;
+      if (next <= cur) break; // factor <= 1，不再增长
+      cur = next;
+    }
+    return steps;
+  })();
+
+  /** 熔断中的条目数 */
+  $: trippedCount =
+    status && status.entries
+      ? status.entries.filter((e) => e.state !== "closed").length
+      : 0;
+
+  function stateMeta(state) {
+    switch (state) {
+      case "closed":
+        return { cls: "badge-success", label: "正常" };
+      case "open":
+        return { cls: "badge-error", label: "熔断" };
+      case "half_open":
+        return { cls: "badge-warning", label: "探测" };
+      default:
+        return { cls: "badge-ghost", label: state || "—" };
+    }
+  }
+
+  onMount(() => {
+    fetchStatus();
+    statusTimer = setInterval(fetchStatus, 3000);
+  });
+  onDestroy(() => {
+    if (statusTimer) clearInterval(statusTimer);
+  });
+</script>
+
+<h3 class="card-title text-sm">
+  <i class="fa-solid fa-bolt-lightning opacity-50 mr-1"></i> LLM 熔断器
+</h3>
+<p class="text-xs opacity-50 mb-3">
+  某个 profile 连续失败时自动熔断，避免持续请求已故障的 LLM。冷却期采用指数退避，恢复时先发探测请求。
+</p>
+
+<!-- Enable toggle -->
+<label class="cfg-check mb-3">
+  <input
+    type="checkbox"
+    class="toggle toggle-sm toggle-primary"
+    bind:checked={config.circuitBreaker.enabled}
+  />
+  <span class="ml-2">启用熔断器</span>
+</label>
+
+{#if !config.circuitBreaker.enabled}
+  <div class="text-xs opacity-40 italic">
+    <i class="fa-solid fa-circle-info mr-1"></i>
+    熔断器已关闭，所有 profile 将始终被尝试调用（不会跳过故障 profile）。
+  </div>
+{:else}
+  <!-- Config fields -->
+  <div class="divider text-xs opacity-50 my-2">
+    <i class="fa-solid fa-sliders mr-1"></i>熔断参数
+  </div>
+  <div class="cfg-grid-2">
+    <label class="cfg-field">
+      <span class="cfg-label">连续失败阈值 (次)</span>
+      <input
+        type="number"
+        class="input input-xs input-bordered w-full"
+        bind:value={config.circuitBreaker.failureThreshold}
+        min="1"
+        step="1"
+      />
+      <span class="text-xs opacity-40">连续失败多少次后熔断该 profile</span>
+    </label>
+    <label class="cfg-field">
+      <span class="cfg-label">退避系数 (×)</span>
+      <input
+        type="number"
+        class="input input-xs input-bordered w-full"
+        bind:value={config.circuitBreaker.cooldownFactor}
+        min="1.0"
+        step="0.1"
+      />
+      <span class="text-xs opacity-40">每次重新熔断后冷却时长乘以这个系数</span>
+    </label>
+    <label class="cfg-field">
+      <span class="cfg-label">冷却基数 (ms)</span>
+      <input
+        type="number"
+        class="input input-xs input-bordered w-full"
+        bind:value={config.circuitBreaker.cooldownBaseMs}
+        min="1000"
+        step="1000"
+      />
+      <span class="text-xs opacity-40"
+        >首次熔断的冷却时长 = {formatMs(
+          config.circuitBreaker.cooldownBaseMs,
+        )}</span
+      >
+    </label>
+    <label class="cfg-field">
+      <span class="cfg-label">冷却上限 (ms)</span>
+      <input
+        type="number"
+        class="input input-xs input-bordered w-full"
+        bind:value={config.circuitBreaker.cooldownMaxMs}
+        min={config.circuitBreaker.cooldownBaseMs}
+        step="1000"
+      />
+      <span class="text-xs opacity-40"
+        >退避封顶值 = {formatMs(config.circuitBreaker.cooldownMaxMs)}</span
+      >
+    </label>
+  </div>
+
+  <!-- Cooldown ladder preview -->
+  {#if ladder.length > 0}
+    <div class="ladder-preview mt-2">
+      <span class="text-xs opacity-50">
+        <i class="fa-solid fa-arrow-trend-up mr-1"></i>退避序列：
+      </span>
+      {#each ladder as step, i}
+        {#if i > 0}<span class="ladder-arrow">→</span>{/if}
+        <span
+          class="ladder-step"
+          class:capped={step >= config.circuitBreaker.cooldownMaxMs}
+        >
+          {formatMs(step)}
+          {#if step >= config.circuitBreaker.cooldownMaxMs}
+            <span class="ladder-cap">封顶</span>
+          {/if}
+        </span>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Live status -->
+  <div class="divider text-xs opacity-50 my-3">
+    <i class="fa-solid fa-wave-square mr-1"></i>实时状态
+  </div>
+
+  {#if !status}
+    <div class="text-center text-xs opacity-40 py-6">
+      <span class="loading loading-xs loading-spinner mr-1"></span> 加载中…
+    </div>
+  {:else if status.entries && status.entries.length > 0}
+    <div class="flex items-center justify-between mb-2">
+      <span class="text-xs opacity-50">
+        {status.entries.length} 个 profile 被追踪，<span
+          class="text-error font-semibold">{trippedCount}</span
+        >
+        个熔断中
+      </span>
+    </div>
+    <table class="table table-xs w-full">
+      <thead>
+        <tr>
+          <th>组件</th>
+          <th>Profile</th>
+          <th class="text-center">状态</th>
+          <th class="text-center">连续错误</th>
+          <th class="text-center">冷却剩余</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each status.entries as e (e.component + "/" + e.profileName)}
+          {@const m = stateMeta(e.state)}
+          <tr>
+            <td class="font-mono text-xs">{e.component}</td>
+            <td class="font-mono text-xs">{e.profileName}</td>
+            <td class="text-center">
+              <span class="badge badge-sm {m.cls} gap-1">
+                {#if e.probing}
+                  <span class="probe-dot"></span>
+                {/if}
+                {m.label}
+              </span>
+            </td>
+            <td class="text-center">{e.consecutiveErrors ?? 0}</td>
+            <td class="text-center font-mono">
+              {#if e.cooldownRemainingMs > 0}
+                {formatMs(e.cooldownRemainingMs)}
+              {:else}
+                <span class="opacity-30">—</span>
+              {/if}
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {:else}
+    <div class="empty-state">
+      <i class="fa-solid fa-heart-pulse empty-icon"></i>
+      <div class="empty-text">暂无熔断记录</div>
+      <div class="empty-sub">所有 profile 运行正常</div>
+    </div>
+  {/if}
+{/if}
+
+<!-- TODO: 未来可加「重置所有熔断状态」按钮，需后端提供 POST /circuit-breaker/reset 端点 -->
+
+<style>
+  .ladder-preview {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    background: var(--color-base-200);
+  }
+  .ladder-step {
+    font-family: "JetBrains Mono", "Fira Code", monospace;
+    font-size: 0.72rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 0.25rem;
+    background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+    color: var(--color-primary);
+  }
+  .ladder-step.capped {
+    background: color-mix(in srgb, var(--color-warning) 15%, transparent);
+    color: var(--color-warning);
+  }
+  .ladder-cap {
+    font-size: 0.55rem;
+    margin-left: 0.2rem;
+    opacity: 0.7;
+  }
+  .ladder-arrow {
+    font-size: 0.6rem;
+    opacity: 0.35;
+  }
+  .probe-dot {
+    display: inline-block;
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 999px;
+    background: currentColor;
+    animation: cb-pulse 1.2s ease-in-out infinite;
+  }
+  @keyframes cb-pulse {
+    0%,
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+    50% {
+      opacity: 0.35;
+      transform: scale(1.45);
+    }
+  }
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+    text-align: center;
+    opacity: 0.65;
+  }
+  .empty-icon {
+    font-size: 1.75rem;
+    color: oklch(0.7 0.15 160);
+    margin-bottom: 0.5rem;
+  }
+  .empty-text {
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+  .empty-sub {
+    font-size: 0.7rem;
+    opacity: 0.6;
+    margin-top: 0.15rem;
+  }
+</style>

--- a/src/memory-v2/context-manager.ts
+++ b/src/memory-v2/context-manager.ts
@@ -524,7 +524,7 @@ async function generateBriefing(
     ];
 
     try {
-        const response = await callLLMWithFallback(briefingMessages, llmConfigs, { caller: "context-manager", timeoutMs: resolveComponentTimeout("compact") });
+        const response = await callLLMWithFallback(briefingMessages, llmConfigs, { caller: "context-manager", component: "compact", timeoutMs: resolveComponentTimeout("compact") });
         const briefing = response.content.trim();
 
         // 检查 briefing 是否超过预算

--- a/src/memory-v2/memory-v2.ts
+++ b/src/memory-v2/memory-v2.ts
@@ -2136,7 +2136,7 @@ export class MemoryStoreV2 implements IMemoryStoreV2 {
             { role: "user", content: `查询：${query}\n\n相关记忆：\n${topicSummaries}\n${factSummaries}` },
         ];
 
-        const response = await callLLMWithFallback(messages, memoryConfigs, { caller: "memory", timeoutMs: resolveComponentTimeout("memory") });
+        const response = await callLLMWithFallback(messages, memoryConfigs, { caller: "memory", component: "memory", timeoutMs: resolveComponentTimeout("memory") });
         return response.content.trim();
     }
 
@@ -2304,7 +2304,7 @@ export class MemoryStoreV2 implements IMemoryStoreV2 {
             { role: "user", content: intent },
         ];
 
-        const response = await callLLMWithFallback(messages, memoryConfigs, { caller: "memory", timeoutMs: resolveComponentTimeout("memory") });
+        const response = await callLLMWithFallback(messages, memoryConfigs, { caller: "memory", component: "memory", timeoutMs: resolveComponentTimeout("memory") });
         try {
             const parsed = JSON.parse(response.content.replace(/```json?\s*/g, "").replace(/```/g, "").trim());
             return {
@@ -2341,7 +2341,7 @@ export class MemoryStoreV2 implements IMemoryStoreV2 {
             { role: "user", content: `问题：${intent}\n\n对话记录：\n${contextParts.join("\n\n---\n\n")}` },
         ];
 
-        const response = await callLLMWithFallback(messages, memoryConfigs, { caller: "memory", timeoutMs: resolveComponentTimeout("memory") });
+        const response = await callLLMWithFallback(messages, memoryConfigs, { caller: "memory", component: "memory", timeoutMs: resolveComponentTimeout("memory") });
         return response.content.trim();
     }
 

--- a/src/memory-v2/reflection.ts
+++ b/src/memory-v2/reflection.ts
@@ -292,6 +292,7 @@ export async function runReflection(
         try {
             const response = await callLLMWithFallback(messages, llmConfigs, {
                 caller: "reflection",
+                component: "reflection",
                 timeoutMs: reflectionTimeout,
                 // 不在单 profile 内重试同一超大 prompt（纯浪费 timeout）；
                 // 收缩回看范围 + profile fallback 才是真正的重试策略。
@@ -2125,6 +2126,7 @@ async function analyzeMergeWithLLM(
         ];
         const response = await callLLMWithFallback(messages, llmConfigs, {
             caller: "reflection",
+            component: "reflection",
             timeoutMs: resolveComponentTimeout("reflection"),
         });
 
@@ -2183,6 +2185,7 @@ async function analyzeCascadeMergeWithLLM(
         ];
         const response = await callLLMWithFallback(messages, llmConfigs, {
             caller: "reflection",
+            component: "reflection",
             timeoutMs: resolveComponentTimeout("reflection"),
         });
 

--- a/src/meta-sandbox/meta-session-runner.ts
+++ b/src/meta-sandbox/meta-session-runner.ts
@@ -262,6 +262,7 @@ export async function runMetaSession(
         try {
             const response = await llmCaller(messages, llmConfigs, {
                 caller: "meta-session",
+                component: "meta",
                 stop: [META_SANDBOX_OBSERVATION_MARKER],
                 timeoutMs: config.llmTimeoutMs,
                 ...(config.contextManifest ? { contextManifest: config.contextManifest } : {}),

--- a/src/pipeline/recording-pipeline.ts
+++ b/src/pipeline/recording-pipeline.ts
@@ -483,7 +483,7 @@ export class RecordingPipeline extends EventEmitter {
 
         let response;
         try {
-            response = await callLLMWithFallback(llmMessages, resolveComponentProfiles("recording_cluster"), { caller: "recording-cluster", timeoutMs: resolveComponentTimeout("recording_cluster") });
+            response = await callLLMWithFallback(llmMessages, resolveComponentProfiles("recording_cluster"), { caller: "recording-cluster", component: "recording_cluster", timeoutMs: resolveComponentTimeout("recording_cluster") });
         } catch (err) {
             // 保底回退：LLM 彻底失败（超时/网关，所有 profile+重试用尽）时不抛出，降级为本地单话题归类。
             // 关键：这样本批次仍被记录并从 buffer 排空，绝不把整批 unshift 回 buffer 头触发死亡螺旋。
@@ -642,7 +642,7 @@ export class RecordingPipeline extends EventEmitter {
 
         let response;
         try {
-            response = await callLLMWithFallback(llmMessages, resolveComponentProfiles("recording_triage"), { caller: "recording-triage", timeoutMs: resolveComponentTimeout("recording_triage") });
+            response = await callLLMWithFallback(llmMessages, resolveComponentProfiles("recording_triage"), { caller: "recording-triage", component: "recording_triage", timeoutMs: resolveComponentTimeout("recording_triage") });
         } catch (err) {
             // 保底回退：triage LLM 彻底失败时不抛出（否则 flush 进 catch → 回退 buffer → 死亡螺旋）。
             // 返回空 triage：话题仍按 clustering 落盘，仅缺 LLM 摘要（后续 reflection 可补）。
@@ -694,7 +694,7 @@ export class RecordingPipeline extends EventEmitter {
             ];
 
             try {
-                const retryResponse = await callLLMWithFallback(retryMessages, resolveComponentProfiles("recording_triage"), { caller: "recording-triage", timeoutMs: resolveComponentTimeout("recording_triage") });
+                const retryResponse = await callLLMWithFallback(retryMessages, resolveComponentProfiles("recording_triage"), { caller: "recording-triage", component: "recording_triage", timeoutMs: resolveComponentTimeout("recording_triage") });
                 const retryJson = retryResponse.content
                     .replace(/```json\s*/g, "")
                     .replace(/```\s*/g, "")

--- a/src/sandbox/session-runner.ts
+++ b/src/sandbox/session-runner.ts
@@ -569,6 +569,7 @@ export async function runCodeActSession(
         try {
             llmResponse = await callLLMWithFallback(messages, configs, {
                 caller: "session-runner",
+                component: "session",
                 timeoutMs: resolveComponentTimeout("session"),
                 // reply 路径：让实际选中的 profile 追加自己的 replyPrompt（fallback 时不会错用 profile[0] 的）。
                 applyReplyPrompt: true,

--- a/src/subagent/post-task-window.ts
+++ b/src/subagent/post-task-window.ts
@@ -802,6 +802,7 @@ async function judgePostTaskFollowUpWithLLM(input: PostTaskFollowUpJudgeInput): 
     ];
     const response = await callLLMWithFallback(llmMessages, profiles, {
         caller: "post-task-followup",
+        component: hasDedicatedRoute ? "post_task_followup" : "recording_triage",
         timeoutMs,
     });
     return parseFollowUpJudgeResult(response.content);

--- a/tests/llm-profile-breaker.test.ts
+++ b/tests/llm-profile-breaker.test.ts
@@ -1,0 +1,257 @@
+/**
+ * llm-profile-breaker.test.ts — Profile 级熔断器 单元测试
+ *
+ * 覆盖：三态转换 / 半开并发只放一个探针 / resetAll / enabled 开关 /
+ *      per-(component,profile) 隔离 / 冷却退避递增 / 冷却封顶
+ */
+
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { profileBreaker } from "../src/core/llm-profile-breaker.js";
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+function entry(component: string, profileName: string) {
+    const e = profileBreaker.getStatus().entries.find(
+        (x) => x.component === component && x.profileName === profileName,
+    );
+    assert.ok(e, `entry ${component}/${profileName} 应存在`);
+    return e;
+}
+
+describe("LLMProfileBreaker", () => {
+    beforeEach(() => {
+        profileBreaker.resetAll();
+        profileBreaker.setConfig({
+            enabled: true,
+            failureThreshold: 3,
+            cooldownBaseMs: 20,
+            cooldownFactor: 2,
+            cooldownMaxMs: 1000,
+        });
+    });
+
+    describe("closed 状态", () => {
+        it("新 entry 放行且非探针", () => {
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: true,
+                probe: false,
+            });
+        });
+
+        it("recordSuccess 后保持 closed", () => {
+            profileBreaker.recordSuccess("meta", "p1");
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: true,
+                probe: false,
+            });
+        });
+
+        it("未达阈值时累计失败仍 closed、放行", () => {
+            profileBreaker.recordFailure("meta", "p1");
+            profileBreaker.recordFailure("meta", "p1");
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: true,
+                probe: false,
+            });
+        });
+    });
+
+    describe("open 状态", () => {
+        it("达阈值后熔断，tryAcquire 拒绝", () => {
+            for (let i = 0; i < 3; i++) profileBreaker.recordFailure("meta", "p1");
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: false,
+                probe: false,
+            });
+            assert.equal(entry("meta", "p1").state, "open");
+        });
+
+        it("成功调用重置计数（不会因历史失败累积而误熔断）", () => {
+            profileBreaker.recordFailure("meta", "p1");
+            profileBreaker.recordFailure("meta", "p1");
+            profileBreaker.recordSuccess("meta", "p1");
+            profileBreaker.recordFailure("meta", "p1");
+            profileBreaker.recordFailure("meta", "p1");
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: true,
+                probe: false,
+            });
+        });
+    });
+
+    describe("half_open 状态", () => {
+        async function tripAndExpire(component: string, profileName: string) {
+            for (let i = 0; i < 3; i++) profileBreaker.recordFailure(component, profileName);
+            assert.deepStrictEqual(
+                profileBreaker.tryAcquire(component, profileName),
+                { try: false, probe: false },
+            );
+            await sleep(25);
+        }
+
+        it("冷却到期后转 half_open 并放行首个探针", async () => {
+            await tripAndExpire("meta", "p1");
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: true,
+                probe: true,
+            });
+            assert.equal(entry("meta", "p1").state, "half_open");
+        });
+
+        it("半开期间只放一个探针，其余拒绝", async () => {
+            await tripAndExpire("meta", "p1");
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: true,
+                probe: true,
+            });
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: false,
+                probe: false,
+            });
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: false,
+                probe: false,
+            });
+        });
+
+        it("探针成功 → 恢复 closed", async () => {
+            await tripAndExpire("meta", "p1");
+            profileBreaker.tryAcquire("meta", "p1");
+            profileBreaker.recordSuccess("meta", "p1");
+            assert.equal(entry("meta", "p1").state, "closed");
+            assert.equal(entry("meta", "p1").consecutiveErrors, 0);
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: true,
+                probe: false,
+            });
+        });
+
+        it("探针失败 → 重新 open 且 errors 累加", async () => {
+            await tripAndExpire("meta", "p1");
+            profileBreaker.tryAcquire("meta", "p1");
+            profileBreaker.recordFailure("meta", "p1");
+            assert.equal(entry("meta", "p1").state, "open");
+            assert.equal(entry("meta", "p1").consecutiveErrors, 4);
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: false,
+                probe: false,
+            });
+        });
+    });
+
+    describe("resetAll", () => {
+        it("清空所有 entry，之后放行", () => {
+            for (let i = 0; i < 3; i++) profileBreaker.recordFailure("meta", "p1");
+            assert.equal(profileBreaker.getStatus().entries.length, 1);
+            profileBreaker.resetAll();
+            assert.equal(profileBreaker.getStatus().entries.length, 0);
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: true,
+                probe: false,
+            });
+        });
+    });
+
+    describe("enabled 开关", () => {
+        it("enabled=false 时即使已熔断也放行", () => {
+            for (let i = 0; i < 3; i++) profileBreaker.recordFailure("meta", "p1");
+            profileBreaker.setConfig({ enabled: false });
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: true,
+                probe: false,
+            });
+        });
+
+        it("重新 enable 后恢复熔断语义", () => {
+            for (let i = 0; i < 3; i++) profileBreaker.recordFailure("meta", "p1");
+            profileBreaker.setConfig({ enabled: false });
+            profileBreaker.tryAcquire("meta", "p1");
+            profileBreaker.setConfig({ enabled: true });
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: false,
+                probe: false,
+            });
+        });
+    });
+
+    describe("隔离性", () => {
+        it("不同 component 的同名 profile 状态独立", () => {
+            for (let i = 0; i < 3; i++) profileBreaker.recordFailure("meta", "p1");
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: false,
+                probe: false,
+            });
+            assert.deepStrictEqual(profileBreaker.tryAcquire("session", "p1"), {
+                try: true,
+                probe: false,
+            });
+        });
+
+        it("同 component 的不同 profile 状态独立", () => {
+            for (let i = 0; i < 3; i++) profileBreaker.recordFailure("meta", "p1");
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p1"), {
+                try: false,
+                probe: false,
+            });
+            assert.deepStrictEqual(profileBreaker.tryAcquire("meta", "p2"), {
+                try: true,
+                probe: false,
+            });
+        });
+
+        it("getStatus 反映不同 component/profile 的独立条目", () => {
+            profileBreaker.recordFailure("meta", "p1");
+            profileBreaker.recordFailure("session", "p1");
+            profileBreaker.recordFailure("meta", "p2");
+            const entries = profileBreaker.getStatus().entries;
+            assert.equal(entries.length, 3);
+            const keys = entries.map((e) => `${e.component}/${e.profileName}`).sort();
+            assert.deepStrictEqual(keys, ["meta/p1", "meta/p2", "session/p1"]);
+        });
+    });
+
+    describe("冷却退避", () => {
+        it("连续 half_open 失败使冷却时长递增", async () => {
+            profileBreaker.setConfig({
+                enabled: true,
+                failureThreshold: 2,
+                cooldownBaseMs: 20,
+                cooldownFactor: 2,
+                cooldownMaxMs: 10_000,
+            });
+            profileBreaker.recordFailure("meta", "p1");
+            profileBreaker.recordFailure("meta", "p1");
+            const c1 = entry("meta", "p1").cooldownRemainingMs;
+            assert.ok(c1 > 0, "首次冷却应 > 0");
+
+            await sleep(25);
+            profileBreaker.tryAcquire("meta", "p1");
+            profileBreaker.recordFailure("meta", "p1");
+            const c2 = entry("meta", "p1").cooldownRemainingMs;
+            assert.ok(c2 > c1, `二次冷却应更长 ${c1} → ${c2}`);
+
+            await sleep(45);
+            profileBreaker.tryAcquire("meta", "p1");
+            profileBreaker.recordFailure("meta", "p1");
+            const c3 = entry("meta", "p1").cooldownRemainingMs;
+            assert.ok(c3 > c2, `三次冷却应更长 ${c2} → ${c3}`);
+        });
+
+        it("冷却封顶不超过 cooldownMaxMs", async () => {
+            profileBreaker.setConfig({
+                enabled: true,
+                failureThreshold: 1,
+                cooldownBaseMs: 20,
+                cooldownFactor: 10,
+                cooldownMaxMs: 50,
+            });
+            profileBreaker.recordFailure("meta", "p1");
+            await sleep(25);
+            profileBreaker.tryAcquire("meta", "p1");
+            profileBreaker.recordFailure("meta", "p1");
+            const c = entry("meta", "p1").cooldownRemainingMs;
+            assert.ok(c <= 50, `应封顶到 ≤50，实际 ${c}`);
+        });
+    });
+});


### PR DESCRIPTION
## 概述

**6 commits | 生产级稳定性**

为 LLM 调用链路添加 profile 级别的熔断机制，当某个 API 故障时自动跳过。

### 功能
- **熔断器模块** — 半开/开/闭三态状态机
- **配置项** circuit_breaker + LLMConfig.name 注入
- 集成到 callLLMWithFallback 主调用路径
- 所有 LLM 调用点接入组件身份标识
- API 端点 GET /api/circuit-breaker/status
- Dashboard 新增「熔断器」Tab

### 变更
- 新增: src/core/llm-profile-breaker.ts, tests, CircuitBreakerTab.svelte
- 修改: config, LLM调用层, API路由, Dashboard