### PR TITLE
fix(codeact): 在首次执行前压缩恢复的超限会话

### DIFF
--- a/docs/dev/codeact-session-recovery.md
+++ b/docs/dev/codeact-session-recovery.md
@@ -1,0 +1,14 @@
+# CodeAct session recovery
+
+Persisted CodeAct history can exceed the current policy after a restart, a configuration change, or a model switch. The executor checks it before its first sandbox/model execution and reuses the existing compaction flow:
+
+1. Structured summaries retain recent messages and known execution/interaction summaries.
+2. The existing token-aware compactor reduces remaining oversized history.
+3. Missing or failing summary models fall back to local trimming.
+4. The recovered session is saved before execution. History that remains above policy (for example, oversized protected context) returns an `ERROR` callback instead of being submitted unchanged.
+
+In-budget history is left unchanged before execution. Normal post-execution compaction still runs. This check uses the existing message count and history token policy; it does not impose a fixed character limit or guarantee that arbitrary new task content fits the provider's complete request limit.
+
+The history token policy uses the selected session profile's `max_context_tokens` (85% compaction trigger), falling back to `context_budget.effective_context_window` if the profile has no limit. A provider's advertised maximum window is not a latency target: configure an effective limit that works with your request timeout and observed latency. For example, a session profile can deliberately use a smaller `max_context_tokens` than the model's advertised window. No universal latency guarantee or new character-based default is introduced here.
+
+Compaction reduces the working session; raw chat storage is separate. This change does not rewrite historical chat records or migrate production state.

