### PR TITLE
feat: 工具/运维改进 (sticker cache + dashboard + pnpm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ data/
 AGENTS.md
 CLAUDE.md
 workspace
+.pnpm-store

--- a/scripts/rebuild-sticker-cache.ts
+++ b/scripts/rebuild-sticker-cache.ts
@@ -1,0 +1,273 @@
+/**
+ * 批量重建贴纸描述缓存（最新 N 个）
+ * 
+ * 用法: npx tsx scripts/rebuild-sticker-cache.ts [数量] [--dry-run] [--animated]
+ * 默认处理最新 50 个贴纸；--animated 包含动态贴纸（ffmpeg 抽帧）
+ */
+import Database from "better-sqlite3";
+import fs from "fs";
+import path from "path";
+import { createHash } from "crypto";
+import { execSync } from "child_process";
+
+// ─── 配置（支持环境变量覆盖） ───
+const STICKERS_DIR = process.env.STICKERS_DIR || path.resolve("workspace/Downloads/stickers");
+const DB_PATH = process.env.DB_PATH || path.resolve("workspace/memory.db");
+const COUNT = parseInt(process.argv[2] || "50", 10);
+const DRY_RUN = process.argv.includes("--dry-run");
+const INCLUDE_ANIMATED = process.argv.includes("--animated");
+
+// Vision LLM 配置（通过环境变量配置，默认使用 OpenAI 兼容标准值）
+const VISION_API = {
+  baseUrl: process.env.VISION_BASE_URL || "https://api.openai.com/v1",
+  apiKey: process.env.VISION_API_KEY || "",
+  model: process.env.VISION_MODEL || "gpt-4o",
+};
+
+// ─── 工具函数 ───
+
+function sha256(buffer: Buffer): string {
+  return createHash("sha256").update(buffer).digest("hex");
+}
+
+function getLatestStickers(dir: string, count: number): string[] {
+  const files = fs.readdirSync(dir)
+    .map(f => ({ name: f, mtime: fs.statSync(path.join(dir, f)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, count);
+  return files.map(f => f.name);
+}
+
+function isAnimated(fileName: string): boolean {
+  return fileName.endsWith(".webm") || fileName.endsWith(".tgs");
+}
+
+/** 用 ffmpeg 从动态贴纸抽第一帧（PNG），返回 buffer 或 null */
+function extractFirstFrame(filePath: string): Buffer | null {
+  try {
+    const result = execSync(
+      `ffmpeg -i "${filePath}" -frames:v 1 -f image2pipe -vcodec png -`,
+      { maxBuffer: 10 * 1024 * 1024, stdio: ["pipe", "pipe", "pipe"] }
+    );
+    if (result.length > 0) return result as Buffer;
+  } catch (e: any) {
+    console.error(`  ⚠️ ffmpeg 抽帧失败: ${e.message?.slice(0, 100)}`);
+  }
+  return null;
+}
+
+/** 准备图片数据：静态贴纸直接读文件，动态贴纸 ffmpeg 抽帧 */
+interface ImageData {
+  buffer: Buffer;
+  mimeType: string;
+  b64url: string;
+}
+
+function prepareImage(filePath: string, fileName: string): ImageData | null {
+  if (isAnimated(fileName)) {
+    if (!INCLUDE_ANIMATED) return null;
+    const frame = extractFirstFrame(filePath);
+    if (!frame) return null;
+    return {
+      buffer: frame,
+      mimeType: "image/png",
+      b64url: `data:image/png;base64,${frame.toString("base64")}`,
+    };
+  }
+
+  const buf = fs.readFileSync(filePath);
+  let mimeType = "image/webp";
+  if (fileName.endsWith(".png")) mimeType = "image/png";
+  else if (fileName.endsWith(".jpg") || fileName.endsWith(".jpeg")) mimeType = "image/jpeg";
+  else if (fileName.endsWith(".gif")) mimeType = "image/gif";
+  return {
+    buffer: buf,
+    mimeType,
+    b64url: `data:${mimeType};base64,${buf.toString("base64")}`,
+  };
+}
+
+interface StickerResult {
+  fileName: string;
+  uniqueFileId: string;
+  contentHash: string;
+  description: string;
+  emojis: string[];
+  emoji: string;
+  skipped: boolean;
+  error?: string;
+}
+
+async function callVisionLLM(imageUrl: string, isAnimatedSticker: boolean): Promise<{ description: string; emojis: string[] }> {
+  const hint = isAnimatedSticker
+    ? "这是一个 Telegram 动态贴纸的关键帧截图。"
+    : "这是一个 Telegram 贴纸图片。";
+
+  const response = await fetch(`${VISION_API.baseUrl}/chat/completions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${VISION_API.apiKey}`,
+    },
+    body: JSON.stringify({
+      model: VISION_API.model,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "image_url", image_url: { url: imageUrl } },
+            {
+              type: "text",
+              text: `${hint}请你：
+1. 用几个词简短描述贴纸表情/动作/含义。如果贴纸中有文字，结合图片内容理解并描述文字的完整内容。
+2. 生成多个可用于匹配这个贴纸含义的 emoji 候选，输出为数组。候选数量无上限，但至少 2 个。
+
+请用以下 JSON 格式回复（仅返回 JSON，不要包含其他内容）：
+{"description": "描述内容", "emojis": ["emoji1", "emoji2", "..."]}`,
+            },
+          ],
+        },
+      ],
+      max_tokens: 1024,   // GLM-5V-Turbo 有 thinking，需要留够 token
+      temperature: 0.3,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Vision API error ${response.status}: ${text.slice(0, 200)}`);
+  }
+
+  const json = await response.json();
+  const raw = json.choices?.[0]?.message?.content?.trim() ?? "";
+
+  // 解析 JSON
+  const cleaned = raw.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "").trim();
+  const objMatch = cleaned.match(/\{[\s\S]*\}/);
+  const parsed = JSON.parse(objMatch ? objMatch[0] : cleaned);
+
+  if (!parsed || typeof parsed.description !== "string" || !Array.isArray(parsed.emojis)) {
+    throw new Error(`无法解析 Vision 回复: ${raw.slice(0, 150)}`);
+  }
+
+  return {
+    description: parsed.description.trim(),
+    emojis: parsed.emojis.filter((e: string) => typeof e === "string"),
+  };
+}
+
+// ─── 主流程 ───
+
+async function main() {
+  console.log(`🎭 贴纸缓存批量重建工具`);
+  console.log(`📁 贴纸目录: ${STICKERS_DIR}`);
+  console.log(`📊 处理数量: ${COUNT} (最新)`);
+  console.log(`🔧 模式: ${DRY_RUN ? "DRY RUN" : "正式写入"} | 动态贴纸: ${INCLUDE_ANIMATED ? "启用(ffmpeg抽帧)" : "跳过"}`);
+  console.log();
+
+  // 1. 获取最新贴纸列表
+  const stickers = getLatestStickers(STICKERS_DIR, COUNT);
+  console.log(`📋 找到 ${stickers.length} 个贴纸文件`);
+
+  // 2. 打开数据库
+  const db = new Database(DB_PATH);
+  db.pragma("journal_mode = WAL");
+
+  const existingCount = db.prepare("SELECT COUNT(*) as c FROM sticker_descriptions").get() as { c: number };
+  console.log(`📦 当前 sticker_descriptions 表记录数: ${existingCount.c}`);
+
+  const results: StickerResult[] = [];
+  let success = 0, skipped = 0, failed = 0;
+
+  for (let i = 0; i < stickers.length; i++) {
+    const fileName = stickers[i];
+    const filePath = path.join(STICKERS_DIR, fileName);
+    const uniqueFileId = fileName.replace(/\.[^.]+$/, "");
+    const animated = isAnimated(fileName);
+
+    process.stdout.write(`[${i + 1}/${stickers.length}] ${fileName}${animated ? " [动态]" : ""} ... `);
+
+    const img = prepareImage(filePath, fileName);
+    if (!img) {
+      console.log(`⏭️ 跳过${animated ? " (动态贴纸，加 --animated 启用)" : ""}`);
+      results.push({ fileName, uniqueFileId, contentHash: "", description: "", emojis: [], emoji: "", skipped: true });
+      skipped++;
+      continue;
+    }
+
+    try {
+      const contentHash = sha256(img.buffer);
+
+      // 检查是否已存在（按 content_hash）
+      const existing = db.prepare(
+        "SELECT unique_file_id FROM sticker_descriptions WHERE content_hash = ? LIMIT 1"
+      ).get(contentHash) as { unique_file_id: string } | undefined;
+
+      if (existing) {
+        console.log(`✅ 已存在 (${existing.unique_file_id})`);
+        results.push({ fileName, uniqueFileId, contentHash, description: "(existing)", emojis: [], emoji: "", skipped: true });
+        skipped++;
+        continue;
+      }
+
+      // 调 Vision API
+      const visionResult = await callVisionLLM(img.b64url, animated);
+
+      if (DRY_RUN) {
+        console.log(`🔍 DRY RUN → "${visionResult.description}" [${visionResult.emojis.join(",")}]`);
+        results.push({
+          fileName, uniqueFileId, contentHash,
+          description: visionResult.description,
+          emojis: visionResult.emojis,
+          emoji: visionResult.emojis[0] || "",
+          skipped: false,
+        });
+      } else {
+        const now = new Date().toISOString();
+        const emojisJson = JSON.stringify(visionResult.emojis);
+        db.prepare(`
+          INSERT OR REPLACE INTO sticker_descriptions (unique_file_id, description, created_at, emoji, emojis, enabled, content_hash)
+          VALUES (?, ?, ?, ?, ?, 1, ?)
+        `).run(uniqueFileId, visionResult.description, now, visionResult.emojis[0] || null, emojisJson, contentHash);
+
+        console.log(`✅ "${visionResult.description}" [${visionResult.emojis.join(",")}]`);
+        results.push({
+          fileName, uniqueFileId, contentHash,
+          description: visionResult.description,
+          emojis: visionResult.emojis,
+          emoji: visionResult.emojis[0] || "",
+          skipped: false,
+        });
+      }
+
+      success++;
+      await new Promise(r => setTimeout(r, 500));
+
+    } catch (err: any) {
+      console.log(`❌ 失败: ${err.message?.slice(0, 100)}`);
+      results.push({ fileName, uniqueFileId, contentHash: "", description: "", emojis: [], emoji: "", skipped: false, error: err.message });
+      failed++;
+    }
+  }
+
+  // ── 汇总 ──
+  const finalCount = db.prepare("SELECT COUNT(*) as c FROM sticker_descriptions").get() as { c: number };
+  console.log("\n═════════════════════════════════");
+  console.log(`📊 结果汇总:`);
+  console.log(`   ✅ 成功: ${success}`);
+  console.log(`   ⏭️ 跳过: ${skipped} (动态/已存在)`);
+  console.log(`   ❌ 失败: ${failed}`);
+  console.log(`   📦 sticker_descriptions 总记录: ${finalCount.c}`);
+  
+  if (DRY_RUN) {
+    console.log(`\n⚠️  DRY RUN 模式 — 未实际写入数据库`);
+    console.log(`   去掉 --dry-run 参数即可正式执行`);
+  }
+
+  db.close();
+}
+
+main().catch(err => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/src/dashboard/api-routes.ts
+++ b/src/dashboard/api-routes.ts
@@ -2103,11 +2103,15 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
         if (!deps.harnessManager) {
             return res.json({ enabled: false });
         }
+        // getStatus() 已用 summarizeRun() 去掉 events；currentRun/runs 也必须去掉 events
+        // （列表视图不需要 events，避免每 2.5s 传输数万条事件对象）
+        const rawCurrent = deps.harnessManager.getCurrentRun();
+        const rawRuns = deps.harnessManager.getRecentRuns(20);
         res.json({
             enabled: true,
             ...deps.harnessManager.getStatus(),
-            currentRun: deps.harnessManager.getCurrentRun(),
-            runs: deps.harnessManager.getRecentRuns(20),
+            currentRun: rawCurrent ? { ...rawCurrent, events: [] } : null,
+            runs: rawRuns.map((run) => ({ ...run, events: [] })),
         });
     });
 

--- a/src/dashboard/ui/src/panels/BackgroundAgentPanel.svelte
+++ b/src/dashboard/ui/src/panels/BackgroundAgentPanel.svelte
@@ -16,6 +16,8 @@
   let selectedEventsRunId = null;
   let eventLogSource = 'memory';
   let visibleEvents = [];
+  // 智能轮询：有运行中的任务时拉 events，否则只刷新状态
+  const POLL_INTERVAL = 10000;       // 状态轮询：10s（原 2.5s 太猛）
 
   $: allRuns = status?.enabled
     ? [status.currentRun, ...(status.runs ?? [])].filter(Boolean)
@@ -44,7 +46,9 @@
       status = next;
       const runId = selectedRunId ?? next.currentRun?.id ?? next.runs?.[0]?.id;
       if (!selectedRunId && runId) selectedRunId = runId;
-      if (runId) await loadRunEvents(runId, selectedEventsRunId === runId);
+      // 只在选中运行正在执行或首次加载时才拉 events
+      const needsEvents = selectedRun && (!selectedRun.endedAt || selectedEvents.length === 0);
+      if (runId && needsEvents) await loadRunEvents(runId, selectedEventsRunId === runId);
     } catch (e) {
       status = { enabled: false, error: String(e) };
     }
@@ -485,7 +489,7 @@
 
   onMount(() => {
     refresh();
-    const timer = setInterval(refresh, 2500);
+    const timer = setInterval(refresh, POLL_INTERVAL);
     return () => clearInterval(timer);
   });
 </script>


### PR DESCRIPTION
## 概述

**3 commits | 便利性改进**

### 包含内容
1. **sticker cache rebuild 脚本** — 批量重建贴纸描述缓存，支持 Vision LLM 自动识别（已修复硬编码，改为环境变量读取）
2. **Dashboard 性能优化** — background agent 面板优化
3. **忽略 .pnpm-store** — .gitignore 添加 pnpm store 目录

### 变更
- 新增: scripts/rebuild-sticker-cache.ts
- 修改: Dashboard UI, .gitignore