### PR TITLE
fix(harness): reject object-style background.enqueue and stringify non-string payloads

### DIFF
--- a/src/harness/prompt.ts
+++ b/src/harness/prompt.ts
@@ -28,7 +28,9 @@ export function renderPendingFile(pending: HarnessNotify[]): string {
 }
 
 function formatPendingNotification(notify: HarnessNotify, index: number): string {
-    const lines = [`${index + 1}. ${notify.source ? `[来自 ${notify.source}] ` : ""}${notify.content}`];
+    // 投递路径若漏传非 string content，兜底成 JSON 而不是 "[object Object]"
+    const contentText = typeof notify.content === "string" ? notify.content : safeStringify(notify.content);
+    const lines = [`${index + 1}. ${notify.source ? `[来自 ${notify.source}] ` : ""}${contentText}`];
     const context = [
         notify.actorId ? `actorId=${notify.actorId}` : "",
         notify.runId ? `runId=${notify.runId}` : "",

--- a/src/meta-sandbox/meta-api/background.ts
+++ b/src/meta-sandbox/meta-api/background.ts
@@ -6,6 +6,16 @@ type BackgroundEnqueueOptions = Omit<HarnessNotify, "content" | "source">;
 export function createBackgroundApi(getHarnessManager: () => HarnessManager | null) {
     return {
         enqueue: async (content: string, source?: string, options?: BackgroundEnqueueOptions) => {
+            // sandbox 里是 LLM 运行时生成的 JS，静态类型管不住；对象式调用会让对象落进 content 位，
+            // 渲染成 "[object Object]"。这里报错回喂给 agent（runner 会自动注入本文档）让它自我修正。
+            if (typeof content !== "string") {
+                throw new TypeError(
+                    `background.enqueue(content, source?, options?) 的 content 必须是 string，收到的是 ` +
+                    `${content === null ? "null" : typeof content}。` +
+                    `对象式调用会被拒绝：请改写为 background.enqueue(obj.content, obj.source, obj.options)，` +
+                    `或直接 background.enqueue("任务描述")。`,
+                );
+            }
             const hm = getHarnessManager();
             if (!hm) return { queued: false, reason: "Background Agent not configured" };
             hm.enqueue({ content, source: source ?? "meta", ...(options ?? {}) });

--- a/src/meta-sandbox/meta-api/modules/background.d.ts
+++ b/src/meta-sandbox/meta-api/modules/background.d.ts
@@ -36,7 +36,9 @@ declare const background: {
      * 向 Background Agent 派发一个任务。任务会进入队列，
      * 如果没有正在运行的实例则立即拉起，否则等当前实例结束后处理。
      *
-     * @param content 任务描述。写清楚需要做什么。
+     * @param content 任务描述。写清楚需要做什么。必须是字符串——
+     *   传对象（含 null/undefined）会抛 TypeError。不要写 background.enqueue({content, source})，
+     *   要结构化传参请展开位置参数：background.enqueue(payload.content, payload.source, payload.options)。
      * @param source 来源标识，默认 "meta"。
      * @param options 结构化上下文，会写入 harness pending 文件，供启动后的意识流读取。
      * @returns queued=true 表示已入队；queued=false 表示 Background Agent 未配置。

--- a/tests/harness-manager.test.ts
+++ b/tests/harness-manager.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { buildHarnessEnv, getHarnessHome, getHarnessInstructionPath, writeHarnessInstructions } from "../src/harness/home.js";
 import { HarnessManager } from "../src/harness/manager.js";
 import { serializeClaudeMcpConfig, serializeCodexMcpConfig, serializeCopilotMcpConfig } from "../src/harness/mcp-config.js";
-import { buildSystemPrompt, buildTaskPrompt } from "../src/harness/prompt.js";
+import { buildSystemPrompt, buildTaskPrompt, renderPendingFile } from "../src/harness/prompt.js";
 import type { HarnessMcpConfig } from "../src/harness/types.js";
 
 describe("HarnessManager MCP config loading", () => {
@@ -152,6 +152,20 @@ describe("Harness prompt and user home handling", () => {
         } finally {
             rmSync(root, { recursive: true, force: true });
         }
+    });
+
+    it("renders non-string notification content as JSON instead of [object Object]", () => {
+        const pending = [
+            // 模拟对象式调用漏过投递侧校验时的载荷形状
+            { source: "meta", content: { content: "任务正文", source: "meta" } },
+            { source: "scheduler", content: "普通文本通知" },
+        ] as unknown as Parameters<typeof renderPendingFile>[0];
+
+        const output = renderPendingFile(pending);
+
+        assert.match(output, /\[来自 meta\] \{"content":"任务正文","source":"meta"\}/);
+        assert.match(output, /\[来自 scheduler\] 普通文本通知/);
+        assert.doesNotMatch(output, /object Object/);
     });
 
     it("writes launcher instructions under the selected user HOME", () => {

--- a/tests/meta-api-background.test.ts
+++ b/tests/meta-api-background.test.ts
@@ -1,0 +1,75 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { createBackgroundApi } from "../src/meta-sandbox/meta-api/background.js";
+import type { HarnessManager } from "../src/harness/manager.js";
+import type { HarnessNotify } from "../src/harness/types.js";
+
+function createApi() {
+    const enqueued: HarnessNotify[] = [];
+    const manager = {
+        enqueue: (notify: HarnessNotify) => {
+            enqueued.push(notify);
+        },
+        get queueLength() {
+            return enqueued.length;
+        },
+        getStatus: async () => ({ enabled: true }),
+    } as unknown as HarnessManager;
+    const api = createBackgroundApi(() => manager);
+    return { api, enqueued };
+}
+
+describe("metaApi.background.enqueue", () => {
+    it("rejects object-style calls with rewrite guidance instead of stringifying to [object Object]", async () => {
+        const { api, enqueued } = createApi();
+
+        await assert.rejects(
+            api.enqueue({ content: "任务正文", source: "meta" } as unknown as string),
+            (err: unknown) => {
+                assert.ok(err instanceof TypeError);
+                assert.match((err as TypeError).message, /content 必须是 string/);
+                assert.match((err as TypeError).message, /obj\.content, obj\.source, obj\.options/);
+                return true;
+            },
+        );
+        assert.equal(enqueued.length, 0);
+    });
+
+    it("rejects null/undefined content", async () => {
+        const { api } = createApi();
+
+        for (const bad of [null, undefined]) {
+            await assert.rejects(
+                api.enqueue(bad as unknown as string),
+                (err: unknown) => {
+                    assert.match((err as TypeError).message, /收到的是 (null|undefined)/);
+                    return true;
+                },
+            );
+        }
+    });
+
+    it("defaults source to meta and forwards options on correct positional calls", async () => {
+        const { api, enqueued } = createApi();
+
+        const minimal = await api.enqueue("整理搜索技巧成 skill");
+        assert.deepEqual(minimal, { queued: true, queueLength: 1 });
+        assert.deepEqual(enqueued[0], { content: "整理搜索技巧成 skill", source: "meta" });
+
+        const full = await api.enqueue("深入查资料", "proactive-idle", { taskId: "task-1", metadata: { k: 1 } });
+        assert.deepEqual(full, { queued: true, queueLength: 2 });
+        assert.deepEqual(enqueued[1], {
+            content: "深入查资料",
+            source: "proactive-idle",
+            taskId: "task-1",
+            metadata: { k: 1 },
+        });
+    });
+
+    it("returns queued:false with reason when harness manager is absent", async () => {
+        const api = createBackgroundApi(() => null);
+        const result = await api.enqueue("任务");
+        assert.deepEqual(result, { queued: false, reason: "Background Agent not configured" });
+    });
+});


### PR DESCRIPTION
## 修复

### 后台通知载荷被序列化为 [object Object]

`metaApi.background.enqueue(content, source?, options?)` 是位置参数签名，而越界投递方在 meta sandbox——那里执行的是 LLM 运行时生成的 JS，TypeScript 静态类型管不到。对象式调用 `background.enqueue({content, source})` 会把整个对象塞进 `content` 位，`source` 缺省成 `"meta"`，随后 `prompt.ts` 的模板字符串把对象渲染成 `[object Object]` 写进 `background-pending.md`：交办正文完全不可读，任务上下文丢失，只能靠 session digest 兜底补回。线上已实际出现 `[来自 meta] [object Object]` 条目。

排查确认仓库内其余调用方均无此问题：MCP 的 `notify` / `harness_enqueue` 带 `z.string()` 校验且按位置参数调用，`main.ts` 走的是 `HarnessManager.enqueue` 自身的对象签名——坏载荷的唯一来源是 sandbox 运行时代码。

### 改法

- **`enqueue` 入口类型守卫**（`meta-sandbox/meta-api/background.ts`）：`content` 非 string（含 null/undefined）即抛 `TypeError`，文案写明实际收到的类型并给出改写指引（`background.enqueue("任务描述")` 或 `background.enqueue(obj.content, obj.source, obj.options)`）。meta session runner 会把执行错误作为 observation 回喂 agent 并自动注入对应 API 的 d.ts 文档，模型下一轮即可自我修正——与本仓库对越界 sandbox 调用的既有处置一致（同 `dispatch.ts` 对 `taskSpec.context` 的拒绝）
- **`background.d.ts`**：文档注明「content 必须为 string，传对象会被拒绝」及结构化传参写法；报错后 runner 注入的正是这份文档
- **渲染层兜底**（`harness/prompt.ts`）：`formatPendingNotification` 对非 string 的 `content` 走 `safeStringify`，其他 `HarnessNotify` 投递路径即使漏传对象，pending 文件也会是可读 JSON 而非 `[object Object]`

## 测试

新增 `tests/meta-api-background.test.ts`（4 用例：对象式调用拒绝且文案含改写指引、null/undefined 拒绝、位置参数透传 + 默认 source=meta + options 展开、未配置返回 queued:false），并在 `tests/harness-manager.test.ts` 补 `renderPendingFile` 对对象 content 输出 JSON 而非 `[object Object]` 的回归用例。

> 本分支 `tsc --noEmit` 干净；`npm test` 909 用例 900 通过，9 个失败全部为存量问题（`banned-words.test.ts` 4 个、`telegram-adapter.test.ts` 5 个），在 `agentic` 基线 3f2200b 上同样失败，与本 PR 无关。

