### PR TITLE
feat: LLM profiles 新增 omit_temperature 选项

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -38,6 +38,8 @@ export interface LLMConfig {
     apiKey: string;
     model: string;
     temperature: number;
+    /** 设为 true 则不传 temperature 参数（用于不支持的模型如 gpt-5.5） */
+    omit_temperature?: boolean;
     maxTokens: number;
     /** 模型允许的最大上下文输入 token 数。用于触发 compact。未设置则使用 context_budget.effective_context_window（默认 32000） */
     maxContextTokens?: number;
@@ -587,6 +589,7 @@ const DEFAULT_LLM: LLMConfig = {
     apiKey: "",
     model: "gpt-4o",
     temperature: 0.7,
+    omit_temperature: false,
     maxTokens: 8192,
 };
 
@@ -1241,6 +1244,7 @@ function parseLLMProfile(raw: Record<string, unknown>): LLMConfig {
         apiKey: str(raw.api_key) ?? DEFAULT_LLM.apiKey,
         model: str(raw.model) ?? DEFAULT_LLM.model,
         temperature: num(raw.temperature, DEFAULT_LLM.temperature),
+            omit_temperature: Boolean(raw.omit_temperature ?? DEFAULT_LLM.omit_temperature),
         maxTokens: num(raw.max_tokens, DEFAULT_LLM.maxTokens),
         maxContextTokens: raw.max_context_tokens != null ? num(raw.max_context_tokens, 0) : undefined,
         thinkingLevel: str(raw.thinking_level),
@@ -1372,6 +1376,7 @@ export function serializeConfigToObject(config: AppConfig): Record<string, unkno
         if (p.responsesRequestMode) entry.responses_request_mode = p.responsesRequestMode;
         if (p.replyPrompt) entry.reply_prompt = p.replyPrompt;
         if (p.supportsPrefill === false) entry.supports_prefill = false;
+        if (p.omit_temperature === true) entry.omit_temperature = true;
         if (p.pricing) {
             const pricing: Record<string, unknown> = {
                 input: p.pricing.input,

--- a/src/core/llm/anthropic.ts
+++ b/src/core/llm/anthropic.ts
@@ -92,7 +92,7 @@ export async function callAnthropic(
     const body: Record<string, unknown> = {
         model,
         messages: apiMessages,
-        temperature,
+        ...(config.omit_temperature ? {} : { temperature }),
         max_tokens: maxTokens,
         // Stop sequences（Anthropic 使用 stop_sequences 字段）
         ...(stop && stop.length > 0 ? { stop_sequences: stop } : {}),

--- a/src/core/llm/google.ts
+++ b/src/core/llm/google.ts
@@ -136,7 +136,7 @@ export async function callGoogle(
         model,
         contents,
         config: {
-            temperature,
+            ...(config.omit_temperature ? {} : { temperature }),
             maxOutputTokens: maxTokens,
             ...(systemInstruction ? { systemInstruction } : {}),
             ...(stop && stop.length > 0 ? { stopSequences: stop } : {}),

--- a/src/core/llm/openai-responses.ts
+++ b/src/core/llm/openai-responses.ts
@@ -75,7 +75,7 @@ export async function callOpenAIResponses(
         store: false,
         ...(systemMessages.length > 0 ? { instructions: systemMessages.join("\n\n") } : {}),
         input,
-        temperature,
+        ...(config.omit_temperature ? {} : { temperature }),
         max_output_tokens: maxTokens,
         ...(reasoningEffort ? { reasoning: { effort: reasoningEffort as ReasoningEffort } } : {}),
         ...(stop && stop.length > 0 ? { stop } : {}),

--- a/src/core/llm/openai.ts
+++ b/src/core/llm/openai.ts
@@ -61,7 +61,7 @@ export async function callOpenAI(
         body: JSON.stringify({
             model,
             messages: apiMessages,
-            temperature,
+            ...(config.omit_temperature ? {} : { temperature }),
             max_tokens: maxTokens,
             // Gemini thinking 参数（OpenAI 兼容格式：reasoning_effort）
             ...(thinkingLevel && thinkingLevel !== "none" ? {

--- a/src/dashboard/ui/src/panels/ConfigPanel.svelte
+++ b/src/dashboard/ui/src/panels/ConfigPanel.svelte
@@ -295,6 +295,7 @@
       apiKey: "",
       model: "",
       temperature: 0.7,
+      omit_temperature: false,
       maxTokens: 8192,
     };
     config = config;

--- a/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
+++ b/src/dashboard/ui/src/panels/config/LlmProfilesTab.svelte
@@ -100,6 +100,7 @@
             <input type="password" class="input input-xs input-bordered w-full" bind:value={p.apiKey} on:focus={pwFocus} on:blur={pwBlur} /></label
           >
           <label class="cfg-field"><span class="cfg-label">Temperature</span><input type="number" class="input input-xs input-bordered w-full" bind:value={p.temperature} min="0" max="2" step="0.1" /></label>
+          <label class="cfg-check" title="勾选后不传 temperature 参数（适用于 gpt-5.5 等不支持的模型）"><input type="checkbox" class="checkbox checkbox-xs" bind:checked={p.omit_temperature} /><span>Omit Temperature</span></label>
           <label class="cfg-field"><span class="cfg-label">Max Tokens</span><input type="number" class="input input-xs input-bordered w-full" bind:value={p.maxTokens} min="1" /></label>
           <label class="cfg-field"><span class="cfg-label">Max Context Tokens</span><input type="number" class="input input-xs input-bordered w-full" bind:value={p.maxContextTokens} placeholder="(默认)" /></label>
           <label class="cfg-field"><span class="cfg-label">Thinking Level</span>


### PR DESCRIPTION
## 概述

**1 commit | API 兼容性**

为 LLM profiles 新增 `omit_temperature` 配置选项，允许对不支持 temperature 参数的 API 省略该字段。

### 变更
- 修改: src/core/config.ts + LLM 调用层