--- a/src/subagent/code-act-executor.ts
+++ b/src/subagent/code-act-executor.ts
@@ -620,6 +620,7 @@ export class CodeActExecutor {
         try {
             // ═══ Fix 9: 实际的 Sandbox 执行逻辑 ═══
             if (this.hasDependencies()) {
+                await this.prepareSessionForExecution();
                 callback = await this.executeWithSandbox(task, startTime);
             } else {
                 // Fallback: 无依赖时使用骨架逻辑（测试用）
@@ -665,6 +666,18 @@ export class CodeActExecutor {
 
         await this.finalizeExecutionArtifacts();
         return callback;
+    }
+
+    /** Restored history must satisfy the current policy before its first executor request. */
+    private async prepareSessionForExecution(): Promise<void> {
+        if (!this.needsCompaction()) return;
+        // Reuse structured summaries, token-aware compaction, local fallback, and persistence.
+        await this.finalizeExecutionArtifacts();
+        if (this.needsCompaction()) {
+            // Protected context can exceed the budget even after forceTrim. Do not knowingly
+            // submit the same oversized history; execute() reports a normal ERROR callback.
+            throw new Error("CodeAct session remains over the configured history budget after compaction");
+        }
     }
 
     private async finalizeExecutionArtifacts(): Promise<void> {

--- a/tests/code-act-session-preflight.test.ts
+++ b/tests/code-act-session-preflight.test.ts
@@ -1,0 +1,110 @@
+import { it, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CodeActExecutor } from "../src/subagent/code-act-executor.js";
+import { NotificationCenter } from "../src/event/notification-center.js";
+import { clearConfigCache, loadConfig, resolveComponentProfiles } from "../src/core/config.js";
+import { shouldCompact } from "../src/memory-v2/context-manager.js";
+import type { SandboxPool } from "../src/subagent/sandbox-pool.js";
+import type { CodeActReplyTask } from "../src/subagent/types.js";
+
+function setup(t: TestContext, history: CodeActExecutor["session"], maxSessionMessages = 6, maxContextTokens = 32768) {
+    const dir = mkdtempSync(join(tmpdir(), "codeact-preflight-"));
+    const configPath = join(dir, "config.yaml");
+    writeFileSync(configPath, [
+        "persona:", "  name: Test", "  description: Test.",
+        "llm_profiles:", "  test:", "    provider: openai", "    base_url: https://llm.invalid/v1",
+        "    api_key: test-only", "    model: test-model", "    max_tokens: 100", `    max_context_tokens: ${maxContextTokens}`,
+        "llm_routing:", "  session: [test]", "  compact: []",
+    ].join("\n"));
+    loadConfig(configPath, true);
+    const nc = new NotificationCenter();
+    t.after(() => { nc.dispose(); clearConfigCache(); rmSync(dir, { recursive: true, force: true }); });
+    const sessionFile = join(dir, "session.json");
+    const original = JSON.stringify({ chatId: "telegram:102", session: history, executionCount: 3 });
+    writeFileSync(sessionFile, original);
+    const executor = new CodeActExecutor("telegram:102", { maxSessionMessages });
+    assert.equal(executor.loadSession(sessionFile), true);
+    const snapshots: Array<{ history: CodeActExecutor["session"]; saved: string; request: any }> = [];
+    t.mock.method(globalThis, "fetch", async (url: string, init: RequestInit) => {
+        assert.equal(url, "https://llm.invalid/v1/chat/completions");
+        snapshots.push({ history: structuredClone(executor.session), saved: readFileSync(sessionFile, "utf8"), request: JSON.parse(String(init.body)) });
+        return new Response(JSON.stringify({
+            choices: [{ message: { role: "assistant", content: "[SESSION_DIGEST]No action needed.[/SESSION_DIGEST]\n<end_task>" }, finish_reason: "stop" }],
+            usage: { prompt_tokens: 10, completion_tokens: 10, total_tokens: 20 },
+        }));
+    });
+    const sandbox = Object.assign(new EventEmitter(), {
+        execute: async () => ({ success: true, output: "", executionMs: 0 }),
+        consumeExecutionControl: () => null, isAlive: () => true, resetNotebookScope: async () => {},
+    });
+    executor.setDependencies({ acquire: async () => sandbox, release() {} } as unknown as SandboxPool, nc);
+    const task = {
+        type: "CODEACT_REPLY", chatId: executor.chatId, taskId: "next-task", decisions: [], replyMode: "SINGLE",
+        contextSnapshot: { chatId: executor.chatId, depth: 0, snapshotTimestamp: new Date().toISOString(), topicDigests: [], engagementScore: 50 },
+        createdAt: new Date().toISOString(),
+    } as CodeActReplyTask;
+    return { executor, task, snapshots, original };
+}
+const history = (count: number): CodeActExecutor["session"] => Array.from({ length: count }, (_, index) => ({
+    role: index % 2 === 0 ? "user" : "assistant", content: `message ${index}`, timestamp: "2026-01-01T00:00:00.000Z",
+}));
+
+it("compacts and saves restored history before the first executor model request", async t => {
+    const { executor, task, snapshots } = setup(t, history(20));
+    const callback = await executor.execute(task);
+    assert.notEqual(callback.status, "ERROR", callback.error);
+    assert.equal(snapshots.length, 1);
+    const first = snapshots[0];
+    assert.ok(first.history.length <= 6, "restored over-limit history must not reach the first request");
+    assert.match(first.history[0].content, /SESSION_HISTORY_COMPACT/);
+    assert.equal(first.history.at(-1)?.content, "message 19");
+    assert.deepEqual(JSON.parse(first.saved).session, first.history, "preflight must persist recovery before the call");
+    assert.ok(first.request.messages.some((m: any) => m.content.includes("message 19")));
+    assert.ok(!first.request.messages.some((m: any) => m.content === "message 0"));
+});
+
+it("leaves in-budget restored history and its persisted file unchanged before execution", async t => {
+    const originalHistory = history(4);
+    const { executor, task, snapshots, original } = setup(t, originalHistory);
+    const callback = await executor.execute(task);
+    assert.notEqual(callback.status, "ERROR", callback.error);
+    assert.deepEqual(snapshots[0].history, originalHistory);
+    assert.equal(snapshots[0].saved, original);
+});
+
+it("uses the configured token budget for a few huge restored messages, including reasoning", async t => {
+    const large = history(2);
+    large[0].content = "old context ".repeat(25000);
+    large[1].content = "recent context ".repeat(25000);
+    large[1].reasoning = { provider: "openai_chat", content: "old reasoning ".repeat(25000), originKey: "test", tokenCount: 80000 };
+    const { executor, task, snapshots } = setup(t, large);
+    assert.ok(shouldCompact(executor.session, undefined, resolveComponentProfiles("session")[0]));
+    const callback = await executor.execute(task);
+    assert.notEqual(callback.status, "ERROR", callback.error);
+    assert.equal(snapshots.length, 1);
+    assert.equal(shouldCompact(snapshots[0].history, undefined, resolveComponentProfiles("session")[0]), false);
+    assert.deepEqual(JSON.parse(snapshots[0].saved).session, snapshots[0].history);
+});
+
+it("falls back to existing local trimming when compaction throws before execution", async t => {
+    const { executor, task, snapshots } = setup(t, history(20));
+    t.mock.method(executor as any, "compactSession", async () => { throw new Error("summary unavailable"); });
+    const callback = await executor.execute(task);
+    assert.notEqual(callback.status, "ERROR", callback.error);
+    assert.ok(snapshots[0].history.length <= 6);
+    assert.equal(snapshots[0].history.at(-1)?.content, "message 19");
+    assert.deepEqual(JSON.parse(snapshots[0].saved).session, snapshots[0].history);
+});
+
+it("returns a controlled error instead of submitting history that remains untrimmable", async t => {
+    const protectedHistory = [{ role: "system" as const, content: "protected ".repeat(50000), timestamp: "2026-01-01T00:00:00.000Z" }];
+    const { executor, task, snapshots } = setup(t, protectedHistory);
+    const callback = await executor.execute(task);
+    assert.equal(callback.status, "ERROR");
+    assert.match(callback.error ?? "", /session.*budget/i);
+    assert.equal(snapshots.length, 0, "must not send the over-budget executor request");
+});


### PR DESCRIPTION
Closes #72

恢复的 CodeAct session 可能已经超过当前消息条数或模型历史 token 预算。原先 `execute()` 先发起执行，之后才压缩，因此第一次请求仍会携带超限历史。

本 PR 在 sandbox/model 执行前检查会话，复用现有结构化摘要、token-aware compaction、失败时本地裁剪和持久化。预算内的历史不提前改写；压缩后仍超限的历史返回正常 `ERROR` callback，避免原样提交给执行模型。执行后的压缩继续保留。

没有引入生产应急补丁中的固定字符裁剪阈值。现有 session profile 的 `max_context_tokens` 可以作为实际运行预算，文档解释了它与模型宣称窗口及延迟的区别。这个检查针对恢复历史；不承诺任意新任务内容和 system prompt 的完整请求一定适合所有模型窗口。

回归验证在未修改上游上先运行：5 项中 4 项失败，预算内历史的控制用例通过。修复后覆盖消息超限恢复、少量巨型消息及 reasoning、首次调用前保存、压缩异常兜底和无法裁剪时的受控错误。

验证（Node 24.14.0，Windows）：`tsc --noEmit` 通过；恢复/上下文相关测试 49/49；完整默认测试集 915/915。测试仅使用模拟模型与 sandbox，不触碰生产 session。
