### PR TITLE
feat(telegram): 增加显式 Bot API 模式与配置选择

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -230,13 +230,14 @@ backfill:
 # ─── Telegram 设置 ───
 # 可选。telegram 和 discord 至少配置一个。
 telegram:
-  # 连接模式: "bot" | "userbot"
+  # 连接模式: "bot_api" (HTTP Bot API) | "bot" (MTProto bot，旧配置保持不变) | "userbot" (MTProto 用户账号)
+  # 只使用 BotFather Token 时选择 bot_api；不会根据凭据是否留空自动切换协议。
   mode: bot
   # Bot Token (bot 模式下使用)
   bot_token: ""
-  # API ID (bot / userbot 都需要)
+  # API ID (bot / userbot 需要；bot_api 不需要)
   api_id: ""
-  # API Hash (bot / userbot 都需要)
+  # API Hash (bot / userbot 需要；bot_api 不需要)
   api_hash: ""
   # 手机号 (userbot 模式下使用；首次登录时会在终端提示输入 OTP / 2FA)
   phone: ""

--- a/docs/dev/telegram-bot-api.md
+++ b/docs/dev/telegram-bot-api.md
@@ -1,0 +1,25 @@
+# Telegram connection modes
+
+The Dashboard connection selector distinguishes the account type from the protocol:
+
+| Mode | Account / protocol | Credentials |
+| --- | --- | --- |
+| `bot_api` | Bot / HTTP Bot API | BotFather token |
+| `bot` | Bot / MTProto (existing behavior) | Token, API ID, API Hash |
+| `userbot` | User / MTProto | API ID, API Hash, phone; interactive code / 2FA |
+
+Existing `bot` settings and omitted modes retain MTProto behavior. Credentials do not automatically select a transport. To use a token-only bot, explicitly choose **机器人（Bot API）** or configure:
+
+```yaml
+telegram:
+  mode: bot_api
+  bot_token: "<BOTFATHER_TOKEN>"
+```
+
+Bot API mode supports incoming messages/channel posts, text replies, photo/document/video/audio/voice/sticker media, file downloads, and typing. It uses a single long poller per running client; do not run multiple instances using the same token. The poller starts after a consumer subscribes and advances its offset after all consumers finish. Failed consumers may receive a message again; this is not an exactly-once delivery guarantee. Telegram retains pending updates for at most 24 hours. Editing an old message does not trigger a new message event.
+
+An existing webhook blocks startup and must be removed explicitly by its owner. Group visibility still follows Telegram's privacy-mode and administrator rules. HTTP requests use Node's fetch; this mode does not use the MTProto SOCKS transport (`TG_PROXY`). Ensure the process can reach `api.telegram.org` over HTTPS.
+
+History queries, dialogs, member enumeration, user login, and MTProto native passthrough are unavailable. The scene instructions list the supported host calls, and unsupported calls return an explicit capability error. Use existing `bot` / `userbot` modes when those transports and capabilities are needed, subject to Telegram's own bot restrictions.
+
+References: [Bot API](https://core.telegram.org/bots/api), [Bot privacy FAQ](https://core.telegram.org/bots/faq#what-messages-will-my-bot-get), [MTProto bot authorization](https://core.telegram.org/method/auth.importBotAuthorization).

--- a/src/adapter/telegram-adapter.ts
+++ b/src/adapter/telegram-adapter.ts
@@ -23,9 +23,14 @@ import { createHash, randomBytes } from "node:crypto";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { Long } from "@mtcute/node";
+import { TelegramBotApiClient } from "./telegram-bot-api-client.js";
 import { isAllowedTelegramMtcutePassthroughMethod, isBlockedTelegramMtcuteNativeMethod } from "../core/telegram-mtcute-passthrough.js";
 
 const log = createLogger("telegram-adapter");
+const BOT_API_METHODS = new Set([
+    "telegram.getMe", "telegram.getChat", "telegram.sendText", "telegram.sendMedia",
+    "telegram.sendFile", "telegram.sendSticker", "telegram.sendTyping", "telegram.downloadMedia",
+]);
 
 /** 白名单条目：去掉 `telegram:` 前缀并 trim，便于与 composite chatId 比对 */
 function normalizeWhitelistId(raw: string): string {
@@ -372,7 +377,7 @@ export class TelegramAdapter implements PlatformAdapter {
         const generation = ++this.clientGeneration;
         this.attachConnectionListeners(client, generation);
 
-        const self = this.config.mode === "bot"
+        const self = this.config.mode !== "userbot"
             ? await client.start({ botToken: this.config.botToken })
             : await client.start({
                 phone: () => this.config.phone,
@@ -613,6 +618,9 @@ export class TelegramAdapter implements PlatformAdapter {
         if (!this.client) {
             return { chats: 0, messages: 0, notes: ["telegram adapter 未连接"] };
         }
+        if (this.config.mode === "bot_api") {
+            return { chats: 0, messages: 0, notes: ["Bot API 无历史查询；仅接收 Telegram 保留的待处理更新（最长 24 小时）"] };
+        }
         if (this.config.mode === "bot") {
             return {
                 chats: 0,
@@ -792,7 +800,9 @@ export class TelegramAdapter implements PlatformAdapter {
             ? baseTypeDefs.replace(/^\s*\/\/ \[USERBOT_ONLY_BEGIN\]\s*$/gm, "").replace(/^\s*\/\/ \[USERBOT_ONLY_END\]\s*$/gm, "")
             : baseTypeDefs.replace(/^\s*\/\/ \[USERBOT_ONLY_BEGIN\]\s*$[\s\S]*?^\s*\/\/ \[USERBOT_ONLY_END\]\s*$/gm, "");
 
-        const modeNote = this.config.mode === "bot"
+        const modeNote = this.config.mode === "bot_api"
+            ? `// 当前 Telegram adapter 模式: bot_api (HTTP Bot API)\n// 仅支持: ${[...BOT_API_METHODS].join(", ")}。其他方法及 mtcute 透传不可用。\n`
+            : this.config.mode === "bot"
             ? "// 当前 Telegram adapter 模式: bot\n// 注意: bot mode 下不应使用历史读取、对话遍历、读回执、成员枚举等受限 API。\n"
             : "// 当前 Telegram adapter 模式: userbot\n// 可使用完整的 Telegram host proxy 能力面。\n";
 
@@ -802,6 +812,10 @@ export class TelegramAdapter implements PlatformAdapter {
     async handleCall(method: string, args: unknown[]): Promise<unknown> {
         if (!this.client) {
             throw new Error("TelegramAdapter is not started");
+        }
+
+        if (this.config.mode === "bot_api" && !BOT_API_METHODS.has(method)) {
+            throw new Error(`${method} is not supported in Telegram Bot API mode; MTProto methods require bot or userbot mode`);
         }
 
         // ─── /mute 写操作拦截 ───
@@ -1973,6 +1987,13 @@ export class TelegramAdapter implements PlatformAdapter {
     }
 
     private validateConfig(): void {
+        if (!["bot", "bot_api", "userbot"].includes(this.config.mode)) {
+            throw new Error("telegram.mode must be bot, bot_api, or userbot");
+        }
+        if (this.config.mode === "bot_api") {
+            if (!this.config.botToken?.trim()) throw new Error("telegram.bot_token is required in bot_api mode");
+            return;
+        }
         if (!this.config.apiId || !this.config.apiHash) {
             throw new Error("Telegram API credentials are missing in config.yaml (telegram.api_id / telegram.api_hash)");
         }
@@ -2536,6 +2557,7 @@ export class TelegramAdapter implements PlatformAdapter {
         options: { failOnUnresolved?: boolean; kind?: MeetPeerOptions["kind"]; dialogsLimit?: number; force?: boolean } = {},
     ): Promise<unknown> {
         const peer = this.normalizePeerArg(rawPeer, options.kind);
+        if (this.config.mode === "bot_api") return peer;
         this.rememberPeerObject(rawPeer);
 
         // 检查本地缓存
@@ -3242,6 +3264,9 @@ export class TelegramAdapter implements PlatformAdapter {
 }
 
 async function defaultTelegramClientFactory(config: TelegramConfig): Promise<TelegramClientLike> {
+    if (config.mode === "bot_api") {
+        return new TelegramBotApiClient(config.botToken);
+    }
     const { TelegramClient, SocksProxyTcpTransport } = await import("@mtcute/node");
     const proxyUrl = process.env.TG_PROXY || process.env.HTTPS_PROXY || "";
     const clientOpts: Record<string, unknown> = {

--- a/src/adapter/telegram-bot-api-client.ts
+++ b/src/adapter/telegram-bot-api-client.ts
@@ -1,0 +1,401 @@
+import { basename } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+export type TelegramEventHandler = (message: unknown) => void | Promise<void>;
+
+type FetchLike = typeof fetch;
+
+type BotApiEnvelope<T> = {
+    ok: boolean;
+    result?: T;
+    description?: string;
+    error_code?: number;
+};
+
+type BotApiUser = {
+    id: number;
+    is_bot: boolean;
+    first_name?: string;
+    last_name?: string;
+    username?: string;
+};
+
+type BotApiChat = {
+    id: number;
+    type: "private" | "group" | "supergroup" | "channel";
+    title?: string;
+    username?: string;
+    first_name?: string;
+    last_name?: string;
+};
+
+type BotApiFile = {
+    file_id: string;
+    file_unique_id?: string;
+    file_name?: string;
+    mime_type?: string;
+    file_size?: number;
+    width?: number;
+    height?: number;
+    emoji?: string;
+};
+
+type BotApiMessage = {
+    message_id: number;
+    date: number;
+    text?: string;
+    caption?: string;
+    chat: BotApiChat;
+    from?: BotApiUser;
+    sender_chat?: BotApiChat;
+    reply_to_message?: { message_id: number; from?: BotApiUser };
+    entities?: Array<{ type: string; offset: number; length: number; user?: BotApiUser }>;
+    caption_entities?: BotApiMessage["entities"];
+    photo?: BotApiFile[];
+    document?: BotApiFile;
+    video?: BotApiFile;
+    animation?: BotApiFile;
+    audio?: BotApiFile;
+    voice?: BotApiFile;
+    sticker?: BotApiFile;
+};
+
+type BotApiUpdate = {
+    update_id: number;
+    message?: BotApiMessage;
+    edited_message?: BotApiMessage;
+    channel_post?: BotApiMessage;
+    edited_channel_post?: BotApiMessage;
+};
+
+/**
+ * HTTP client selected explicitly by mode: bot_api.
+ * It keeps the TelegramAdapter event contract while
+ * intentionally exposing only Bot API capabilities.
+ */
+export class TelegramBotApiClient {
+    private readonly handlers = new Set<TelegramEventHandler>();
+    private readonly baseUrl: string;
+    private running = false;
+    private polling: Promise<void> | null = null;
+    private abortController: AbortController | null = null;
+    private updateOffset = 0;
+    private self: BotApiUser | null = null;
+    private lifetime = new AbortController();
+    private readonly errorHandlers = new Set<(error: Error) => void>();
+    private readonly stateHandlers = new Set<(state: string) => void>();
+    readonly onError = { add: (handler: (error: Error) => void) => { this.errorHandlers.add(handler); } };
+    readonly onConnectionState = { add: (handler: (state: string) => void) => { this.stateHandlers.add(handler); } };
+
+    readonly onNewMessage = {
+        add: (handler: TelegramEventHandler) => {
+            this.handlers.add(handler);
+            this.ensurePolling();
+        },
+        remove: (handler: TelegramEventHandler) => {
+            this.handlers.delete(handler);
+            if (this.handlers.size === 0) this.abortController?.abort();
+        },
+    };
+
+    constructor(
+        private readonly botToken: string,
+        private readonly fetchImpl: FetchLike = globalThis.fetch,
+        baseUrl = "https://api.telegram.org",
+    ) {
+        this.baseUrl = `${baseUrl.replace(/\/$/, "")}/bot${botToken}`;
+    }
+
+    async start(_params: Record<string, unknown> = {}): Promise<unknown> {
+        if (this.running) return this.getMe();
+        if (this.lifetime.signal.aborted) this.lifetime = new AbortController();
+        const self = await this.api<BotApiUser>("getMe");
+        const webhook = await this.api<{ url: string }>("getWebhookInfo");
+        if (webhook.url) {
+            throw new Error("Telegram Bot API polling conflicts with an existing webhook; remove it explicitly before starting bot_api mode");
+        }
+        this.self = self;
+        this.running = true;
+        this.ensurePolling();
+        return this.normalizeUser(self);
+    }
+
+    async destroy(): Promise<void> {
+        this.running = false;
+        this.lifetime.abort();
+        this.abortController?.abort();
+        try {
+            await this.polling;
+        } catch {
+            // An abort during shutdown is expected.
+        }
+        this.polling = null;
+        this.abortController = null;
+    }
+
+    async getMe(): Promise<unknown> {
+        if (!this.self) this.self = await this.api<BotApiUser>("getMe");
+        return this.normalizeUser(this.self);
+    }
+
+    async getChat(chatId: unknown): Promise<unknown> {
+        return this.normalizeChat(await this.api<BotApiChat>("getChat", { chat_id: this.chatId(chatId) }));
+    }
+
+    async downloadAsBuffer(fileId: unknown): Promise<Uint8Array> {
+        const id = String(fileId ?? "").trim();
+        if (!id) throw new Error("Telegram Bot API downloadAsBuffer requires a file_id");
+        const file = await this.api<{ file_path?: string }>("getFile", { file_id: id });
+        if (!file.file_path) throw new Error("Telegram Bot API getFile returned no file_path");
+        const response = await this.request(`${this.baseUrl.replace(/\/bot([^/]+)$/, "/file/bot$1")}/${file.file_path}`);
+        if (!response.ok) throw new Error(`Telegram Bot API file download failed: ${response.status}`);
+        return new Uint8Array(await response.arrayBuffer());
+    }
+
+    async sendText(chatId: unknown, text: unknown, opts?: unknown): Promise<unknown> {
+        const result = await this.api<BotApiMessage>("sendMessage", {
+            chat_id: this.chatId(chatId),
+            text: typeof text === "string" ? text : String(text ?? ""),
+            ...this.replyOptions(opts),
+        });
+        return this.normalizeMessage(result);
+    }
+
+    async sendTyping(chatId: unknown): Promise<void> {
+        await this.api("sendChatAction", { chat_id: this.chatId(chatId), action: "typing" });
+    }
+
+    async sendMedia(chatId: unknown, media: unknown, opts?: unknown): Promise<unknown> {
+        const value = media && typeof media === "object" ? media as Record<string, unknown> : { file: media };
+        const type = typeof value.type === "string" ? value.type : "document";
+        const methodAndField = this.mediaMethod(type, value);
+        const form = new FormData();
+        form.set("chat_id", this.chatId(chatId));
+        const caption = typeof value.caption === "string" ? value.caption : undefined;
+        if (caption) form.set("caption", caption);
+        for (const [key, item] of Object.entries(this.replyOptions(opts))) {
+            form.set(key, String(item));
+        }
+
+        const file = value.file;
+        if (file instanceof Uint8Array || Buffer.isBuffer(file)) {
+            const name = typeof value.fileName === "string" && value.fileName.trim()
+                ? value.fileName.trim()
+                : `${type || "document"}.bin`;
+            const mime = typeof value.fileMime === "string" ? value.fileMime : "application/octet-stream";
+            // Copy into a plain ArrayBuffer: Node's Buffer can be backed by a
+            // SharedArrayBuffer, which TypeScript correctly refuses as BlobPart.
+            const bytes = new Uint8Array(file.byteLength);
+            bytes.set(file);
+            form.set(methodAndField.field, new Blob([bytes.buffer], { type: mime }), basename(name));
+        } else if (typeof file === "string" && file.trim()) {
+            form.set(methodAndField.field, file.trim());
+        } else {
+            throw new Error("Telegram Bot API sendMedia requires a file_id, URL, or binary file");
+        }
+
+        const result = await this.apiForm<BotApiMessage>(methodAndField.method, form);
+        return this.normalizeMessage(result);
+    }
+
+    private ensurePolling(): void {
+        if (!this.running || this.polling || this.handlers.size === 0) return;
+        this.polling = this.pollLoop().finally(() => {
+            this.polling = null;
+            if (this.running && this.handlers.size > 0) this.ensurePolling();
+        });
+    }
+
+    private async pollLoop(): Promise<void> {
+        while (this.running && this.handlers.size > 0) {
+            this.abortController = new AbortController();
+            try {
+                const updates = await this.api<BotApiUpdate[]>("getUpdates", {
+                    offset: this.updateOffset || undefined,
+                    timeout: 25,
+                    allowed_updates: ["message", "channel_post"],
+                }, this.abortController.signal);
+                for (const handler of this.stateHandlers) handler("connected");
+                for (const update of updates) {
+                    if (!this.running || this.handlers.size === 0) return;
+                    const message = update.message ?? update.channel_post;
+                    if (message) {
+                        const normalized = this.normalizeMessage(message);
+                        for (const handler of this.handlers) {
+                            await handler(normalized);
+                        }
+                    }
+                    // Acknowledge only after every handler completed, so a
+                    // transient downstream failure is retried instead of lost.
+                    this.updateOffset = Math.max(this.updateOffset, update.update_id + 1);
+                }
+            } catch (error) {
+                if (!this.running || this.abortController.signal.aborted) return;
+                const safeError = this.sanitizeError(error);
+                for (const handler of this.errorHandlers) handler(safeError);
+                for (const handler of this.stateHandlers) handler("offline");
+                // Avoid a hot retry loop when Telegram or the network is transiently unavailable.
+                await delay(2_000, undefined, {
+                    signal: AbortSignal.any([this.lifetime.signal, this.abortController.signal]),
+                }).catch(() => {});
+            } finally {
+                this.abortController = null;
+            }
+        }
+    }
+
+    private async api<T>(method: string, payload: Record<string, unknown> = {}, signal?: AbortSignal): Promise<T> {
+        const response = await this.request(`${this.baseUrl}/${method}`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(payload),
+            signal,
+        });
+        const body = await this.readEnvelope<T>(response);
+        if (!response.ok || !body.ok) {
+            throw this.sanitizeError(`Telegram Bot API ${method} failed: ${body.description ?? response.statusText}`);
+        }
+        return body.result as T;
+    }
+
+    private async apiForm<T>(method: string, form: FormData): Promise<T> {
+        const response = await this.request(`${this.baseUrl}/${method}`, { method: "POST", body: form });
+        const body = await this.readEnvelope<T>(response);
+        if (!response.ok || !body.ok) {
+            throw this.sanitizeError(`Telegram Bot API ${method} failed: ${body.description ?? response.statusText}`);
+        }
+        return body.result as T;
+    }
+
+    private async readEnvelope<T>(response: Response): Promise<BotApiEnvelope<T>> {
+        try {
+            return await response.json() as BotApiEnvelope<T>;
+        } catch {
+            return { ok: false, description: `HTTP ${response.status}` };
+        }
+    }
+
+    private sanitizeError(error: unknown): Error {
+        const message = error instanceof Error ? error.message : String(error);
+        const redacted = [this.botToken, encodeURIComponent(this.botToken)]
+            .filter(Boolean).reduce((text, secret) => text.replaceAll(secret, "[REDACTED]"), message);
+        // Do not retain the original error/cause: fetch errors may embed the token-bearing URL.
+        return new Error(redacted);
+    }
+
+    private async request(url: string, init: RequestInit = {}): Promise<Response> {
+        try {
+            return await this.fetchImpl(url, {
+                ...init,
+                signal: AbortSignal.any([
+                    this.lifetime.signal,
+                    AbortSignal.timeout(60_000),
+                    ...(init.signal ? [init.signal] : []),
+                ]),
+            });
+        } catch (error) {
+            throw this.sanitizeError(error);
+        }
+    }
+
+    private chatId(value: unknown): string {
+        const raw = String(value ?? "").trim().replace(/^telegram:/, "");
+        if (!raw) throw new Error("Telegram Bot API requires a target chat ID");
+        return raw;
+    }
+
+    private replyOptions(value: unknown): Record<string, unknown> {
+        const opts = value && typeof value === "object" ? value as Record<string, unknown> : {};
+        const replyTo = Number(opts.replyTo ?? opts.reply_to_message_id);
+        return Number.isSafeInteger(replyTo) && replyTo > 0 ? { reply_to_message_id: replyTo } : {};
+    }
+
+    private mediaMethod(type: string, media: Record<string, unknown>): { method: string; field: string } {
+        const fileName = typeof media.fileName === "string" ? media.fileName : "";
+        const mime = typeof media.fileMime === "string" ? media.fileMime : "";
+        const normalized = type === "auto"
+            ? (mime.startsWith("image/") || /\.(jpe?g|png|gif|webp|bmp|avif)$/i.test(fileName) ? "photo" : "document")
+            : type;
+        switch (normalized) {
+            case "photo": return { method: "sendPhoto", field: "photo" };
+            case "video": return { method: "sendVideo", field: "video" };
+            case "animation": return { method: "sendAnimation", field: "animation" };
+            case "audio": return { method: "sendAudio", field: "audio" };
+            case "voice": return { method: "sendVoice", field: "voice" };
+            case "sticker": return { method: "sendSticker", field: "sticker" };
+            default: return { method: "sendDocument", field: "document" };
+        }
+    }
+
+    private normalizeUser(user: BotApiUser): Record<string, unknown> {
+        return {
+            id: user.id,
+            firstName: user.first_name,
+            lastName: user.last_name,
+            displayName: [user.first_name, user.last_name].filter(Boolean).join(" ") || user.username,
+            username: user.username,
+            isBot: user.is_bot,
+            type: "private",
+        };
+    }
+
+    private normalizeChat(chat: BotApiChat): Record<string, unknown> {
+        return {
+            id: chat.id,
+            type: chat.type,
+            title: (chat.title ?? [chat.first_name, chat.last_name].filter(Boolean).join(" ")) || chat.username,
+            username: chat.username,
+        };
+    }
+
+    private normalizeMessage(message: BotApiMessage): Record<string, unknown> {
+        return {
+            id: message.message_id,
+            text: message.text ?? message.caption ?? "",
+            date: new Date(message.date * 1_000),
+            chat: this.normalizeChat(message.chat),
+            sender: message.sender_chat
+                ? { ...this.normalizeChat(message.sender_chat), displayName: message.sender_chat.title }
+                : message.from ? this.normalizeUser(message.from) : undefined,
+            replyToMessage: message.reply_to_message ? { id: message.reply_to_message.message_id } : undefined,
+            isMention: this.isMention(message),
+            media: this.normalizeMedia(message),
+        };
+    }
+
+    private isMention(message: BotApiMessage): boolean {
+        const username = this.self?.username?.toLowerCase();
+        const text = message.text ?? message.caption ?? "";
+        const entities = message.text != null ? message.entities : message.caption_entities;
+        if (entities?.some(entity =>
+            (entity.type === "mention" && username
+                && text.slice(entity.offset, entity.offset + entity.length).toLowerCase() === `@${username}`)
+            || (entity.type === "text_mention" && entity.user?.id === this.self?.id),
+        )) return true;
+        return this.self != null && message.reply_to_message?.from?.id === this.self.id;
+    }
+
+    private normalizeMedia(message: BotApiMessage): Record<string, unknown> | undefined {
+        const pick = (files: BotApiFile[] | undefined) => files?.at(-1);
+        const source = pick(message.photo) ?? message.document ?? message.video ?? message.animation ?? message.audio ?? message.voice ?? message.sticker;
+        if (!source) return undefined;
+        const type = message.photo ? "photo"
+            : message.document ? "document"
+            : message.video ? "video"
+            : message.animation ? "animation"
+            : message.audio ? "audio"
+            : message.voice ? "voice"
+            : "sticker";
+        return {
+            type,
+            fileId: source.file_id,
+            uniqueFileId: source.file_unique_id,
+            fileName: source.file_name,
+            mimeType: source.mime_type,
+            fileSize: source.file_size,
+            width: source.width,
+            height: source.height,
+            emoji: source.emoji,
+        };
+    }
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -167,7 +167,8 @@ export interface TelegramWhitelistConfig {
 }
 
 export interface TelegramConfig {
-    mode: "bot" | "userbot";
+    /** bot = MTProto bot (legacy); bot_api = HTTP Bot API; userbot = MTProto user. */
+    mode: "bot" | "bot_api" | "userbot";
     botToken: string;
     apiId: string;
     apiHash: string;
@@ -744,7 +745,7 @@ export function loadConfig(configPath?: string, forceReload?: boolean): AppConfi
         },
         timezone: str(fileConfig.timezone),
         telegram: Object.keys(fileTG).length > 0 ? {
-            mode: (str(fileTG.mode) as "bot" | "userbot") ?? "bot",
+            mode: (str(fileTG.mode) as TelegramConfig["mode"]) ?? "bot",
             botToken: str(fileTG.bot_token) ?? "",
             apiId: str(fileTG.api_id) ?? "",
             apiHash: str(fileTG.api_hash) ?? "",
@@ -1971,8 +1972,8 @@ export function validateConfig(config: unknown): { valid: boolean; errors: strin
     // telegram (optional)
     const tg = c.telegram as Record<string, unknown> | undefined;
     if (tg) {
-        if (!tg.mode || (tg.mode !== "bot" && tg.mode !== "userbot")) {
-            errors.push("telegram.mode 必须是 \"bot\" 或 \"userbot\"");
+        if (!tg.mode || !["bot", "bot_api", "userbot"].includes(String(tg.mode))) {
+            errors.push("telegram.mode 必须是 \"bot\"、\"bot_api\" 或 \"userbot\"");
         }
         // whitelist enabled + empty lists = reject all — valid config, no error
     }

--- a/src/dashboard/ui/src/panels/config/TelegramTab.svelte
+++ b/src/dashboard/ui/src/panels/config/TelegramTab.svelte
@@ -30,9 +30,12 @@
         class="select select-xs select-bordered w-full"
         bind:value={config.telegram.mode}
       >
-        <option value="bot">bot</option><option value="userbot">userbot</option>
+        <option value="bot_api">机器人（Bot API）</option>
+        <option value="bot">机器人（MTProto）</option>
+        <option value="userbot">用户账号（MTProto）</option>
       </select></label
     >
+    {#if config.telegram.mode !== 'userbot'}
     <label class="cfg-field"
       ><span class="cfg-label"
         ><i class="fa-solid fa-rotate-right restart-icon"></i> Bot Token</span
@@ -45,6 +48,8 @@
         on:blur={pwBlur}
       /></label
     >
+    {/if}
+    {#if config.telegram.mode !== 'bot_api'}
     <label class="cfg-field"
       ><span class="cfg-label"
         ><i class="fa-solid fa-rotate-right restart-icon"></i> API ID</span
@@ -67,6 +72,8 @@
         on:blur={pwBlur}
       /></label
     >
+    {/if}
+    {#if config.telegram.mode === 'userbot'}
     <label class="cfg-field col-span-2"
       ><span class="cfg-label"
         ><i class="fa-solid fa-rotate-right restart-icon"></i> 手机号 (userbot)</span
@@ -78,7 +85,13 @@
         placeholder="+86..."
       /></label
     >
+    {/if}
   </div>
+  {#if config.telegram.mode === 'bot_api'}
+    <p class="text-xs opacity-60 mt-2">仅需 BotFather 签发的 Token。通过长轮询接收消息，需先手动移除已有 webhook。群消息受 Telegram 隐私模式限制；不支持历史查询、用户登录及 MTProto 原生方法。</p>
+  {:else}
+    <p class="text-xs opacity-60 mt-2">MTProto 连接需要 Telegram API ID 和 API Hash。机器人另需 Token；用户账号使用手机号、验证码及可选的两步验证密码登录。</p>
+  {/if}
   <div class="divider text-xs opacity-50 my-3">拟人化发送延迟</div>
   <label class="cfg-check mb-2">
     <input

--- a/tests/telegram-bot-api-client.test.ts
+++ b/tests/telegram-bot-api-client.test.ts
@@ -1,0 +1,244 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TelegramBotApiClient } from "../src/adapter/telegram-bot-api-client.js";
+import { TelegramAdapter } from "../src/adapter/telegram-adapter.js";
+import { NotificationCenter } from "../src/event/notification-center.js";
+import { clearConfigCache, loadConfig, serializeConfigToYAML, validateConfig } from "../src/core/config.js";
+
+const token = "123456:TEST_TOKEN";
+const self = { id: 123456, is_bot: true, first_name: "Test", username: "TestBot" };
+const message = (extra = {}) => ({
+    message_id: 41, date: 1_800_000_000, text: "hello", chat: { id: -100123, type: "supergroup", title: "Group" },
+    from: { id: 77, first_name: "Member", is_bot: false }, ...extra,
+});
+const ok = (result: unknown) => new Response(JSON.stringify({ ok: true, result }));
+function pending(signal?: AbortSignal | null): Promise<Response> {
+    return new Promise((_, reject) => {
+        const abort = () => reject(new DOMException("Aborted", "AbortError"));
+        if (signal?.aborted) abort();
+        else signal?.addEventListener("abort", abort, { once: true });
+    });
+}
+function fakeApi(onCall?: (method: string, init: RequestInit) => Response | Promise<Response> | undefined) {
+    const calls: Array<{ method: string; init: RequestInit }> = [];
+    const fetchImpl: typeof fetch = async (input, init = {}) => {
+        const method = String(input).split("/").at(-1)!;
+        calls.push({ method, init });
+        const result = onCall?.(method, init);
+        if (result !== undefined) return result;
+        if (method === "getMe") return ok(self);
+        if (method === "getWebhookInfo") return ok({ url: "" });
+        if (method === "getUpdates") return pending(init.signal);
+        return ok(message());
+    };
+    return { fetchImpl, calls };
+}
+async function until(check: () => boolean) {
+    const deadline = Date.now() + 4_000;
+    while (!check() && Date.now() < deadline) await delay(5);
+    assert.ok(check(), "condition did not become true");
+}
+
+describe("Telegram Bot API client", () => {
+    it("starts polling only after subscription, delivers before acknowledging, and aborts on stop", async t => {
+        let polls = 0;
+        let release!: () => void;
+        const api = fakeApi((method) => method === "getUpdates" && ++polls === 1
+            ? ok([{ update_id: 900, message: message() }]) : undefined);
+        const client = new TelegramBotApiClient(token, api.fetchImpl);
+        t.after(() => client.destroy());
+        await client.start();
+        assert.equal(polls, 0);
+        const received: any[] = [];
+        client.onNewMessage.add(async msg => {
+            received.push(msg);
+            await new Promise<void>(resolve => { release = resolve; });
+        });
+        await until(() => received.length === 1);
+        assert.equal(polls, 1, "must not acknowledge while the consumer is still processing");
+        assert.equal(received[0].id, 41);
+        assert.equal(received[0].chat.id, -100123);
+        assert.equal(received[0].sender.id, 77);
+        assert.equal(received[0].date.getTime(), 1_800_000_000_000);
+        release();
+        await until(() => polls === 2);
+        const request = api.calls.filter(c => c.method === "getUpdates")[1];
+        assert.equal(JSON.parse(String(request.init.body)).offset, 901);
+        await client.destroy();
+        assert.equal(request.init.signal?.aborted, true);
+    });
+
+    it("retries a failed consumer without advancing offset and reports the failure", async t => {
+        let polls = 0;
+        const api = fakeApi(method => method === "getUpdates" && ++polls <= 2
+            ? ok([{ update_id: 7, message: message() }]) : undefined);
+        const client = new TelegramBotApiClient(token, api.fetchImpl);
+        t.after(() => client.destroy());
+        const errors: Error[] = [];
+        client.onError.add(error => errors.push(error));
+        await client.start();
+        let attempts = 0;
+        client.onNewMessage.add(() => { if (++attempts === 1) throw new Error("consumer unavailable"); });
+        await until(() => polls === 3);
+        const offsets = api.calls.filter(c => c.method === "getUpdates").map(c => JSON.parse(String(c.init.body)).offset);
+        assert.deepEqual(offsets, [undefined, undefined, 8]);
+        assert.equal(attempts, 2);
+        assert.match(errors[0].message, /consumer unavailable/);
+    });
+
+    it("cancels backoff promptly and sanitizes polling errors", async t => {
+        const api = fakeApi(method => {
+            if (method === "getUpdates") throw new Error(`failure at https://api.telegram.org/bot${token}/getUpdates`);
+        });
+        const client = new TelegramBotApiClient(token, api.fetchImpl);
+        t.after(() => client.destroy());
+        const errors: Error[] = [];
+        client.onError.add(error => errors.push(error));
+        await client.start();
+        client.onNewMessage.add(() => {});
+        await until(() => errors.length > 0);
+        const started = Date.now();
+        await client.destroy();
+        assert.ok(Date.now() - started < 500, "stop should cancel the retry delay");
+        assert.ok(!String(errors[0]).includes(token));
+        assert.equal(errors[0].cause, undefined);
+    });
+
+    it("refuses an existing webhook without deleting it or consuming updates", async () => {
+        const api = fakeApi(method => method === "getWebhookInfo" ? ok({ url: "https://example.invalid/hook" }) : undefined);
+        const client = new TelegramBotApiClient(token, api.fetchImpl);
+        await assert.rejects(client.start(), /existing webhook/);
+        assert.deepEqual(api.calls.map(c => c.method), ["getMe", "getWebhookInfo"]);
+        await client.destroy();
+    });
+
+    it("does not treat replies to other people or longer usernames as mentions", async t => {
+        const variants = [
+            { reply_to_message: { message_id: 1, from: { id: 77 } } },
+            { reply_to_message: { message_id: 1, from: self } },
+            { text: "@TestBotExtra", entities: [{ type: "mention", offset: 0, length: 13 }] },
+            { text: "😀 @TESTBOT", entities: [{ type: "mention", offset: 3, length: 8 }] },
+            { entities: [{ type: "text_mention", offset: 0, length: 5, user: self }] },
+        ];
+        let delivered = false;
+        const api = fakeApi(method => {
+            if (method !== "getUpdates" || delivered) return;
+            delivered = true;
+            return ok(variants.map((extra, i) => ({ update_id: i + 1, message: message(extra) })));
+        });
+        const client = new TelegramBotApiClient(token, api.fetchImpl);
+        t.after(() => client.destroy());
+        await client.start();
+        const mentions: boolean[] = [];
+        client.onNewMessage.add((msg: any) => { mentions.push(msg.isMention); });
+        await until(() => mentions.length === variants.length);
+        assert.deepEqual(mentions, [false, true, false, true, true]);
+    });
+
+    it("maps text replies, uploads, typing, and file downloads without leaking token-bearing errors", async t => {
+        const api = fakeApi((method) => {
+            if (method === "getFile") return ok({ file_path: "documents/file.bin" });
+            if (method === "file.bin") return new Response(new Uint8Array([1, 2, 3]));
+        });
+        const client = new TelegramBotApiClient(token, api.fetchImpl);
+        t.after(() => client.destroy());
+        const sent: any = await client.sendText("telegram:-100123", "reply", { replyTo: 41 });
+        assert.equal(sent.id, 41);
+        assert.deepEqual(JSON.parse(String(api.calls[0].init.body)), { chat_id: "-100123", text: "reply", reply_to_message_id: 41 });
+        await client.sendMedia(-100123, { type: "document", file: Buffer.from("hello"), fileName: "original.txt", fileMime: "text/plain" });
+        const form = api.calls[1].init.body as FormData;
+        assert.equal(api.calls[1].method, "sendDocument");
+        const upload = form.get("document") as File;
+        assert.equal(upload.name, "original.txt");
+        assert.equal(await upload.text(), "hello");
+        await client.sendTyping(-100123);
+        assert.equal(api.calls[2].method, "sendChatAction");
+        assert.deepEqual(await client.downloadAsBuffer("file-id"), new Uint8Array([1, 2, 3]));
+        for (const result of [
+            () => { throw new Error(`fetch ${token} ${encodeURIComponent(token)}`); },
+            () => new Response(JSON.stringify({ ok: false, description: `error ${token}` }), { status: 401 }),
+        ]) {
+            const failing = new TelegramBotApiClient(token, (async () => result()) as typeof fetch);
+            await assert.rejects(failing.sendText(1, "test"), (err: Error) =>
+                !err.message.includes(token) && !err.message.includes(encodeURIComponent(token)) && err.cause === undefined);
+        }
+    });
+
+    it("normalizes incoming photo captions, file ids and channel senders", async t => {
+        let delivered = false;
+        const api = fakeApi(method => {
+            if (method !== "getUpdates" || delivered) return;
+            delivered = true;
+            return ok([{ update_id: 1, channel_post: message({
+                text: undefined, caption: "photo caption", sender_chat: { id: -100123, type: "channel", title: "Channel" },
+                photo: [{ file_id: "small" }, { file_id: "large", file_unique_id: "unique", width: 1024 }],
+            }) }]);
+        });
+        const client = new TelegramBotApiClient(token, api.fetchImpl);
+        t.after(() => client.destroy());
+        await client.start();
+        const received: any[] = [];
+        client.onNewMessage.add(msg => { received.push(msg); });
+        await until(() => received.length === 1);
+        assert.equal(received[0].text, "photo caption");
+        assert.equal(received[0].media.fileId, "large");
+        assert.equal(received[0].sender.id, -100123);
+    });
+});
+
+describe("explicit Telegram connection modes", () => {
+    it("uses HTTP even with MTProto credentials present and exposes capability errors", async t => {
+        const api = fakeApi();
+        t.mock.method(globalThis, "fetch", api.fetchImpl);
+        const nc = new NotificationCenter();
+        const adapter = new TelegramAdapter({ mode: "bot_api", botToken: token, apiId: "123", apiHash: "hash", phone: "" }, nc,
+            async () => { throw new Error("must not prompt for user login"); }, () => {});
+        t.after(async () => { await adapter.stop(); nc.dispose(); });
+        await adapter.start();
+        assert.equal(api.calls[0].method, "getMe");
+        await adapter.handleCall("telegram.sendText", [-100123, "test"]);
+        assert.ok(api.calls.some(c => c.method === "sendMessage"));
+        await assert.rejects(adapter.handleCall("telegram.getHistory", [-100123]), /not supported in Telegram Bot API mode/);
+        await assert.rejects(adapter.handleCall("telegram.mtcute", ["getMe"]), /not supported in Telegram Bot API mode/);
+        assert.match(adapter.getSceneTypeDefs("telegram", "")!, /bot_api/);
+    });
+
+    it("accepts token-only bot_api but never silently downgrades legacy bot or userbot", async t => {
+        for (const mode of ["bot_api", "bot", "userbot"] as const) {
+            const nc = new NotificationCenter();
+            let created = false;
+            const adapter = new TelegramAdapter({ mode, botToken: token, apiId: "", apiHash: "", phone: "" }, nc,
+                async () => { throw new Error("unexpected prompt"); }, () => {}, async () => {
+                    created = true;
+                    return { start: async () => self, onNewMessage: { add() {}, remove() {} }, destroy: async () => {} };
+                });
+            t.after(async () => { await adapter.stop(); nc.dispose(); });
+            if (mode === "bot_api") await adapter.start();
+            else await assert.rejects(adapter.start(), /API credentials are missing/);
+            assert.equal(created, mode === "bot_api");
+            await adapter.stop();
+        }
+    });
+
+    it("round-trips all modes and retains the legacy default when mode is omitted", () => {
+        const dir = mkdtempSync(join(tmpdir(), "tg-mode-test-"));
+        try {
+            const file = join(dir, "config.yaml");
+            for (const mode of ["bot_api", "bot", "userbot", undefined]) {
+                writeFileSync(file, `persona:\n  name: Test\ntelegram:\n  bot_token: ${token}\n${mode ? `  mode: ${mode}\n` : ""}`);
+                const config = loadConfig(file, true);
+                assert.equal(config.telegram?.mode, mode ?? "bot");
+                assert.ok(!validateConfig(config).errors.some(e => e.startsWith("telegram.mode")));
+                writeFileSync(file, serializeConfigToYAML(config));
+                assert.equal(loadConfig(file, true).telegram?.mode, mode ?? "bot");
+            }
+        } finally {
+            clearConfigCache();
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
Closes #70

目前选择 `bot` 仍通过 mtcute/MTProto 连接，只填写 BotFather Token 会因缺少 API ID/Hash 而启动失败。本 PR 增加显式 `mode: bot_api`，通过官方 HTTP Bot API 接入；Dashboard 下拉框显示“机器人（Bot API）”“机器人（MTProto）”“用户账号（MTProto）”，按模式显示凭据。原有 `bot`、`userbot` 和省略 mode 的配置保持现有行为，不按凭据是否填写自动切换协议。

Bot API client 覆盖基本消息/频道消息、回复、媒体、下载和 typing；消费处理完成后再确认更新，停止时取消长轮询及重试等待。已有 webhook 会明确报冲突，错误中的 Token 会脱敏。Bot API 不支持的历史查询、成员枚举、MTProto 透传等调用会返回能力错误，scene 说明和文档列出支持范围。

验证（Node 24.14.0，Windows）：

- `tsc --noEmit` 通过。
- Telegram 新增及原有测试 33/33 通过，覆盖配置往返、旧模式兼容、HTTP 模式选择、offset 确认/重试、停止取消、webhook 冲突、提及判定、文本/媒体及 Token 脱敏。
- 默认测试集 920/920 通过。
- Dashboard `vite build` 通过。

测试使用模拟 HTTP，不连接真实 bot。HTTP 模式不使用 MTProto 的 `TG_PROXY` SOCKS transport；详见 `docs/dev/telegram-bot-api.md`。本 PR 不涉及生产部署。
