### PR TITLE
fix: enable vision routing fallback in Path A describe

### DIFF
--- a/src/core/vision-processor.ts
+++ b/src/core/vision-processor.ts
@@ -399,7 +399,7 @@ export async function processMediaBatch(
             representative,
             config,
             isPathA || isPathB,
-            isPathA ? [llmConfig] : visionLlmConfigs,
+            isPathA ? dedupConfigs([llmConfig, ...(visionLlmConfigs ?? [])]) : visionLlmConfigs,
             downloadFn,
             stickerCache,
             mediaDownloader,
@@ -454,7 +454,7 @@ export async function processMediaBatch(
                 .catch(err => {
                     log.warn("路径 A 下载/转码失败，降级为描述", { fileId: photo.fileId, error: String(err) });
                     if (canDescribe) {
-                        const visionCfgs = isPathA ? [llmConfig] : visionLlmConfigs!;
+                        const visionCfgs = isPathA ? dedupConfigs([llmConfig, ...(visionLlmConfigs ?? [])]) : visionLlmConfigs!;
                         return describeWithCache(visionCfgs).catch(err2 => {
                             log.warn("降级描述也失败", { fileId: photo.fileId, error: String(err2) });
                             return { index: photo.messageIndex, description: "[📷 图片（加载失败）]" } as ProcessedMedia;
@@ -466,7 +466,7 @@ export async function processMediaBatch(
 
         if (canDescribe) {
             // 路径 A 溢出 或 路径 B: 调用 vision LLM 描述（带缓存）
-            const visionCfgs = isPathA ? [llmConfig] : visionLlmConfigs!;
+            const visionCfgs = isPathA ? dedupConfigs([llmConfig, ...(visionLlmConfigs ?? [])]) : visionLlmConfigs!;
             return describeWithCache(visionCfgs).catch(err => {
                 log.warn("Vision 描述失败，使用占位符", { fileId: photo.fileId, error: String(err) });
                 return { index: photo.messageIndex, description: "[📷 图片（加载失败）]" } as ProcessedMedia;
@@ -831,6 +831,18 @@ async function processSingleSticker(
 /**
  * 调用 Vision LLM 描述图片
  */
+function dedupConfigs(configs: LLMConfig[]): LLMConfig[] {
+    const seen = new Set<string>();
+    const out: LLMConfig[] = [];
+    for (const c of configs) {
+        const id = c.name ?? `${c.model}@${c.baseUrl}`;
+        if (seen.has(id)) continue;
+        seen.add(id);
+        out.push(c);
+    }
+    return out;
+}
+
 export async function describeImage(
     imageBuffer: Buffer,
     mimeType: string,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1028,7 +1028,7 @@ async function main(): Promise<void> {
         const persona = currentConfig.persona;
         const visionConfig = currentConfig.vision;
         const visionLlmConfig = currentConfig.llmRouting.vision
-            ? resolveComponentProfiles("vision", currentConfig)[0]
+            ? resolveComponentProfiles("vision", currentConfig)
             : undefined;
         const chatAdapter = adapters.find((item) => chatId.startsWith(item.platform + ":"));
         const formatMention = chatAdapter

--- a/src/subagent/code-act-executor.ts
+++ b/src/subagent/code-act-executor.ts
@@ -505,7 +505,7 @@ export class CodeActExecutor {
     /** Vision 配置 */
     private visionConfig: VisionConfig | undefined;
     /** Vision tier LLM 配置（独立 vision 模型，Path B 描述用） */
-    private visionLlmConfig: LLMConfig | undefined;
+    private visionLlmConfig: LLMConfig[] | undefined;
     /** 媒体下载函数（委托给 adapter） */
     private downloadFn: ((fileId: string) => Promise<Buffer>) | undefined;
     /** 平台无关的 typing 状态发送函数（由宿主注入，如 Telegram sendTyping） */
@@ -524,7 +524,7 @@ export class CodeActExecutor {
         visionConfig?: VisionConfig,
         downloadFn?: (fileId: string) => Promise<Buffer>,
         sendTyping?: (chatId: string) => Promise<void>,
-        visionLlmConfig?: LLMConfig,
+        visionLlmConfig?: LLMConfig[],
         mediaDownloader?: MediaDownloader,
         formatMention?: (rawUserId: string, username?: string) => string | undefined,
         globalState?: Pick<GlobalState, "getSessionDigests" | "updateDispatchedSubagentTask">,


### PR DESCRIPTION
When the main model has `vision:true` (Path A), describe calls only used `[llmConfig]` and ignored the vision routing chain, so a main-model outage (e.g. kimi-k3 503) left vision describe dead with no fallback — placeholders instead of trying qwen3.7-plus etc.

Path A now uses `dedupConfigs([llmConfig, ...visionLlmConfigs])`: main model first, then the vision routing chain deduped by name (fallback to `model@baseUrl` fingerprint). Also pass the full vision chain (not `[0]`) from `main.ts initializeCodeActExecutor` to `code-act-executor`, widening its `visionLlmConfig` type to `LLMConfig[]`.

```
src/core/vision-processor.ts      | 18 +++++++++++++++---
src/main.ts                       |  2 +-
src/subagent/code-act-executor.ts |  4 ++--
3 files changed, 18 insertions(+), 6 deletions(-)
```

This makes Path A describe consistent with the vision routing fallback already used by `vision.see` (host-call-handler) and Path B.