### PR TITLE
test: fix suite rot from userGate migration and banned-words config move

### DIFF
--- a/tests/banned-words.test.ts
+++ b/tests/banned-words.test.ts
@@ -12,26 +12,29 @@ import { createDiscordClientProxy } from "../src/sandbox/modules/discord/index.j
 
 // ─── findBannedWords ───
 
+/** 测试 fixture：3be2c6a 前的默认词表（源自 SOUL.md）。运行时默认词表已配置化（DEFAULT_BANNED_WORDS = []），匹配器与具体词表无关。 */
+const WORDS = ["确实", "笑死", "还真是", "接住", "抓住", "你说得对", "说得对", "不绕", "我认了"];
+
 describe("findBannedWords", () => {
     it("returns empty array when no banned words found", () => {
-        const result = findBannedWords("这是一句正常的话", DEFAULT_BANNED_WORDS);
+        const result = findBannedWords("这是一句正常的话", WORDS);
         assert.deepEqual(result, []);
     });
 
     it("detects single banned word", () => {
-        const result = findBannedWords("确实有点那个味道", DEFAULT_BANNED_WORDS);
+        const result = findBannedWords("确实有点那个味道", WORDS);
         assert.deepEqual(result, ["确实"]);
     });
 
     it("detects multiple banned words", () => {
-        const result = findBannedWords("确实笑死我了", DEFAULT_BANNED_WORDS);
+        const result = findBannedWords("确实笑死我了", WORDS);
         assert.ok(result.includes("确实"));
         assert.ok(result.includes("笑死"));
         assert.equal(result.length, 2);
     });
 
     it("deduplicates repeated occurrences", () => {
-        const result = findBannedWords("确实确实确实", DEFAULT_BANNED_WORDS);
+        const result = findBannedWords("确实确实确实", WORDS);
         assert.deepEqual(result, ["确实"]);
     });
 
@@ -41,13 +44,18 @@ describe("findBannedWords", () => {
     });
 
     it("does not trigger on non-matching text", () => {
-        const result = findBannedWords("谢谢你对我真的很好哦", DEFAULT_BANNED_WORDS);
+        const result = findBannedWords("谢谢你对我真的很好哦", WORDS);
         assert.deepEqual(result, []);
     });
 
     it("detects 说得对 in context", () => {
-        const result = findBannedWords("你说得对，这个方向是对的", DEFAULT_BANNED_WORDS);
+        const result = findBannedWords("你说得对，这个方向是对的", WORDS);
         assert.ok(result.includes("说得对"));
+    });
+
+    it("default word list is empty — actual list is config/Dashboard-managed", () => {
+        // 3be2c6a 起词表由配置管理，代码内默认不拦截任何词；锁定该契约防止硬编码词表回归
+        assert.deepEqual(DEFAULT_BANNED_WORDS, []);
     });
 });
 

--- a/tests/telegram-adapter.test.ts
+++ b/tests/telegram-adapter.test.ts
@@ -13,6 +13,7 @@ import { gzipSync } from "node:zlib";
 import { NotificationCenter } from "../src/event/notification-center.js";
 import type { NotificationEvent } from "../src/event/notification-center.js";
 import { TelegramAdapter } from "../src/adapter/telegram-adapter.js";
