### PR TITLE
fix(dashboard): memory panel quick-query jumps + search & cross-navigation

### DIFF
--- a/src/dashboard/api-routes.ts
+++ b/src/dashboard/api-routes.ts
@@ -1039,6 +1039,11 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
         }
     });
 
+    router.get("/memory/user/:userId/profiles", (req, res) => {
+        const profiles = deps.memory.getProfilesForUser(req.params.userId);
+        res.json(profiles);
+    });
+
     router.get("/memory/group/:chatId", (req, res) => {
         const chatId = req.params.chatId;
         const model = deps.memory.getGroupModel(chatId);
@@ -1543,7 +1548,8 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
     router.get("/memory/persons", (req, res) => {
         const limit = Math.min(parseInt(qs(req.query.limit)) || 50, 200);
         const offset = Math.max(parseInt(qs(req.query.offset)) || 0, 0);
-        res.json(deps.memory.listPersonIdentities(limit, offset));
+        const q = qs(req.query.q) || undefined;
+        res.json(deps.memory.listPersonIdentities(limit, offset, q));
     });
 
     router.put("/memory/person/:userId", (req, res) => {
@@ -1582,8 +1588,8 @@ export function createApiRouter(deps: DashboardDeps, bridge: EventBridge): Route
     });
 
     // Group Models
-    router.get("/memory/groups", (_req, res) => {
-        res.json(deps.memory.listGroupModels());
+    router.get("/memory/groups", (req, res) => {
+        res.json(deps.memory.listGroupModels(qs(req.query.q) || undefined));
     });
 
     router.put("/memory/group/:chatId", (req, res) => {

--- a/src/dashboard/ui/src/panels/DecisionsPanel.svelte
+++ b/src/dashboard/ui/src/panels/DecisionsPanel.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onDestroy, tick } from 'svelte';
-  import { activeTab } from '../lib/stores.js';
+  import { activeTab, pendingMemoryLink, activeMemoryTab } from '../lib/stores.js';
   import { api } from '../lib/api.js';
   import { isAtBottom, scrollToBottom, getGroupLabel, getPlatform, platformLabel } from '../lib/utils.js';
 
@@ -38,8 +38,10 @@
   function onScrollD() { if (decisionsEl) wasBottomD = isAtBottom(decisionsEl); }
 
   function quickQueryGroup(chatId) {
+    // payload 先写入 store，再由 RecallTab 消费（组件可能尚未挂载）
+    pendingMemoryLink.set({ tab: 'm-recall', kind: 'group', chatId });
+    activeMemoryTab.set('m-recall');
     activeTab.set('memory');
-    window.dispatchEvent(new CustomEvent('quickQueryGroup', { detail: { chatId } }));
   }
 
   /** 决策类型分析（从 decision 文本中提取） */

--- a/src/dashboard/ui/src/panels/MemoryPanel.svelte
+++ b/src/dashboard/ui/src/panels/MemoryPanel.svelte
@@ -1,6 +1,5 @@
 <script>
-  import { onMount } from "svelte";
-  import { activeMemoryTab, activeTab } from "../lib/stores.js";
+  import { activeMemoryTab } from "../lib/stores.js";
   import PersonsTab from "./memory/PersonsTab.svelte";
   import ProfilesTab from "./memory/ProfilesTab.svelte";
   import GroupsTab from "./memory/GroupsTab.svelte";
@@ -23,22 +22,6 @@
     activeMemoryTab.set(id);
   }
 
-  // Fix cross-tab navigation: listen at MemoryPanel level,
-  // auto-switch to m-recall sub-tab when quickQueryUser/quickQueryGroup fires
-  onMount(() => {
-    function onQuickUser(e) {
-      activeMemoryTab.set("m-recall");
-    }
-    function onQuickGroup(e) {
-      activeMemoryTab.set("m-recall");
-    }
-    window.addEventListener("quickQueryUser", onQuickUser);
-    window.addEventListener("quickQueryGroup", onQuickGroup);
-    return () => {
-      window.removeEventListener("quickQueryUser", onQuickUser);
-      window.removeEventListener("quickQueryGroup", onQuickGroup);
-    };
-  });
 </script>
 
 <div class="memory-layout">

--- a/src/dashboard/ui/src/panels/MessagesPanel.svelte
+++ b/src/dashboard/ui/src/panels/MessagesPanel.svelte
@@ -5,6 +5,8 @@
     selectedChatId,
     appState,
     activeTab,
+    pendingMemoryLink,
+    activeMemoryTab,
   } from "../lib/stores.js";
   import { api } from "../lib/api.js";
   import {
@@ -208,12 +210,10 @@
   }
 
   function quickQueryUser(userId, chatId) {
+    // payload 先写入 store，再由 RecallTab 消费（组件可能尚未挂载）
+    pendingMemoryLink.set({ tab: "m-recall", kind: "user", userId, chatId });
+    activeMemoryTab.set("m-recall");
     activeTab.set("memory");
-    // will be handled by MemoryPanel
-    window.__quickQueryUser = { userId, chatId };
-    window.dispatchEvent(
-      new CustomEvent("quickQueryUser", { detail: { userId, chatId } }),
-    );
   }
 
   function editChatTitle(chatId) {

--- a/src/dashboard/ui/src/panels/QueuePanel.svelte
+++ b/src/dashboard/ui/src/panels/QueuePanel.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { appState, activeTab } from "../lib/stores.js";
+  import { appState, activeTab, pendingMemoryLink, activeMemoryTab } from "../lib/stores.js";
   import { api } from "../lib/api.js";
   import { shortId, getPlatform, platformLabel } from "../lib/utils.js";
 
@@ -21,10 +21,10 @@
   }
 
   function quickQueryGroup(chatId) {
+    // payload 先写入 store，再由 RecallTab 消费（组件可能尚未挂载）
+    pendingMemoryLink.set({ tab: "m-recall", kind: "group", chatId });
+    activeMemoryTab.set("m-recall");
     activeTab.set("memory");
-    window.dispatchEvent(
-      new CustomEvent("quickQueryGroup", { detail: { chatId } }),
-    );
   }
 
   function showEnqueueModal() {

--- a/src/dashboard/ui/src/panels/TopicDetailPanel.svelte
+++ b/src/dashboard/ui/src/panels/TopicDetailPanel.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { topicDetailId, activeTab } from '../lib/stores.js';
+  import { topicDetailId, activeTab, pendingMemoryLink, activeMemoryTab } from '../lib/stores.js';
   import { api } from '../lib/api.js';
   import { escapeHtml, getGroupLabel } from '../lib/utils.js';
 
@@ -20,8 +20,10 @@
   }
 
   function quickQueryUser(userId, chatId) {
+    // payload 先写入 store，再由 RecallTab 消费（组件可能尚未挂载）
+    pendingMemoryLink.set({ tab: 'm-recall', kind: 'user', userId, chatId });
+    activeMemoryTab.set('m-recall');
     activeTab.set('memory');
-    window.dispatchEvent(new CustomEvent('quickQueryUser', { detail: { userId, chatId } }));
   }
 
   function callbackTone(score) {

--- a/src/dashboard/ui/src/panels/TopicsPanel.svelte
+++ b/src/dashboard/ui/src/panels/TopicsPanel.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { appState, activeTab, topicDetailId } from '../lib/stores.js';
+  import { appState, activeTab, topicDetailId, pendingMemoryLink, activeMemoryTab } from '../lib/stores.js';
   import { api } from '../lib/api.js';
   import { escapeHtml, shortId, getGroupLabel, getPlatform, platformLabel } from '../lib/utils.js';
 
@@ -71,8 +71,10 @@
   }
 
   function quickQueryUser(userId, chatId) {
+    // payload 先写入 store，再由 RecallTab 消费（组件可能尚未挂载）
+    pendingMemoryLink.set({ tab: 'm-recall', kind: 'user', userId, chatId });
+    activeMemoryTab.set('m-recall');
     activeTab.set('memory');
-    window.dispatchEvent(new CustomEvent('quickQueryUser', { detail: { userId, chatId } }));
   }
 
   function callbackBadge(score) {

--- a/src/dashboard/ui/src/panels/memory/GroupsTab.svelte
+++ b/src/dashboard/ui/src/panels/memory/GroupsTab.svelte
@@ -2,13 +2,27 @@
   import { activeTab, activeMemoryTab, pendingMemoryLink } from '../../lib/stores.js';
   import { api } from '../../lib/api.js';
   import { shortId, escapeHtml, getPlatform, platformLabel, getChatTypeLabel } from '../../lib/utils.js';
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
 
   let groups = [];
+  let searchInput = '';
 
   $: if ($activeTab === 'memory' && $activeMemoryTab === 'm-groups') load();
 
+  onMount(() => {
+    const pending = get(pendingMemoryLink);
+    if (pending?.tab === 'm-groups') {
+      if (pending.search) searchInput = pending.search;
+      pendingMemoryLink.set(null);
+      if (searchInput) load();
+    }
+  });
+
   async function load() {
-    groups = await api('/memory/groups');
+    let url = '/memory/groups';
+    if (searchInput.trim()) url += `?q=${encodeURIComponent(searchInput.trim())}`;
+    groups = await api(url);
   }
 
   function editGroup(chatId) {
@@ -30,7 +44,12 @@
   <div class="card-body p-4">
     <div class="flex justify-between items-center mb-2">
       <h3 class="card-title text-sm">群组画像 (GroupModel)</h3>
-      <button class="btn btn-xs btn-primary" onclick={load}>刷新</button>
+      <div class="flex gap-2 items-center">
+        <input type="text" placeholder="搜索 chatId / 群名" class="input input-sm input-bordered w-48"
+               bind:value={searchInput} onkeydown={(e) => e.key === 'Enter' && load()} />
+        <button class="btn btn-xs btn-primary" onclick={load}>搜索</button>
+        <button class="btn btn-xs btn-ghost" onclick={() => { searchInput = ''; load(); }}>清除</button>
+      </div>
     </div>
     <div class="overflow-x-auto">
       <table class="table table-xs">

--- a/src/dashboard/ui/src/panels/memory/PersonsTab.svelte
+++ b/src/dashboard/ui/src/panels/memory/PersonsTab.svelte
@@ -2,16 +2,30 @@
   import { activeMemoryTab, activeTab, pendingMemoryLink } from '../../lib/stores.js';
   import { api } from '../../lib/api.js';
   import { escapeHtml, getPlatform, platformLabel, stripPlatform } from '../../lib/utils.js';
+  import { onMount } from 'svelte';
+  import { get } from 'svelte/store';
 
   let items = [];
   let total = 0;
   let page = 0;
+  let searchInput = '';
 
   $: if ($activeTab === 'memory' && $activeMemoryTab === 'm-persons') load();
 
+  onMount(() => {
+    const pending = get(pendingMemoryLink);
+    if (pending?.tab === 'm-persons') {
+      if (pending.search) searchInput = pending.search;
+      pendingMemoryLink.set(null);
+      if (searchInput) load(0);
+    }
+  });
+
   async function load(p) {
     if (p !== undefined) page = p;
-    const data = await api(`/memory/persons?limit=50&offset=${page * 50}`);
+    let url = `/memory/persons?limit=50&offset=${page * 50}`;
+    if (searchInput.trim()) url += `&q=${encodeURIComponent(searchInput.trim())}`;
+    const data = await api(url);
     items = data.items || [];
     total = data.total || 0;
   }
@@ -49,8 +63,11 @@
     <div class="flex justify-between items-center mb-2">
       <h3 class="card-title text-sm">用户画像 (PersonIdentity)</h3>
       <div class="flex gap-2 items-center">
+        <input type="text" placeholder="搜索 userId / 显示名 / username" class="input input-sm input-bordered w-56"
+               bind:value={searchInput} onkeydown={(e) => e.key === 'Enter' && load(0)} />
+        <button class="btn btn-xs btn-primary" onclick={() => load(0)}>搜索</button>
+        <button class="btn btn-xs btn-ghost" onclick={() => { searchInput = ''; load(0); }}>清除</button>
         <span class="badge badge-sm badge-ghost">{total}</span>
-        <button class="btn btn-xs btn-primary" onclick={() => load()}>刷新</button>
       </div>
     </div>
     <div class="overflow-x-auto">

--- a/src/dashboard/ui/src/panels/memory/ProfilesTab.svelte
+++ b/src/dashboard/ui/src/panels/memory/ProfilesTab.svelte
@@ -1,26 +1,39 @@
 <script>
   import { activeMemoryTab, pendingMemoryLink } from '../../lib/stores.js';
   import { api } from '../../lib/api.js';
-  import { shortId, escapeHtml, getPlatform, platformLabel, stripPlatform } from '../../lib/utils.js';
+  import { shortId, escapeHtml, getPlatform, platformLabel, stripPlatform, getGroupLabel } from '../../lib/utils.js';
   import { onMount } from 'svelte';
   import { get } from 'svelte/store';
 
   let chatIdInput = '';
+  let userInput = '';
   let profiles = [];
+  // 非空表示当前列表是"该用户在所有群的画像"（仅按 userId 查询时）
+  let queryUserId = '';
 
   onMount(() => {
     const pending = get(pendingMemoryLink);
     if (pending?.tab === 'm-profiles') {
-      if (pending.userId) chatIdInput = '';
+      if (pending.userId) userInput = pending.userId;
       if (pending.chatId) chatIdInput = pending.chatId;
       pendingMemoryLink.set(null);
-      if (chatIdInput) load();
+      if (userInput || chatIdInput) load();
     }
   });
 
   export async function load() {
-    if (!chatIdInput.trim()) { alert('请输入 chatId'); return; }
-    profiles = await api(`/memory/profiles/${chatIdInput.trim()}`);
+    const chat = chatIdInput.trim();
+    const user = userInput.trim();
+    if (!chat && !user) { alert('请输入 userId 或 chatId'); return; }
+    if (chat) {
+      queryUserId = '';
+      let rows = await api(`/memory/profiles/${chat}`);
+      if (user) rows = rows.filter((p) => p.userId.includes(user));
+      profiles = rows;
+    } else {
+      queryUserId = user;
+      profiles = await api(`/memory/user/${encodeURIComponent(user)}/profiles`);
+    }
   }
 
   function editProfile(userId, chatId) {
@@ -34,7 +47,13 @@
   }
 
   function jumpToPersons(userId) {
+    pendingMemoryLink.set({ tab: 'm-persons', search: userId });
     activeMemoryTab.set('m-persons');
+  }
+
+  function jumpToGroup(chatId) {
+    pendingMemoryLink.set({ tab: 'm-groups', search: chatId });
+    activeMemoryTab.set('m-groups');
   }
 
   function jumpToChatLog(userId, chatId) {
@@ -95,8 +114,15 @@
   <div class="card-body p-4">
     <div class="flex justify-between items-center mb-2">
       <h3 class="card-title text-sm">群内画像 (PersonGroupProfile)</h3>
+      {#if queryUserId}
+        <span class="badge badge-sm badge-ghost" title={queryUserId}>
+          {stripPlatform(queryUserId)} · {profiles.length} 个群
+        </span>
+      {/if}
       <div class="flex gap-2 items-center">
-        <input type="text" placeholder="输入 chatId 查询" class="input input-sm input-bordered w-48"
+        <input type="text" placeholder="userId 搜索（可单独用）" class="input input-sm input-bordered w-44"
+               bind:value={userInput} onkeydown={(e) => e.key === 'Enter' && load()} />
+        <input type="text" placeholder="chatId (可选)" class="input input-sm input-bordered w-48"
                bind:value={chatIdInput} onkeydown={(e) => e.key === 'Enter' && load()} />
         <button class="btn btn-xs btn-primary" onclick={load}>查询</button>
       </div>
@@ -104,7 +130,7 @@
     <div class="overflow-x-auto">
       <table class="table table-xs">
         <thead><tr>
-          <th>UserId</th><th>ChatId</th><th>邓巴层</th><th>好感度</th><th>Traits</th><th>沟通风格</th><th>与Agent关系</th><th>消息数</th><th>最后活跃</th><th>操作</th>
+          <th>显示名</th><th>群组</th><th>邓巴层</th><th>好感度</th><th>Traits</th><th>沟通风格</th><th>与Agent关系</th><th>消息数</th><th>最后活跃</th><th>操作</th>
         </tr></thead>
         <tbody>
           {#if !profiles.length}
@@ -112,13 +138,13 @@
           {:else}
             {#each profiles as p}
               <tr>
-                <td class="font-mono text-xs">
+                <td class="max-w-36 truncate whitespace-nowrap" title={p.userId}>
                   {#if getPlatform(p.userId)}<span class="platform-badge platform-{getPlatform(p.userId)}">{platformLabel(getPlatform(p.userId))}</span>{/if}
-                  <button class="clickable-link" onclick={() => jumpToPersons(p.userId)}>{stripPlatform(p.userId)}</button>
+                  <button class="clickable-link" onclick={() => jumpToPersons(p.userId)}>{p.displayName || stripPlatform(p.userId)}</button>
                 </td>
-                <td class="font-mono text-xs">
+                <td class="max-w-40 truncate whitespace-nowrap" title={p.chatId}>
                   {#if getPlatform(p.chatId)}<span class="platform-badge platform-{getPlatform(p.chatId)}">{platformLabel(getPlatform(p.chatId))}</span>{/if}
-                  {shortId(p.chatId)}
+                  <button class="clickable-link" onclick={() => jumpToGroup(p.chatId)}>{p.chatTitle || getGroupLabel(p.chatId)}</button>
                 </td>
                 <td>
                   <span class="badge badge-xs cursor-help" title={tierTooltip(p)}>T{p.dunbarTier}</span>

--- a/src/dashboard/ui/src/panels/memory/RecallTab.svelte
+++ b/src/dashboard/ui/src/panels/memory/RecallTab.svelte
@@ -1,6 +1,5 @@
 <script>
-  import { onMount } from 'svelte';
-  import { activeTab, topicDetailId } from '../../lib/stores.js';
+  import { activeTab, topicDetailId, pendingMemoryLink } from '../../lib/stores.js';
   import { api } from '../../lib/api.js';
   import { escapeHtml, shortId, getGroupLabel, renderJsonHighlighted } from '../../lib/utils.js';
 
@@ -14,24 +13,17 @@
   let recallChatId = '';
   let recallResults = null;
 
-  // Listen for quick query events
-  onMount(() => {
-    function onQuickUser(e) {
-      userInput = e.detail.userId;
-      userChat = e.detail.chatId || '';
-      queryUser();
-    }
-    function onQuickGroup(e) {
-      groupInput = e.detail.chatId;
+  // Consume cross-panel navigation payload (works whether or not this tab was already mounted)
+  $: if ($pendingMemoryLink?.tab === 'm-recall') {
+    const p = $pendingMemoryLink;
+    pendingMemoryLink.set(null);
+    if (p.kind === 'group') {
+      groupInput = p.chatId || '';
       queryGroup();
+    } else {
+      quickQueryUser(p.userId, p.chatId);
     }
-    window.addEventListener('quickQueryUser', onQuickUser);
-    window.addEventListener('quickQueryGroup', onQuickGroup);
-    return () => {
-      window.removeEventListener('quickQueryUser', onQuickUser);
-      window.removeEventListener('quickQueryGroup', onQuickGroup);
-    };
-  });
+  }
 
   async function queryUser() {
     if (!userInput) return;

--- a/src/memory-v2/memory-v2.ts
+++ b/src/memory-v2/memory-v2.ts
@@ -2440,13 +2440,12 @@ export class MemoryStoreV2 implements IMemoryStoreV2 {
         return result;
     }
 
-    getProfilesForChat(chatId: string): PersonGroupProfile[] {
-        const rows = this.db.prepare(
-            "SELECT * FROM person_group_profiles WHERE chat_id = ? ORDER BY message_count DESC"
-        ).all(chatId) as Record<string, unknown>[];
-        const profiles = rows.map(r => ({
+    private profileRowToObj(r: Record<string, unknown>): PersonGroupProfile {
+        return {
             userId: r.user_id as string,
             chatId: r.chat_id as string,
+            displayName: (r.display_name as string) || "",
+            chatTitle: (r.chat_title as string) || "",
             dunbarTier: (r.dunbar_tier as PersonGroupProfile["dunbarTier"]) ?? 4,
             dunbarReason: (r.dunbar_reason as string) ?? "",
             affinityScore: (r.affinity_score as number) ?? 0,
@@ -2461,8 +2460,32 @@ export class MemoryStoreV2 implements IMemoryStoreV2 {
             activeHours: fromJSON<number[]>(r.active_hours as string, []),
             firstSeenAt: (r.first_seen_at as string) ?? "",
             updatedAt: (r.updated_at as string) ?? "",
-        }));
+        };
+    }
+
+    getProfilesForChat(chatId: string): PersonGroupProfile[] {
+        const rows = this.db.prepare(
+            `SELECT p.*, i.display_name, gm.chat_title
+             FROM person_group_profiles p
+             LEFT JOIN person_identities i ON i.user_id = p.user_id
+             LEFT JOIN group_models gm ON gm.chat_id = p.chat_id
+             WHERE p.chat_id = ? ORDER BY p.message_count DESC`
+        ).all(chatId) as Record<string, unknown>[];
+        const profiles = rows.map(r => this.profileRowToObj(r));
         log.debug("getProfilesForChat", { chatId, count: profiles.length });
+        return profiles;
+    }
+
+    getProfilesForUser(userId: string): PersonGroupProfile[] {
+        const rows = this.db.prepare(
+            `SELECT p.*, i.display_name, gm.chat_title
+             FROM person_group_profiles p
+             LEFT JOIN person_identities i ON i.user_id = p.user_id
+             LEFT JOIN group_models gm ON gm.chat_id = p.chat_id
+             WHERE p.user_id = ? ORDER BY p.message_count DESC`
+        ).all(userId) as Record<string, unknown>[];
+        const profiles = rows.map(r => this.profileRowToObj(r));
+        log.debug("getProfilesForUser", { userId, count: profiles.length });
         return profiles;
     }
 
@@ -3237,11 +3260,20 @@ export class MemoryStoreV2 implements IMemoryStoreV2 {
     // ── Dashboard CRUD 方法 ──
 
     /** 分页列出全部 person_identities */
-    listPersonIdentities(limit = 50, offset = 0): { items: PersonIdentity[]; total: number } {
-        const total = (this.db.prepare("SELECT COUNT(*) as cnt FROM person_identities").get() as { cnt: number }).cnt;
+    listPersonIdentities(limit = 50, offset = 0, q?: string): { items: PersonIdentity[]; total: number } {
+        let totalSql = "SELECT COUNT(*) as cnt FROM person_identities";
+        let rowsSql = "SELECT * FROM person_identities";
+        let where = "";
+        const args: unknown[] = [];
+        if (q && q.trim()) {
+            where = " WHERE user_id LIKE ? OR display_name LIKE ? OR IFNULL(username, '') LIKE ?";
+            const like = `%${q.trim()}%`;
+            args.push(like, like, like);
+        }
+        const total = (this.db.prepare(totalSql + where).get(...args) as { cnt: number }).cnt;
         const rows = this.db.prepare(
-            "SELECT * FROM person_identities ORDER BY last_seen_at DESC LIMIT ? OFFSET ?"
-        ).all(limit, offset) as Record<string, unknown>[];
+            rowsSql + where + " ORDER BY last_seen_at DESC LIMIT ? OFFSET ?"
+        ).all(...args, limit, offset) as Record<string, unknown>[];
         return {
             total,
             items: rows.map(row => ({
@@ -3300,10 +3332,16 @@ export class MemoryStoreV2 implements IMemoryStoreV2 {
     }
 
     /** 列出全部群组画像 */
-    listGroupModels(): GroupModel[] {
-        const rows = this.db.prepare(
-            "SELECT * FROM group_models ORDER BY updated_at DESC"
-        ).all() as Record<string, unknown>[];
+    listGroupModels(q?: string): GroupModel[] {
+        let sql = "SELECT * FROM group_models";
+        const args: unknown[] = [];
+        if (q && q.trim()) {
+            sql += " WHERE chat_id LIKE ? OR chat_title LIKE ?";
+            const like = `%${q.trim()}%`;
+            args.push(like, like);
+        }
+        sql += " ORDER BY updated_at DESC";
+        const rows = this.db.prepare(sql).all(...args) as Record<string, unknown>[];
         return rows.map(row => ({
             chatId: row.chat_id as string,
             chatTitle: row.chat_title as string,

--- a/src/memory-v2/types.ts
+++ b/src/memory-v2/types.ts
@@ -151,6 +151,10 @@ export interface PersonGroupProfile {
     userId: string;
     /** 群组 ID（联合主键） */
     chatId: string;
+    /** 用户显示名（JOIN person_identities，列表展示用） */
+    displayName?: string;
+    /** 群组标题（JOIN group_models，列表展示用） */
+    chatTitle?: string;
     /** 邓巴分层 1=核心<=15, 2=熟悉<=50, 3=认识<=150, 4=陌生 */
     dunbarTier: 1 | 2 | 3 | 4;
     /** LLM 给出的分层理由 */
@@ -796,6 +800,9 @@ export interface IMemoryStoreV2 {
     /** 获取指定 chatId 的所有群内画像 */
     getProfilesForChat(chatId: string): PersonGroupProfile[];
 
+    /** 获取指定 userId 在所有群的群内画像 */
+    getProfilesForUser(userId: string): PersonGroupProfile[];
+
     /** 获取指定 chatId 最近的原始消息 */
     getRecentMessages(chatId: string, limit?: number): RecentMessageEntry[];
 
@@ -842,14 +849,15 @@ export interface IMemoryStoreV2 {
     /** 获取近期交互日志 */
     getRecentInteractions(chatId?: string | null, userId?: string, limit?: number): InteractionSearchResult[];
 
-    /** 分页列出全部 person identities */
-    listPersonIdentities(limit?: number, offset?: number): { items: PersonIdentity[]; total: number };
+    /** 分页列出全部 person identities（q 可选，模糊匹配 userId / 显示名 / username） */
+    listPersonIdentities(limit?: number, offset?: number, q?: string): { items: PersonIdentity[]; total: number };
 
     /** 分页列出全部全局 person profiles */
     listPersonProfiles(limit?: number, offset?: number): { items: PersonProfile[]; total: number };
 
     /** 列出全部群组画像 */
-    listGroupModels(): GroupModel[];
+    /** 列出全部群组画像（q 可选，模糊匹配 chatId / 群名） */
+    listGroupModels(q?: string): GroupModel[];
 
     /** 列出指定 binding/chat 的 todo */
     todoList(chatId: string, options?: { includeExpired?: boolean }): Array<{


### PR DESCRIPTION
## 修复

### 跨面板记忆跳转卡在空表单

在消息流、话题注册、话题详情、注意力队列、决策日志面板点击发送者名字或群组 ID 跳转记忆查询时，原实现通过同步 `window.dispatchEvent` 派发 `quickQueryUser` / `quickQueryGroup` 事件。事件先于 RecallTab 挂载到达（RecallTab 仅在 `activeMemoryTab === 'm-recall'` 时挂载，监听器注册在 onMount 中），载荷丢失，跳转后落在空表单且不自动填写、不自动查询。

改为统一写入已有的 `pendingMemoryLink` store，RecallTab 以响应式语句消费，无论跳转发生时组件是否已挂载都能自动填表并执行查询；移除全部相关 window 事件派发/监听与 MemoryPanel 的兜底监听。

> 用 headless Chromium + CDP 以真实点击验证了 5 条跳转链路（覆盖 RecallTab 新挂载 / 已挂载两种消费路径），输入框自动填充与查询结果渲染全部通过。

## 增强

- **群内画像**：新增 userId 搜索框（跳转自动填入）；仅填 userId 时经新端点 `GET /memory/user/:userId/profiles` 查询该用户在所有群的画像，配合 chatId 时前端按 userId 过滤；表格前两列改为展示**用户显示名**与**群组名称**，原始 userId / chatId 移至 tooltip；显示名点击跳用户画像并搜索该用户，群组名点击跳群组画像并搜索该群
- **用户画像**：新增搜索框（userId / 显示名 / username 模糊匹配），`/memory/persons` 透传 `q` 参数（SQL LIKE）
- **群组画像**：新增搜索框（chatId / 群名），`/memory/groups` 透传 `q`
- `getProfilesForChat` / `getProfilesForUser` LEFT JOIN `person_identities` / `group_models` 带出 `displayName` / `chatTitle`；`listPersonIdentities` / `listGroupModels` 支持可选模糊搜索

用户画像 ↔ 群内画像 ↔ 群组画像 三个页面形成带搜索条件的闭环互跳，全部路径已在浏览器中实际验证。