+import { userGate } from "../src/adapter/user-gate.js";
 import type { TelegramConfig } from "../src/core/config.js";
 
 function makeNC(): NotificationCenter {
@@ -845,7 +846,7 @@ interface TelegramClient {
 
     it("/invisible should toggle user invisibility and send confirmation", async () => {
         // 清理跨测试/跨运行持久化状态
-        try { fs.rmSync("workspace/invisible-users.json", { force: true }); } catch {}
+        userGate.setInvisible([]); // 清理跨测试/跨运行持久化状态（单例内存态 + 文件）
         const nc = makeNC();
         const sentTexts: Array<[unknown, unknown]> = [];
         let newMessageHandler: ((msg: unknown) => void | Promise<void>) | null = null;
@@ -885,7 +886,9 @@ interface TelegramClient {
         assert.ok(sentTexts.length >= 1, "should send confirmation message");
         assert.ok(String(sentTexts[0][1]).includes("隐身"), "confirmation should mention 隐身");
         // userId is stored as a composite chat-id ("telegram:42") after normalization.
-        assert.ok(adapter.isUserInvisible("telegram:42"), "user should be invisible");
+        assert.ok(userGate.isInvisible("telegram:42"), "user should be invisible");
+        // 丢弃职责在 main.ts 的 userGate（593e973 起 adapter 不再自行丢弃），验证闸门会真的拦截
+        assert.ok(userGate.shouldDrop("telegram:42"), "gate should drop messages from invisible user");
 
         // Subsequent message from user 42 should be dropped
         sentTexts.length = 0;
@@ -905,7 +908,7 @@ interface TelegramClient {
             chat: { id: -100, title: "Test", type: "group" },
             sender: { id: 42, displayName: "Alice", isBot: false },
         });
-        assert.ok(!adapter.isUserInvisible("telegram:42"), "user should no longer be invisible");
+        assert.ok(!userGate.isInvisible("telegram:42"), "user should no longer be invisible");
         assert.ok(sentTexts.length >= 1, "should send un-invisible confirmation");
 
         await adapter.stop();
@@ -1208,7 +1211,7 @@ interface TelegramClient {
 
     it("should process /invisible@SelfUsername when username matches", async () => {
         // 清理跨测试持久化状态，避免被前序测试污染
-        try { fs.rmSync("workspace/invisible-users.json", { force: true }); } catch {}
+        userGate.setInvisible([]); // 清理跨测试/跨运行持久化状态（单例内存态 + 文件）
         const nc = makeNC();
         const sentTexts: Array<[unknown, unknown]> = [];
         let newMessageHandler: ((msg: unknown) => void | Promise<void>) | null = null;
@@ -1246,7 +1249,7 @@ interface TelegramClient {
 
         assert.ok(sentTexts.length >= 1, "should send confirmation for matching @username");
         assert.ok(String(sentTexts[0][1]).includes("隐身"), "confirmation should mention 隐身");
-        assert.ok(adapter.isUserInvisible("telegram:42"), "user should be invisible");
+        assert.ok(userGate.isInvisible("telegram:42"), "user should be invisible");
 
         await adapter.stop();
         nc.dispose();
@@ -1254,7 +1257,7 @@ interface TelegramClient {
 
     it("should ignore /invisible@OtherBot when username does not match self", async () => {
         // 清理跨测试持久化状态，避免被前序测试污染
-        try { fs.rmSync("workspace/invisible-users.json", { force: true }); } catch {}
+        userGate.setInvisible([]); // 清理跨测试/跨运行持久化状态（单例内存态 + 文件）
         const nc = makeNC();
         const events = captureEvents(nc);
         const sentTexts: Array<[unknown, unknown]> = [];
@@ -1294,7 +1297,7 @@ interface TelegramClient {
         // Should NOT send confirmation reply
         assert.equal(sentTexts.length, 0, "should not send confirmation for non-matching @username");
         // Should NOT toggle invisibility
-        assert.ok(!adapter.isUserInvisible("telegram:42"), "user should NOT be invisible");
+        assert.ok(!userGate.isInvisible("telegram:42"), "user should NOT be invisible");
         // Message should flow through to NC as a normal message
         assert.equal(events.length, 1, "message should be pushed to NC as normal message");
         assert.equal(events[0].type, "nc.message");
@@ -1306,7 +1309,7 @@ interface TelegramClient {
 
     it("should still process bare /invisible when self has no username", async () => {
         // 清理跨测试持久化状态，避免被前序测试污染
-        try { fs.rmSync("workspace/invisible-users.json", { force: true }); } catch {}
+        userGate.setInvisible([]); // 清理跨测试/跨运行持久化状态（单例内存态 + 文件）
         const nc = makeNC();
         const sentTexts: Array<[unknown, unknown]> = [];
         let newMessageHandler: ((msg: unknown) => void | Promise<void>) | null = null;
@@ -1344,7 +1347,7 @@ interface TelegramClient {
         });
 
         assert.ok(sentTexts.length >= 1, "should send confirmation for bare /invisible");
-        assert.ok(adapter.isUserInvisible("telegram:42"), "user should be invisible");
+        assert.ok(userGate.isInvisible("telegram:42"), "user should be invisible");
 
         await adapter.stop();
         nc.dispose();
@@ -1352,7 +1355,7 @@ interface TelegramClient {
 
     it("should still process /invisible@AnyUser when self has no username", async () => {
         // 清理跨测试持久化状态，避免被前序测试污染
-        try { fs.rmSync("workspace/invisible-users.json", { force: true }); } catch {}
+        userGate.setInvisible([]); // 清理跨测试/跨运行持久化状态（单例内存态 + 文件）
         const nc = makeNC();
         const sentTexts: Array<[unknown, unknown]> = [];
         let newMessageHandler: ((msg: unknown) => void | Promise<void>) | null = null;
@@ -1390,7 +1393,7 @@ interface TelegramClient {
         });
 
         assert.ok(sentTexts.length >= 1, "should still process when self has no username");
-        assert.ok(adapter.isUserInvisible("telegram:42"), "user should be invisible");
+        assert.ok(userGate.isInvisible("telegram:42"), "user should be invisible");
 
         await adapter.stop();
         nc.dispose();


### PR DESCRIPTION
## 修复

### 测试腐化：两组上游重构遗留的 9 个基线失败（全部 `tests/` 改动，零源码变更）

**telegram-adapter（5 个失败）**：593e973 把 invisible/blocked 状态从 `TelegramAdapter` 迁到跨平台单例 `userGate` 并删除了 `adapter.isUserInvisible`，但 `/invisible` 用例仍在调用该方法，全部死于断言行 `TypeError: adapter.isUserInvisible is not a function`（`f46705b` 后来新增的 4 个 @username 用例也用了这个已删除的 API）。行为逻辑本身完好：命令拦截、@username 定向、toggle 走 `userGate.toggleInvisible` 均在且正确。

**banned-words（4 个失败）**：3be2c6a 把禁用词表从代码搬进 Dashboard/config 管理并清空 `DEFAULT_BANNED_WORDS`，但 4 个 `findBannedWords` 用例仍断言默认词表内容（"确实"/"笑死"/"说得对"）——空词表匹配不到任何词；另有 2 个用例因同一原因**空洞通过**（空词表下「不误伤」断言恒真，自 6/30 起就没验证过任何东西）。

### 改法

- **telegram-adapter.test.ts**
  - 6 处断言改走 `userGate.isInvisible`——与 adapter 命令处理器写入的是同一个单例（`user-gate.ts:101`），验证的是真实集成点，断言语义 1:1 不变
  - 每个 `/invisible` 用例的 setup 从 `rmSync(invisible-users.json)` 改为 `userGate.setInvisible([])`：旧 API 是 adapter 实例状态、每用例天然隔离，单例的内存态不吃文件删除——不重置的话 1211 用例（toggle ON 后不 OFF）会污染 1297/1347 的否定断言，反而制造新失败
  - 首用例补 `userGate.shouldDrop` 断言：丢弃职责随迁移移到了 `main.ts:754`，原「隐身后消息被丢弃」的覆盖在 adapter 层已名存实亡（普通消息本来就不触发回复，断言只是顺带成立）
- **banned-words.test.ts**
  - 4 个用例改用显式 fixture 词表（3be2c6a 前默认词表的复刻，仅作测试输入，与文件内平台代理测试显式传参的既有写法同构），输入与期望输出逐字不变
  - 恢复 2 个空洞用例的误伤防护
  - 新增契约用例锁定 `DEFAULT_BANNED_WORDS` 为空——「词表配置化」这一决定本身被测试固定，防止硬编码词表悄悄回归

## 测试

- agentic 基线（3f2200b）：`npm test` **905/905 全绿**（此前 900/909，9 失败即本 PR 修复对象），`tsc --noEmit` 干净
- katheryne（agentic + 10 commits 的本地分支）：**940/940 全绿**

合入后两条分支的测试基线清零，后续 PR 不再需要背这 9 个存量失败。
